### PR TITLE
Double clicking on Sketch assets opens Sketch

### DIFF
--- a/packages/haiku-creator/react/components/library/CollapseItem.js
+++ b/packages/haiku-creator/react/components/library/CollapseItem.js
@@ -63,11 +63,6 @@ class CollapseItem extends React.Component {
     })
   }
 
-  handleSketchDoubleClick () {
-    var abspath = path.join(this.props.folder, 'designs', this.props.file.fileName)
-    shell.openItem(abspath)
-  }
-
   render () {
     const {isOpened} = this.state
     const {file} = this.props
@@ -133,10 +128,10 @@ class CollapseItem extends React.Component {
           </span>
           {this.props.file
             ? <span key={`file-header-${file.fileName}`} style={STYLES.header}>
-              <span onContextMenu={this.handleContextMenu.bind(this)} onDoubleClick={this.handleSketchDoubleClick.bind(this)} style={STYLES.icon}>
+              <span onContextMenu={this.handleContextMenu.bind(this)} onDoubleClick={this.props.instantiate} style={STYLES.icon}>
                 <SketchIconSVG style='' color={Radium.getState(this.state, `file-header-${file.fileName}`, ':hover') ? Palette.ORANGE : Palette.DARKER_ROCK} />
               </span>
-              <span onContextMenu={this.handleContextMenu.bind(this)} onDoubleClick={this.handleSketchDoubleClick.bind(this)}>{this.props.file.fileName}</span>
+              <span onContextMenu={this.handleContextMenu.bind(this)} onDoubleClick={this.props.instantiate}>{this.props.file.fileName}</span>
             </span>
             : <span><span style={STYLES.icon}><FolderIconSVG /></span>{this.props.name}</span>
           }

--- a/packages/haiku-creator/react/components/library/Library.js
+++ b/packages/haiku-creator/react/components/library/Library.js
@@ -12,6 +12,7 @@ import RectanglePrimitiveProps from './../../primitives/Rectangle'
 import EllipsePrimitiveProps from './../../primitives/Ellipse'
 import PolygonPrimitiveProps from './../../primitives/Polygon'
 import TextPrimitiveProps from './../../primitives/Text'
+import { shell } from 'electron'
 // import { BTN_STYLES } from '../../styles/btnShared'
 
 // List of extnames which, upon change, should trigger an asset listing refresh.
@@ -128,7 +129,7 @@ class LibraryDrawer extends React.Component {
     })
   }
 
-  handleAssetInstantiation (fileData) {
+  handleFileInstantiation (fileData) {
     if (!fileData.preview) return this.props.createNotice({ type: 'warning', title: 'Oops!', message: 'File path was blank; cannot instantiate' })
     const metadata = {}
     this.props.websocket.request({ type: 'action', method: 'instantiateComponent', params: [this.props.folder, fileData.preview, metadata] }, (err) => {
@@ -136,6 +137,24 @@ class LibraryDrawer extends React.Component {
         return this.props.createNotice({ type: 'danger', title: err.name, message: err.message })
       }
     })
+  }
+
+  handleSketchInstantiation (fileData) {
+    let abspath = path.join(this.props.folder, 'designs', fileData.fileName)
+    shell.openItem(abspath)
+  }
+
+  handleAssetInstantiation (fileData) {
+    switch(fileData.type) {
+      case 'sketch':
+        this.handleSketchInstantiation(fileData)
+        break
+      case 'file':
+        this.handleFileInstantiation(fileData)
+        break
+      default:
+        this.props.createNotice({ type: 'warning', title: 'Oops!', message: 'Couldn\'t handle that file, please contact support.' })
+    }
   }
 
   handleFileDrop (files, event) {


### PR DESCRIPTION
This avoids displaying a confusing notice when the user
double-clicks on a Sketch asset.

Related trello card:
https://trello.com/c/qQKsvMLr/417-opening-sketch-file-can-be-confusing