### PR TITLE
Set units to the timeline when displayed in seconds

### DIFF
--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -2177,13 +2177,13 @@ class Timeline extends React.Component {
         if (totalMilliseconds <= 1000) {
           return (
             <span key={`time-${millisecondsNumber}`} style={{ pointerEvents: 'none', display: 'inline-block', position: 'absolute', left: pixelOffsetLeft, transform: 'translateX(-50%)' }}>
-              <span style={{ fontWeight: 'bold' }}>{millisecondsNumber}</span>
+              <span style={{ fontWeight: 'bold' }}>{millisecondsNumber}ms</span>
             </span>
           )
         } else {
           return (
             <span key={`time-${millisecondsNumber}`} style={{ pointerEvents: 'none', display: 'inline-block', position: 'absolute', left: pixelOffsetLeft, transform: 'translateX(-50%)' }}>
-              <span style={{ fontWeight: 'bold' }}>{this.formatSeconds(millisecondsNumber / 1000)}</span>
+              <span style={{ fontWeight: 'bold' }}>{this.formatSeconds(millisecondsNumber / 1000)}s</span>
             </span>
           )
         }


### PR DESCRIPTION
Found this while solving tour issues and being a simple fix, why not?

**What**

[Trello Card](https://trello.com/c/HbCkNxo8/425-on-timeline-at-certain-zoom-level-when-displaying-as-seconds-milliseconds-are-displayed-but-without-the-unit)

**Result**

![screen shot 2017-09-19 at 10 54 46 am](https://user-images.githubusercontent.com/4419992/30596375-4b178f80-9d2a-11e7-9c2f-4dabc92bbbec.png)
![screen shot 2017-09-19 at 10 54 56 am](https://user-images.githubusercontent.com/4419992/30596374-4b148b46-9d2a-11e7-9936-b9ec0ad1ba41.png)

@matthewtoast added you as a reviewer because in the card wasn't clear if we also wanted to add the units when the time is displayed in seconds. I added the unit just for consistency, but let me know if you prefer to remove the little `s`.