### PR TITLE
fix: disable dragging of collapsed segments

### DIFF
--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1669,6 +1669,7 @@ class Timeline extends React.Component {
         key={`${propertyName}-${index}`}
         axis='x'
         onStart={(dragEvent, dragData) => {
+          if (options.collapsed) return false
           this.setRowCacheActivation({ componentId, propertyName })
           let activeKeyframes = this.state.activeKeyframes
           activeKeyframes = [componentId + '-' + propertyName + '-' + curr.index, componentId + '-' + propertyName + '-' + (curr.index + 1)]

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1879,6 +1879,7 @@ class Timeline extends React.Component {
         key={`${propertyName}-${index}`}
         className='constant-body'
         onContextMenu={(ctxMenuEvent) => {
+          if (options.collapsed) return false
           ctxMenuEvent.stopPropagation()
           let localOffsetX = ctxMenuEvent.nativeEvent.offsetX
           let totalOffsetX = localOffsetX + pxOffsetLeft + Math.round(frameInfo.pxA / frameInfo.pxpf)


### PR DESCRIPTION
This disables the ability to drag transition segments from collapsed levels; i.e., at either property or element level. If a user attempts a drag it will instead expand the row.