### PR TITLE
Set the player state to paused when reaches the end

### DIFF
--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -494,6 +494,7 @@ class Timeline extends React.Component {
       // has arrived at the maximum acceptible frame in the timeline.
       if (currentFrame > frameInfo.friMax) {
         this._component.getCurrentTimeline().seekAndPause(frameInfo.friMax)
+        this.setState({isPlayerPlaying: false})
       }
       // If our current frame has gone outside of the interval that defines the timeline viewport, then
       // try to re-align the ticker inside of that range


### PR DESCRIPTION
**What**

[Trello card](https://trello.com/c/XMNhNs3w/669-playback-controls-are-not-fully-respecting-playback-state-changes-eg-toggling-to-pause-when-reaching-the-end)

**How**

This change sets the state property `isPlayerPlaying` of the
Timeline component to `false` when the playback reaches the end
of the timeline.

In consequence this fixes a bug with the playback buttons, where
the play/pause state wasn't being updated properly

**Result**

<img src="https://thumbs.gfycat.com/DigitalWarlikeAmericancicada-small.gif" alt="timeline GIF" width="100%">

