### PR TITLE
Fix: stop publish popover from shifting

### DIFF
--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -41,7 +41,6 @@ const STYLES = {
   sharePopover: {
     position: 'absolute',
     top: 34,
-    right: -59,
     backgroundColor: Palette.FATHER_COAL,
     width: 204,
     padding: '13px 9px',
@@ -127,13 +126,24 @@ class PopoverBody extends React.Component {
       this.props.titleText !== nextProps.titleText ||
       this.props.linkAddress !== nextProps.linkAddress ||
       this.props.isSnapshotSaveInProgress !== nextProps.isSnapshotSaveInProgress ||
+      this.props.snapshotSaveConfirmed !== nextProps.snapshotSaveConfirmed ||
       this.props.isProjectInfoFetchInProgress !== nextProps.isProjectInfoFetchInProgress
     )
   }
 
   render () {
+    let popoverPosition
+
+    if (this.props.snapshotSaveConfirmed) {
+      popoverPosition = -72
+    } else if (this.props.isSnapshotSaveInProgress) {
+      popoverPosition = -70
+    } else {
+      popoverPosition = -59
+    }
+
     return (
-      <div style={[STYLES.sharePopover, this.props.snapshotSaveConfirmed && {right: -67}, this.props.isSnapshotSaveInProgress && {right: -70}]}>
+      <div style={[STYLES.sharePopover, {right: popoverPosition}]}>
         <button style={STYLES.popoverClose} onClick={this.props.close}>x</button>
         {this.props.titleText}
         <div style={STYLES.linkHolster}>


### PR DESCRIPTION
This stops the publish popover from jumping. Should _actually_ be fixed this time. Was gotcha'ed by there being two components in this file and needing to send the nested one the next props when the state changes.

@roperzh I'm excited that you shared how to set up React Dev tools on that article recently. Probably would have saved me a bit of time on this task if I had insight into the nested components states' not changing. I'm going to try to set them up tomorrow.