### PR TITLE
Round frame value when extrapolating current frame

### DIFF
--- a/packages/haiku-serialization/src/model/Timeline.js
+++ b/packages/haiku-serialization/src/model/Timeline.js
@@ -84,7 +84,7 @@ function TimelineModel (component, window) {
     var lap = Date.now()
     var spanMs = lap - this.stopwatch
     var spanS = spanMs / 1000
-    var spanFrames = spanS * this.fps
+    var spanFrames = Math.round(spanS * this.fps)
     // var max // TODO: handle?
     return this.lastAuthoritativeFrame + spanFrames
   }


### PR DESCRIPTION
**What**

<a href="https://trello.com/c/K2MWDJ3G/244-timeline-unit-ticks-disappear-sometimes-after-playback" class="known-service-link"><img width="18" src="https://a.trellocdn.com/images/services/e1b7406bd79656fdd26ca46dc8963bee/trello.png"> Timeline unit ticks disappear sometimes after playback</a>

**How**

This fixes `TimelineModel#getExtrapolatedCurrentFrame` in order to always return an integer as a representation of a keyframe.

This was causing bugs when rendering the gauge, but overall seems like something that we should do anyway, from Matthew:

> frames should always be integers - they are sequential. There is "no such thing" as frame 1.5

