### PR TITLE
Fix logs not being written and improve format

### DIFF
--- a/packages/haiku-serialization/src/utils/Logger.js
+++ b/packages/haiku-serialization/src/utils/Logger.js
@@ -21,7 +21,7 @@ module.exports = function _loggerConstructor (folder, filepath, options) {
     colorize: config.colorize,
     timestamp: config.timestamp,
     showLevel: config.showLevel,
-    level: 'info',
+    level: process.env.HAIKU_ECHO_ON !== '1' ? 'silly' : 'info',
     eol: config.eol
   }))
 
@@ -34,11 +34,15 @@ module.exports = function _loggerConstructor (folder, filepath, options) {
       maxsize: config.maxsize,
       maxFiles: config.maxFiles,
       colorize: config.colorize,
-      json: config.json,
-      level: 'warn',
+      json: false,
+      level: 'info',
       timestamp: config.timestamp,
       showLevel: config.showLevel,
-      eol: config.eol
+      eol: config.eol,
+      formatter: ({level, message}) => {
+        const timestamp = new Date().toISOString()
+        return `(${timestamp}) (${level.toUpperCase()}) — ${message}`
+      }
     }))
   }
 
@@ -50,22 +54,8 @@ module.exports = function _loggerConstructor (folder, filepath, options) {
     logger.stream({ start: -1 }).on('log', cb)
   }
 
-  function noopLogs (nodeEnv) {
-    logger.info = function () {}
-    logger.warn = function () {}
-    logger.error = function () {}
-    logger.log = function () {}
-    logger.sacred = console.log.bind(console)
-  }
-
-  if (typeof process !== 'undefined') {
-    if (process.env) {
-      // Skip all but the most sacred log messages, unless explicit
-      if (process.env.HAIKU_ECHO_ON !== '1') {
-        noopLogs(process.env.NODE_ENV)
-      }
-    }
-  }
+  // Legacy, use logger.info instead
+  logger.sacred = logger.info.bind(logger)
 
   return logger
 }


### PR DESCRIPTION
This deals with errors associated with logs, by:

- [x] Changing the logging level from `warn` to `info` for the
transport that writes logs to disk. Since all remarkable logs
where being logged at `info` level we were missing those.
- [x] Deprecating `logger.sacred` in favor of standard log
levels, this way we can rely on setting the `level` config option
of a transport to manage the log level instead of nested
conditionals
- [x] Improving the format in which logs are stored in the disk,
instead of storing plain JSON, we are writing the logs in the
format `(timestamp) (level) — message`

Example of `~/.haiku/logs/haiku-debug.log`:

```
(2017-10-26T13:58:36.796Z) (INFO) — [plumbing] websocket opened (commander creator)
(2017-10-26T13:58:36.928Z) (INFO) — [plumbing] ↓-- isUserAuthenticated via creator -> [] --↓
(2017-10-26T13:58:36.931Z) (INFO) — [plumbing] fetching organization name for current user
(2017-10-26T13:58:38.553Z) (INFO) — [plumbing] organization name: robertodip
(2017-10-26T13:58:38.555Z) (INFO) — [plumbing] ↑-- isUserAuthenticated via creator --↑
(2017-10-26T13:58:39.694Z) (INFO) — [plumbing] ↓-- listProjects via creator -> [] --↓
```