### PR TITLE
feat: "80%" of Lottie export.

### DIFF
--- a/packages/haiku-common/src/types/enums.ts
+++ b/packages/haiku-common/src/types/enums.ts
@@ -29,4 +29,5 @@ export enum Curve {
   EaseInOutElastic = 'easeInOutElastic',
   EaseInOutQuint = 'easeInOutQuint',
   EaseInOutSine = 'easeInOutSine',
+  Linear = 'linear',
 }

--- a/packages/haiku-formats/src/exporters/bodymovin/bodymovinEnums.ts
+++ b/packages/haiku-formats/src/exporters/bodymovin/bodymovinEnums.ts
@@ -11,6 +11,9 @@ export enum AnimationKey {
 }
 
 export enum LayerKey {
+  StartTime = 'st',
+  InPoint = 'ip',
+  OutPoint = 'op',
   Shapes = 'shapes',
   Type = 'ty',
   Transform = 'ks',
@@ -53,13 +56,24 @@ export enum ShapeType {
 }
 
 export enum TransformKey {
+  TransformOrigin = 'a',
   BorderRadius = 'r',
   Color = 'c',
   Position = 'p',
   PositionSplit = 's',
   Opacity = 'o',
   Rotation = 'r',
+  RotationX = 'rx',
+  RotationY = 'ry',
+  RotationZ = 'rz',
   Scale = 's',
   Size = 's',
   StrokeWidth = 'w',
+  StrokeLinecap = 'lc',
+}
+
+export enum StrokeLinecap {
+  Butt = 1,
+  Round = 2,
+  Square = 3,
 }

--- a/packages/haiku-formats/src/exporters/bodymovin/bodymovinTransformers.ts
+++ b/packages/haiku-formats/src/exporters/bodymovin/bodymovinTransformers.ts
@@ -1,5 +1,6 @@
 /** @file Transformers for Bodymovin quirks. */
 import ColorUtils from 'haiku-player/lib/helpers/ColorUtils';
+import {StrokeLinecap} from './bodymovinEnums';
 
 /**
  * Transforms CSS opacity in [0, 1] to Bodymovin opacity in [0, 100].
@@ -8,7 +9,13 @@ import ColorUtils from 'haiku-player/lib/helpers/ColorUtils';
 export const opacityTransformer = (opacity) => 100 * opacity;
 
 /**
- * Translate a CSS color to an After Effects color.
+ * Transforms CSS scale in [0, 1] to Bodymovin scale in [0, 100].
+ * @param scale
+ */
+export const scaleTransformer = (scale) => 100 * scale;
+
+/**
+ * Translates a CSS color to an After Effects color.
  *
  * After Effects colors are a 4-element [r, g, b, a] array where each element is normalized in [0, 1].
  * TODO: Support 4- and 8-digit hex codes as well.
@@ -29,4 +36,20 @@ export const colorTransformer = (color: string) => {
     colorModel.value[2] / quotient,
     colorModel.value[3],
   ];
+};
+
+/**
+ * Translates a CSS rotation (radians) to an After Effects rotation (degrees).
+ */
+export const rotationTransformer = (radians: number) => radians * 360 / 2 / Math.PI;
+
+export const linecapTransformer = (linecap: string) => {
+  switch (linecap) {
+    case 'butt':
+      return StrokeLinecap.Butt;
+    case 'round':
+      return StrokeLinecap.Round;
+    default:
+      return StrokeLinecap.Square;
+  }
 };

--- a/packages/haiku-formats/src/exporters/bodymovin/bodymovinUtils.ts
+++ b/packages/haiku-formats/src/exporters/bodymovin/bodymovinUtils.ts
@@ -1,16 +1,89 @@
-import {PathKey, PropertyKey} from './bodymovinEnums';
+import {AnimationKey, PathKey, PropertyKey} from './bodymovinEnums';
 import {BodymovinCoordinates, BodymovinPathComponent, BodymovinProperty} from './bodymovinTypes';
 import SVGPoints from 'haiku-player/lib/helpers/SVGPoints';
 const {pathToPoints} = SVGPoints;
 
 /**
+ * Reducer for an animated timeline property.
+ *
+ * To achieve Bodymovin-compatible animated timeline properties, we have to merge all scalar values
+ * sequentially. For example, the reduction of
+ *
+ * [
+ *   {
+ *     "a": 1,
+ *     "k": [
+ *       {
+ *         "v": [0],
+ *         "i": {"x": [.1], "y": [.3]},
+ *         "o": {"x": [.5], "y": [.7]}
+ *       }
+ *     ]
+ *   },
+ *   {
+ *     "a": 1,
+ *     "k": [
+ *       {
+ *         "v": [1],
+ *         "i": {"x": [.2], "y": [.4]},
+ *         "o": {"x": [.6], "y": [.8]}
+ *       }
+ *     ]
+ *   }
+ * ]
+ *
+ * is
+ *
+ * {
+ *   "a": 1,
+ *   "k": [
+ *     {
+ *       "v": [0, 1],
+ *       "i": {"x": [.1, .2], "y": [.3, .4]},
+ *       "o": {"x": [.5, .6], "y": [.7, .8]}
+ *     }
+ *   ]
+ * }
+ * @param accumulator
+ * @param currentValue
+ * @returns {{}}
+ * @private
+ */
+const animatedTimelineReducer = (accumulator, currentValue) => {
+  if (Object.keys(accumulator).length === 0) {
+    return currentValue;
+  }
+
+  currentValue[PropertyKey.Value].forEach((keyframe, index) => {
+    if (accumulator[PropertyKey.Value][index][AnimationKey.Time] !== keyframe[AnimationKey.Time]) {
+      // TODO: Normalize tweens in compounded properties before we get here, to ensure this error never occurs.
+      throw new Error('Encountered mismatched keyframe times in an animated timeline!');
+    }
+
+    if (index !== currentValue[PropertyKey.Value].length - 1) {
+      accumulator[PropertyKey.Value][index][AnimationKey.Start].push(keyframe[AnimationKey.Start][0]);
+      accumulator[PropertyKey.Value][index][AnimationKey.End].push(keyframe[AnimationKey.End][0]);
+      accumulator[PropertyKey.Value][index][AnimationKey.BezierIn].x.push(keyframe[AnimationKey.BezierIn].x[0]);
+      accumulator[PropertyKey.Value][index][AnimationKey.BezierIn].y.push(keyframe[AnimationKey.BezierIn].y[0]);
+      accumulator[PropertyKey.Value][index][AnimationKey.BezierOut].x.push(keyframe[AnimationKey.BezierOut].x[0]);
+      accumulator[PropertyKey.Value][index][AnimationKey.BezierOut].y.push(keyframe[AnimationKey.BezierOut].y[0]);
+    }
+  });
+
+  return accumulator;
+};
+
+/**
  * Reducer for a compound timeline property.
- * TODO: Add support for a compound animated property.
  * @param accumulator
  * @param currentValue
  * @returns {{}}
  */
 export const compoundTimelineReducer = (accumulator, currentValue) => {
+  if (currentValue[PropertyKey.Animated] === 1) {
+    return animatedTimelineReducer(accumulator, currentValue);
+  }
+
   if (Object.keys(accumulator).length === 0) {
     return {
       ...currentValue, [PropertyKey.Value]: [currentValue[PropertyKey.Value]],
@@ -37,6 +110,14 @@ export const getFixedPropertyValue = (fixedValue: any): BodymovinProperty => {
   value[PropertyKey.Animated] = 0;
   value[PropertyKey.Value] = fixedValue;
   return value;
+};
+
+export const alwaysArray = (maybeArray: any): any[] => {
+  if (Array.isArray(maybeArray)) {
+    return maybeArray;
+  }
+
+  return [maybeArray];
 };
 
 /**
@@ -79,8 +160,16 @@ export const pathToInterpolationTrace = (path: string) => {
   const interpolationInPoints: BodymovinPathComponent = [];
   const interpolationOutPoints: BodymovinPathComponent = [];
 
-  // TODO: Don't assume the path is closed.
+  let closed = true;
   const points = pathToPoints(path);
+
+  // Force the last vertex to be the same as the first so we can use the same algorithm for closed and open paths.
+  // The renderer will respect the value of "closed" we pass below.
+  if (points.length > 1 &&
+    (points[0].x !== points[points.length - 1].x || points[0].y !== points[points.length - 1].y)) {
+    closed = false;
+    points.push(points[0]);
+  }
 
   let lastVertex;
   points.forEach((point, index) => {
@@ -122,6 +211,7 @@ export const pathToInterpolationTrace = (path: string) => {
   translateInterpolationPoints(interpolationOutPoints, vertices);
 
   return {
+    [PathKey.Closed]: closed,
     [PathKey.Points]: vertices,
     [PathKey.InterpolationIn]: interpolationInPoints,
     [PathKey.InterpolationOut]: interpolationOutPoints,
@@ -151,3 +241,35 @@ export const pointsToInterpolationTrace = (svgPoints: string) => {
     [PathKey.InterpolationOut]: dummyCurve,
   };
 };
+
+/**
+ * Decomposes a path, which might be compound, into singly-closed paths which might not be contiguous.
+ *
+ * This is achieved by splitting the path on all occurences of z (or Z, which means the same thing), then filtering
+ * out trivial segments.
+ * @param {string} path
+ * @returns {string[]}
+ */
+export const decomposeMaybeCompoundPath = (path: string): string[] =>
+  path.split(/z/ig).filter((segment) => segment !== '');
+
+/**
+ * Derives keyframes as an array of numbers from a timeline property.
+ *
+ * e.g. given {0: {value: 'foo'}, 10: {value: 'bar'}}, returns [0, 10].
+ * @param timelineProperty
+ * @returns {number[]}
+ */
+export const keyframesFromTimelineProperty = (timelineProperty): number[] => {
+  const keyframes: number[] = Object.keys(timelineProperty).map((i) => parseInt(i, 10));
+  keyframes.sort((a, b) => a - b);
+  return keyframes;
+};
+
+/**
+ * Determines if timeline values are equivalent.
+ *
+ * TODO: Make this more performant by utilizing the allowed values of the timeline.
+ */
+export const timelineValuesAreEquivalent = (valueA: any, valueB: any): boolean =>
+  JSON.stringify(valueA) === JSON.stringify(valueB);


### PR DESCRIPTION
Please expand `bodymovinExporter.ts` for the big picture; I think GitHub hides it by default.

 - Adds support for background color (but not opacity, yet) on the wrapper div. Lottie doesn't speak "wrappers", so requires us to transclude a special rectangle during exporter bootstrapping.
 - Adds support for z-index, which works an odd way in Bodymovin ("lighter" elements need to come earlier, not later).
 - Adds support for path decomposition for paths (e.g. `M0,0 L1,1 L0,0 Z M2,2 L3,3 L2,2 Z`) with multiple closures. This is required because Bodymovin only draws singly-closed paths, so we need shim in the implicit "multiple shapes" in the midst of our recurve parse of the template.
 - Adds most of the necessary support for non-closed paths, including support for `stroke-linecap`.
 - Adds support for CSS non-colors that show up in color-able places inside SVGs (e.g. `stroke="none"`).
 - Adds support for transform-origin (which is required for scale and rotation transformations to be WYSIWYG through export; Lottie uses the After Effects default, which is `(0, 0)` for some strange reason).
 - Adds support for 2.5D rotation transformations and scale transformations. Note: there are some major limitiations to the scale transformation because although Bodymovin nominally supports separate tweening between `scale.x` and `scale.y`, the Lottie player actually ignores the transitions on `scale.y`.
 - Adds support for compound animations, mainly for the scale use case. There are lots of comments in this commit explaining the what and the why of compound animations, but the gist is Bodymovin requires some compound properties like scale to be expressed as a single tuple `[scaleX, scaleY]`. The consequences of this are…complex.
 - Adds support for layer out-points and in-points, without which nothing seems to actually show up in the Bodymovin web player.
 - Adds support for tween-less transitions, which are the de facto hack for creating animations where objects spring into existence on stage at some time `t > 0` but are not supported in After Effects at all. This is achieved by preprocessing the copy of the bytecode our class munges on and injecting 0-frame linear tweens whenever necessary. The unit test for `normalizes curves for transitions lacking tweens` should be readable and explain the expected behavior nicely.