### PR TITLE
feat: Final full support for all features of our demo (built-in) projects for Lottie.

### DIFF
--- a/packages/haiku-formats/src/exporters/bodymovin/bodymovinEnums.ts
+++ b/packages/haiku-formats/src/exporters/bodymovin/bodymovinEnums.ts
@@ -2,7 +2,7 @@
  * @file Bodymovin enumerations.
  */
 
-export enum AnimationKey {
+export const enum AnimationKey {
   BezierIn = 'i',
   BezierOut = 'o',
   Time = 't',
@@ -10,7 +10,7 @@ export enum AnimationKey {
   End = 'e',
 }
 
-export enum LayerKey {
+export const enum LayerKey {
   StartTime = 'st',
   InPoint = 'ip',
   OutPoint = 'op',
@@ -21,29 +21,29 @@ export enum LayerKey {
   Name = 'nm',
 }
 
-export enum LayerType {
+export const enum LayerType {
   Shape = 4,
 }
 
-export enum PathKey {
+export const enum PathKey {
   Closed = 'c',
   InterpolationIn = 'i',
   InterpolationOut = 'o',
   Points = 'v',
 }
 
-export enum PropertyKey {
+export const enum PropertyKey {
   Animated = 'a',
   Value = 'k',
 }
 
-export enum ShapeKey {
+export const enum ShapeKey {
   Type = 'ty',
   GroupItems = 'it',
   Vertices = 'ks',
 }
 
-export enum ShapeType {
+export const enum ShapeType {
   // Proper shapes.
   Ellipse = 'el',
   Rectangle = 'rc',
@@ -51,15 +51,21 @@ export enum ShapeType {
 
   // Organizational "shapes".
   Transform = 'tr',
+  GradientFill = 'gf',
   Group = 'gr',
   Stroke = 'st',
   Fill = 'fl',
 }
 
-export enum TransformKey {
+export const enum TransformKey {
   TransformOrigin = 'a',
   BorderRadius = 'r',
   Color = 'c',
+  FillRule = 'r',
+  GradientEnd = 'e',
+  GradientStart = 's',
+  GradientStops = 'g',
+  GradientType = 't',
   Position = 'p',
   PositionSplit = 's',
   Opacity = 'o',
@@ -71,18 +77,44 @@ export enum TransformKey {
   Scale = 's',
   Size = 's',
   StrokeWidth = 'w',
+  StrokeDasharray = 'd',
   StrokeLinecap = 'lc',
   StrokeLinejoin = 'lj',
 }
 
-export enum StrokeLinecap {
+export const enum StrokeLinecap {
   Butt = 1,
   Round = 2,
   Square = 3,
 }
 
-export enum StrokeLinejoin {
+export const enum StrokeLinejoin {
   Miter = 1,
   Round = 2,
   Bevel = 3,
+}
+
+export const enum FillRule {
+  Nonzero = 1,
+  Evenodd = 2,
+}
+
+export const enum DasharrayRole {
+  Dash = 'd',
+  Gap = 'g',
+}
+
+export const enum DasharrayKey {
+  Role = 'n',
+  Value = 'v',
+}
+
+export const enum GradientType {
+  Linear = 1,
+  Radial = 2,
+}
+
+export const enum GradientKey {
+  TotalStops = 'p',
+  Stops = 'k',
 }

--- a/packages/haiku-formats/src/exporters/curves.ts
+++ b/packages/haiku-formats/src/exporters/curves.ts
@@ -112,6 +112,17 @@ const denormalizeValue = (normalizedValue: number, from: number, to: number): nu
   from + normalizedValue * (to - from);
 
 /**
+ * Convenience method; normalizes a value in [0, 1].
+ * @param {number} value
+ * @param {number} from
+ * @param {number} to
+ * @returns {number}
+ * @private
+ */
+const normalizeValue = (value: number, from: number, to: number): number =>
+  (value - from) / (to - from);
+
+/**
  * Injects a keyframe into a timeline property using De Casteljau's algorithm.
  *
  * Due to the recursive nature of how this method may be called, we always need to find the immediately preceding
@@ -137,7 +148,7 @@ export const splitBezierForTimelinePropertyAtKeyframe = (timelineProperty, keyfr
   const [x1, y1, x2, y2] = getCurveInterpolationPoints(timelineProperty[previousKeyframe].curve);
 
   // Normalize keyframe (time) in [0, 1] to make the curve calculations work with existing tools.
-  const time = keyframe / (nextKeyframe - previousKeyframe);
+  const time = normalizeValue(keyframe, previousKeyframe, nextKeyframe);
 
   // Note: We are using the bezier-easing library for fast heuristic calculation of the value at time instead of
   // the cubic-bezier() function from the just-curves vendor package in haiku-player. This is intentional; the math

--- a/packages/haiku-formats/src/exporters/injectables.ts
+++ b/packages/haiku-formats/src/exporters/injectables.ts
@@ -1,0 +1,47 @@
+/** @file Generic handling for injectables through export. */
+import functionToRFO from '@haiku/player/lib/reflection/functionToRFO';
+
+/**
+ * A class we can instantiate to act as a stub for injectables that can't be evaluated sensibly during export.
+ *
+ * Any instance will return itself through property access, and resolve to 0 when used as a primitive (e.g. through
+ * string concatenation or arithmetic).
+ * TODO: Locate and use better primitive defaults for specific injectables.
+ * @private
+ */
+class DefaultStub {
+  /**
+   * The constructor returns a Proxy, which activates the generic getter for property access mutation.
+   * @returns {Proxy}
+   */
+  constructor() {
+    return new Proxy(this, this);
+  }
+
+  /**
+   * Returns the Proxy through regular access, and return a 0-getter when a primitive value is requested.
+   */
+  get (_, property) {
+    if (property === Symbol.toPrimitive) {
+      return () => 0;
+    }
+
+    return new DefaultStub();
+  }
+}
+
+/**
+ * A value resolver compatible with results from calling `Haiku.inject`.
+ *
+ * @param timelinePropertyValue
+ *   A timeline property value, which is assumed to be a state/summonable-injected function.
+ * @param states
+ *   The state tree we should evaluate parameters against.
+ * @returns {any}
+ */
+export const evaluateInjectedFunctionInExportContext = (timelinePropertyValue, states) => {
+  const rfo = functionToRFO(timelinePropertyValue);
+  const defaultStub = new DefaultStub();
+  const params = rfo.__function.params.map((param) => states.hasOwnProperty(param) ? states[param].value : defaultStub);
+  return timelinePropertyValue.apply(undefined, params) || 0;
+};

--- a/packages/haiku-formats/src/svg/enums.ts
+++ b/packages/haiku-formats/src/svg/enums.ts
@@ -4,6 +4,8 @@ export enum SvgTag {
   Group = 'g',
   CircleShape = 'circle',
   EllipseShape = 'ellipse',
+  LinearGradient = 'linearGradient',
+  RadialGradient = 'radialGradient',
   RectangleShape = 'rect',
   PathShape = 'path',
   PolygonShape = 'polygon',

--- a/packages/haiku-formats/test/exporters/bodymovin.test.ts
+++ b/packages/haiku-formats/test/exporters/bodymovin.test.ts
@@ -732,5 +732,37 @@ tape('BodymovinExporter', (test: tape.Test) => {
     test.end();
   });
 
+  test.test('preprocesses injectables in the context of the bytecode state tree defaults', (test: tape.Test) => {
+    const bytecode = baseBytecodeCopy();
+    bytecode.states = {
+      two: {value: 2},
+    };
+
+    // Simulate the actual result of calling `Haiku.inject`.
+    const Haiku = require('@haiku/player');
+    bytecode.timelines.Default['haiku:svg'].opacity = {
+      0: {
+        value: Haiku.inject(
+          function(two, $user, $basicMagic, $deepMagic) {
+            return .12 * two + $user.mouse.x / 100 + $basicMagic - $deepMagic.arbitrarily.nested.magic;
+          },
+          'two',
+          '$user',
+          '$basicMagic',
+          '$deepMagic',
+        ),
+      },
+    };
+
+    const {
+      layers: [{
+        ks: {o: {k}},
+      }],
+    } = rawOutput(bytecode);
+
+    test.equal(k, 24, 'resolves state variables from bytecode and zeroes summonables');
+    test.end();
+  });
+
   test.end();
 });

--- a/packages/haiku-formats/tsconfig.json
+++ b/packages/haiku-formats/tsconfig.json
@@ -18,7 +18,7 @@
         "lib/*"
       ]
     },
-    "preserveConstEnums": true,
+    "preserveConstEnums": false,
     "removeComments": true,
     "rootDir": "src",
     "sourceMap": true,


### PR DESCRIPTION
A plethora of support for tricky things that show up in CheckTutorial, of all places!

In this PR:
 - Rewrite all `enum`s as `const enum`s, and fix TS compilation to transpile these enumeration values as their strings, instead of making a bunch of dictionaries we need to look up.
 - More tests for stroke and fill interpretation.
 - Full support for `stroke-dasharray`, which thankfully had an analogous equivalent in AE/Bodymovin.
 - Full support for `fill-rule` shading, which fixes the one remaining issue (O missing its donut hole) from Move.
 - Full support for `<linearGradient>` fills (not strokes, although a TODO is added and this *probably* isn't much extra work).
 - Partial, hacky support for `<radialGradient>` fills, with some known rendering deviations from what Haiku is likely to produce from a vanilla Sketch radial gradient. The main work remaining here involves unwinding [gradientTransform](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/gradientTransform). I figured we might already have a parser for SVG transforms floating around somewhere in `haiku-player`, so wanted to leave this alone until I've done some more discovery.