### PR TITLE
feat: Publish lottie.json in project code folder after writing out metadata.

### DIFF
--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -1,6 +1,11 @@
 {
-  "LottieExport": {
+  "LottieExportInGlobalMenu": {
     "test": true,
     "development": true
+  },
+  "LottieExportOnPublish": {
+    "test": true,
+    "development": true,
+    "staging": true
   }
 }

--- a/packages/haiku-common/src/experiments/index.ts
+++ b/packages/haiku-common/src/experiments/index.ts
@@ -8,7 +8,8 @@ import {getExperimentConfig} from './config';
  * @enum {string}
  */
 export enum Experiment {
-  LottieExport = 'LottieExport',
+  LottieExportInGlobalMenu = 'LottieExportInGlobalMenu',
+  LottieExportOnPublish = 'LottieExportOnPublish',
 }
 
 /**

--- a/packages/haiku-creator/src/TopMenu.js
+++ b/packages/haiku-creator/src/TopMenu.js
@@ -84,7 +84,7 @@ export default class TopMenu extends EventEmitter {
       }
     ]
 
-    if (experimentIsEnabled(Experiment.LottieExport)) {
+    if (experimentIsEnabled(Experiment.LottieExportInGlobalMenu)) {
       projectSubmenu.push({
         label: 'Export',
         submenu: [{

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -19,6 +19,8 @@ import {
   DangerIconSVG,
   CliboardIconSVG
 } from './Icons'
+import { Experiment, experimentIsEnabled } from 'haiku-common/lib/experiments'
+import { ExporterFormat } from 'haiku-sdk-creator/lib/exporter'
 
 var mixpanel = require('haiku-serialization/src/utils/Mixpanel')
 
@@ -283,7 +285,8 @@ class StageTitleBar extends React.Component {
   getProjectSaveOptions () {
     return {
       commitMessage: 'Changes saved (via Haiku Desktop)',
-      saveStrategy: SNAPSHOT_SAVE_RESOLUTION_STRATEGIES[this.state.snapshotSaveResolutionStrategyName]
+      saveStrategy: SNAPSHOT_SAVE_RESOLUTION_STRATEGIES[this.state.snapshotSaveResolutionStrategyName],
+      exporterFormats: experimentIsEnabled(Experiment.LottieExportOnPublish) ? [ExporterFormat.Bodymovin] : [],
     }
   }
 

--- a/packages/haiku-formats/src/exporters/index.ts
+++ b/packages/haiku-formats/src/exporters/index.ts
@@ -17,7 +17,13 @@ const getExporter = (format: ExporterFormat, bytecode: HaikuBytecode): Exporter 
   }
 };
 
-export const handleExporterSaveRequest = (request: ExporterRequest, bytecode: HaikuBytecode): string => {
-  const exporter: Exporter = getExporter(request.format, bytecode);
-  return exporter.binaryOutput();
+export const handleExporterSaveRequest = (request: ExporterRequest, bytecode: HaikuBytecode): Promise<string> => {
+  return new Promise<string>((resolve, reject) => {
+    try {
+      const exporter: Exporter = getExporter(request.format, bytecode);
+      resolve(exporter.binaryOutput());
+    } catch (e) {
+      reject(e);
+    }
+  });
 };

--- a/packages/haiku-plumbing/src/envoy/handleExporterChannel.js
+++ b/packages/haiku-plumbing/src/envoy/handleExporterChannel.js
@@ -1,25 +1,15 @@
-import fs from 'fs'
-
 import { EXPORTER_CHANNEL } from 'haiku-sdk-creator/lib/exporter'
-import { handleExporterSaveRequest } from 'haiku-formats/lib/exporters'
+
+import saveExport from '../publish-hooks/saveExport'
 
 export default (exporterChannel, activeComponent) => {
   exporterChannel.on(`${EXPORTER_CHANNEL}:save`, (request) => {
-    const bytecodeSnapshot = activeComponent.fetchActiveBytecodeFile().getReifiedBytecode()
-    // Re-mount the active component so mutations to the bytecode snapshot don't trickle into the project.
-    activeComponent.reloadBytecodeFromDisk((err) => {
+    saveExport(request, activeComponent, (err) => {
       if (err) {
         throw err
       }
 
-      const contents = handleExporterSaveRequest(request, bytecodeSnapshot)
-      fs.writeFile(request.filename, contents, (err) => {
-        if (err) {
-          throw err
-        }
-
-        exporterChannel.saved(request)
-      })
+      exporterChannel.saved(request)
     })
   })
 }

--- a/packages/haiku-plumbing/src/publish-hooks/saveExport.js
+++ b/packages/haiku-plumbing/src/publish-hooks/saveExport.js
@@ -1,0 +1,19 @@
+import fse from 'haiku-fs-extra'
+import { handleExporterSaveRequest } from 'haiku-formats/lib/exporters'
+
+export default (request, activeComponent, cb) => {
+  const bytecodeSnapshot = activeComponent.fetchActiveBytecodeFile().getReifiedBytecode()
+  // Re-mount the active component so mutations to the bytecode snapshot don't trickle into the project.
+  activeComponent.reloadBytecodeFromDisk((err) => {
+    if (err) {
+      cb(err)
+      return
+    }
+
+    handleExporterSaveRequest(request, bytecodeSnapshot)
+      .then((contents) => {
+        fse.writeFile(request.filename, contents, (error) => cb(error))
+      })
+      .catch((error) => cb(error))
+  })
+}

--- a/packages/haiku-serialization/src/model/ActiveComponent.js
+++ b/packages/haiku-serialization/src/model/ActiveComponent.js
@@ -152,6 +152,10 @@ function ActiveComponent (options) {
 
 util.inherits(ActiveComponent, EventEmitter)
 
+ActiveComponent.prototype._getSceneCodeFolder = function _getSceneCodeFolder () {
+  return this.fetchActiveBytecodeFile().get('folder');
+}
+
 ActiveComponent.prototype._getSceneCodePath = function _getSceneCodePath () {
   return path.join('code', this.scenename, 'code.js')
 }
@@ -163,6 +167,10 @@ ActiveComponent.prototype._getSceneDomModulePath = function _getSceneDomModulePa
 ActiveComponent.prototype._setSceneName = function _setSceneName (scenename) {
   this._scenename = scenename
   return this
+}
+
+ActiveComponent.prototype.getAbsoluteLottieFilePath = function getAbsoluteLottieFilePath () {
+  return path.join(this._getSceneCodeFolder(), 'code', this.scenename, 'lottie.json')
 }
 
 ActiveComponent.prototype.fetchActiveBytecodeFile = function fetchActiveBytecodeFile () {


### PR DESCRIPTION
In this PR:

 - Teach ActiveComponent where to plop the `lottie.json` file.
 - Split `LottieExport` experiments into two: `LottieExportInGlobalMenu` and `LottieExportOnPublish`.
 - Fork `Master.js`'s `saveProject` to run through a list of `ExporterFormat`s currently controlled by the `LottieExportOnPublish` experiment.
 - Churn through request `ExporterFormat`s and write out the results to disk.

As is will launch in staging. When production-ready, just update `experiments.json` to include `"production": true`.

(Future of experiments.json: lives on the server, so we can release features to all users or certain users or a fraction of users…whatever we want.)