### PR TITLE
feat: provide {} failsafe for Lottie export.

### DIFF
--- a/packages/haiku-common/test/experiments.test.ts
+++ b/packages/haiku-common/test/experiments.test.ts
@@ -4,15 +4,16 @@ import * as tape from 'tape';
 
 tape('experimentIsEnabled', (test: tape.Test) => {
   test.test('throws on unknown experiments', (test: tape.Test) => {
-    const [{experimentIsEnabled}, getExperimentConfig] = importStubs(
+    const [{experimentIsEnabled}, getExperimentConfig, unstub] = importStubs(
       'lib/experiments', {'./config': 'getExperimentConfig'});
     getExperimentConfig.returns({});
     test.throws(experimentIsEnabled.bind('NotAnExperiment'));
+    unstub();
     test.end();
   });
 
   test.test('reads enabled status from configuration', (test: tape.Test) => {
-    const [{experimentIsEnabled}, getExperimentConfig] = importStubs(
+    const [{experimentIsEnabled}, getExperimentConfig, unstub] = importStubs(
       'lib/experiments', {'./config': 'getExperimentConfig'});
     getExperimentConfig.returns({
       FooExperiment: {
@@ -20,24 +21,27 @@ tape('experimentIsEnabled', (test: tape.Test) => {
       },
     });
     test.true(experimentIsEnabled('FooExperiment'));
+    unstub();
     test.end();
   });
 
   test.test('defaults to disabled if nothing is configured for the environment', (test: tape.Test) => {
-    const [{experimentIsEnabled}, getExperimentConfig] = importStubs(
+    const [{experimentIsEnabled}, getExperimentConfig, unstub] = importStubs(
       'lib/experiments', {'./config': 'getExperimentConfig'});
     getExperimentConfig.returns({FooExperiment: {}});
     test.false(experimentIsEnabled('FooExperiment'));
+    unstub();
     test.end();
   });
 
   test.test('caches the result of getExperimentConfig()', (test: tape.Test) => {
-    const [{experimentIsEnabled}, getExperimentConfig] = importStubs(
+    const [{experimentIsEnabled}, getExperimentConfig, unstub] = importStubs(
       'lib/experiments', {'./config': 'getExperimentConfig'});
     getExperimentConfig.returns({FooExperiment: {}});
     experimentIsEnabled('FooExperiment');
     experimentIsEnabled('FooExperiment');
     test.true(getExperimentConfig.calledOnce);
+    unstub();
     test.end();
   });
 

--- a/packages/haiku-formats/src/exporters/bodymovin/bodymovinExporter.ts
+++ b/packages/haiku-formats/src/exporters/bodymovin/bodymovinExporter.ts
@@ -1139,6 +1139,14 @@ export class BodymovinExporter implements Exporter {
     return JSON.stringify(this.rawOutput());
   }
 
+  /**
+   * Interface method to provide failsafe binary output.
+   * @returns {{}}
+   */
+  failsafeBinaryOutput() {
+    return '{}';
+  }
+
   constructor(private bytecode) {
     // If not already known, get the Bodymovin version.
     if (!bodymovinVersion) {

--- a/packages/haiku-formats/src/exporters/index.ts
+++ b/packages/haiku-formats/src/exporters/index.ts
@@ -6,6 +6,7 @@ import {BodymovinExporter} from './bodymovin/bodymovinExporter';
 export interface Exporter {
   rawOutput(): any;
   binaryOutput(): string;
+  failsafeBinaryOutput(): string;
 }
 
 const getExporter = (format: ExporterFormat, bytecode: HaikuBytecode): Exporter => {
@@ -18,12 +19,17 @@ const getExporter = (format: ExporterFormat, bytecode: HaikuBytecode): Exporter 
 };
 
 export const handleExporterSaveRequest = (request: ExporterRequest, bytecode: HaikuBytecode): Promise<string> => {
-  return new Promise<string>((resolve, reject) => {
+  return new Promise<string>((resolve) => {
+    let binaryOutput = '';
     try {
       const exporter: Exporter = getExporter(request.format, bytecode);
-      resolve(exporter.binaryOutput());
+      binaryOutput = exporter.binaryOutput();
     } catch (e) {
-      reject(e);
+      console.error(`[formats] caught exception during export: ${e.toString()}`);
+      const exporter: Exporter = getExporter(request.format, bytecode);
+      binaryOutput = exporter.failsafeBinaryOutput();
+    } finally {
+      resolve(binaryOutput);
     }
   });
 };

--- a/packages/haiku-formats/test/exporters/index.test.ts
+++ b/packages/haiku-formats/test/exporters/index.test.ts
@@ -2,11 +2,14 @@ import * as tape from 'tape';
 
 import {HaikuBytecode} from 'haiku-common/lib/types';
 import {ExporterFormat, ExporterRequest} from 'haiku-sdk-creator/lib/exporter';
-import {importStubs} from 'haiku-testing/lib/mock';
+import {importStubs, stubProperties} from 'haiku-testing/lib/mock';
+
+import {handleExporterSaveRequest} from '../../lib/exporters';
+import {BodymovinExporter} from '../../lib/exporters/bodymovin/bodymovinExporter';
 
 tape('handleExporterSaveRequest', (test: tape.Test) => {
   test.test('supports exporting to Bodymovin', (test: tape.Test) => {
-    const [{handleExporterSaveRequest}, exporterStub] = importStubs(
+    const [{handleExporterSaveRequest}, exporterStub, unstub] = importStubs(
       'lib/exporters', {'./bodymovin/bodymovinExporter': 'BodymovinExporter'});
 
     const request: ExporterRequest = {
@@ -17,19 +20,47 @@ tape('handleExporterSaveRequest', (test: tape.Test) => {
     exporterStub.returns({binaryOutput: () => 'hello'});
 
     const bytecode: HaikuBytecode = {foo: 'bar'};
-    test.equal(handleExporterSaveRequest(request, bytecode), 'hello');
-    test.true(exporterStub.calledWith(bytecode));
-    test.end();
+    handleExporterSaveRequest(request, bytecode)
+      .then((binaryOutput) => {
+        test.equal(binaryOutput, 'hello');
+        test.true(exporterStub.calledWith(bytecode));
+        unstub();
+        test.end();
+      });
   });
 
-  test.test('throws on unkown formats', (test: tape.Test) => {
-    const [{handleExporterSaveRequest}] = importStubs('lib/exporters');
+  test.test('Bodymovin failsafe resolves to empty JSON object', (test: tape.Test) => {
+    const [binaryOutputStub, unstub] = stubProperties(
+      BodymovinExporter.prototype,
+      'binaryOutput',
+    );
+
+    const request: ExporterRequest = {
+      format: ExporterFormat.Bodymovin,
+      filename: undefined,
+    };
+
+    binaryOutputStub.throws();
+
+    handleExporterSaveRequest(request, {})
+      .then((binaryOutput) => {
+        test.equal(binaryOutput, JSON.stringify({}), 'uses failsafe output from exporter');
+        unstub();
+        test.end();
+      });
+  });
+
+  test.test('generic failsafe resolves to empty string', (test: tape.Test) => {
     const request: ExporterRequest = {
       format: ExporterFormat.Unknown,
       filename: undefined,
     };
-    test.throws(handleExporterSaveRequest.bind(undefined, request, {}));
-    test.end();
+
+    handleExporterSaveRequest(request, {})
+      .then((binaryOutput) => {
+        test.equal(binaryOutput, '', 'uses generic failsafe output of empty string');
+        test.end();
+      });
   });
 
   test.end();


### PR DESCRIPTION
Also fixes haiku-formats tests to resolve Promises, and includes some general refactoring of stubbing to make stubbing properties of existing objects a bit cleaner.