### PR TITLE
productivity: create `yarn sync`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/*
 config.js
 source/*
 ~tmp
+.last-sync

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ And add to `~/.ssh/config`:
 **git/yarn/packages setup**
 
     $ yarn install
-    $ yarn run yarn-install
-    $ yarn relink
+    $ yarn sync
 
 ## Development
 
@@ -47,15 +46,15 @@ You can also skip the interactive prompt and start with good defaults with:
 
 First lint all of the code:
 
-    $ yarn run lint-all
+    $ yarn lint-all
 
 Then run the unit tests in all of the code:
 
-    $ yarn run test-all
+    $ yarn test-all
 
 You might also want to run:
 
-    $ yarn run compile-all
+    $ yarn compile-all
 
 Assuming no lint errors or test failures, push your changes:
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "setup": "node ./scripts/setup.js",
     "changelog": "node ./scripts/changelog.js",
     "start": "node ./scripts/start.js",
+    "sync": "node ./scripts/sync.js",
     "lint": "standard \"./scripts/**/*.js\" --fix --verbose | snazzy",
     "semver": "node ./scripts/semver.js",
     "lint-all": "node ./scripts/lint-all.js",

--- a/packages/haiku-plumbing/yarn.lock
+++ b/packages/haiku-plumbing/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@haiku/player@2.3.18":
-  version "2.3.18"
-  resolved "https://reservoir.haiku.ai:8910/@haiku%2fplayer/-/player-2.3.18.tgz#6de217e92802641933a844bf3937203eed899bb9"
+"@haiku/player@2.3.19":
+  version "2.3.19"
+  resolved "https://reservoir.haiku.ai:8910/@haiku%2fplayer/-/player-2.3.19.tgz#0fbb5988b95ad575ecb6e7e84a5eb67e3da2b6d7"
   dependencies:
     lodash "^4.17.4"
     react "15.4.2"

--- a/scripts/helpers/checkNodeVersion.js
+++ b/scripts/helpers/checkNodeVersion.js
@@ -1,0 +1,15 @@
+const cp = require('child_process')
+
+const log = require('./log')
+
+const NODE_VERSION = 'v8.4.0'
+
+module.exports = () => {
+  const nodeVersion = cp.execSync('node --version').toString().trim()
+  if (nodeVersion !== NODE_VERSION) {
+    log.warn(`WARNING: you are using node version ${nodeVersion}. We recommend version ${NODE_VERSION}.`)
+    log.warn('Get it via:')
+    log.warn(`  curl -0 https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}.pkg > /tmp/node-${NODE_VERSION}.pkg && sudo installer -target / -pkg /tmp/node-${NODE_VERSION}`)
+    log.warn('You have been warned!\n')
+  }
+}

--- a/scripts/helpers/checkYarnVersion.js
+++ b/scripts/helpers/checkYarnVersion.js
@@ -1,0 +1,15 @@
+const cp = require('child_process')
+
+const log = require('./log')
+
+const YARN_VERSION = '1.0.2'
+
+module.exports = () => {
+  const yarnVersion = cp.execSync('yarn --version').toString().trim()
+  if (yarnVersion !== YARN_VERSION) {
+    log.warn(`WARNING: you are using yarn version ${yarnVersion}. We recommend version ${YARN_VERSION}.`)
+    log.warn('Get it via:')
+    log.warn(`  curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${YARN_VERSION}`)
+    log.warn('You have been warned!\n')
+  }
+}

--- a/scripts/helpers/log.js
+++ b/scripts/helpers/log.js
@@ -11,6 +11,10 @@ module.exports = {
     console.log(clc.red(msg))
   },
 
+  warn: function (msg) {
+    console.log(clc.yellow(msg))
+  },
+
   hat: function (msg, color) {
     console.log(clc[color || 'cyan'](SPACER + msg + SPACER))
   }

--- a/scripts/helpers/yarnInstall.js
+++ b/scripts/helpers/yarnInstall.js
@@ -1,0 +1,16 @@
+const lodash = require('lodash')
+const cp = require('child_process')
+
+var EXEC_OPTIONS = {
+  maxBuffer: 1024 * 1024 // bytes
+}
+
+module.exports = function yarnInstall (pack, cb) {
+  // TODO: Why does asynchronous execution crash a Macbook Pro?
+  cp.execSync(
+    `yarn install --mutex file:/tmp/.yarn_mono_lock --cache-folder="/tmp/.yarn_mono_cache" --ignore-engines \
+        --frozen-lockfile --non-interactive`,
+    lodash.merge(EXEC_OPTIONS, { cwd: pack.abspath, stdio: 'inherit' })
+  )
+  cb()
+}

--- a/scripts/helpers/yarnLink.js
+++ b/scripts/helpers/yarnLink.js
@@ -1,0 +1,50 @@
+const async = require('async')
+const cp = require('child_process')
+const lodash = require('lodash')
+
+const allPackages = require('./allPackages')()
+const log = require('./log')
+
+const allDeps = lodash.map(allPackages, (pack) => pack.name)
+
+module.exports = {
+  linkAllPackages: function linkPackages (cb) {
+    async.each(allPackages, function (pack, next) {
+      log.log('yarn linking ' + pack.name)
+      cp.exec('yarn link', { cwd: pack.abspath, stdio: 'inherit' }, next)
+    }, function (err) {
+      if (err) {
+        throw err
+      }
+
+      cb()
+    })
+  },
+  linkDeps: function linkDeps (packages, cb) {
+    async.each(packages, function (pack, next) {
+      if (!pack.pkg) {
+        next()
+        return
+      }
+
+      const depTypes = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']
+      async.each(allDeps, (depName, next) => {
+        async.each(depTypes, (depType, nextDepType) => {
+          if (!pack.pkg[depType] || !pack.pkg[depType][depName]) {
+            nextDepType()
+            return
+          }
+
+          log.log('yarn linking ' + depName + ' into project ' + pack.name)
+          cp.exec('yarn link ' + depName, {cwd: pack.abspath, stdio: 'inherit'}, nextDepType)
+        }, next)
+      }, next)
+    }, function (err) {
+      if (err) {
+        throw err
+      }
+
+      cb()
+    })
+  }
+}

--- a/scripts/helpers/yarnUnlink.js
+++ b/scripts/helpers/yarnUnlink.js
@@ -1,0 +1,37 @@
+const async = require('async')
+const cp = require('child_process')
+const lodash = require('lodash')
+
+const log = require('./log')
+
+const allDeps = lodash.map(require('./allPackages')(), (pack) => pack.name)
+
+module.exports = {
+  unlinkDeps: function yarnUnlink (packages, cb) {
+    async.each(packages, function (pack, next) {
+      if (!pack.pkg) {
+        next()
+        return
+      }
+
+      const depTypes = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']
+      async.each(allDeps, (depName, next) => {
+        async.each(depTypes, (depType, nextDepType) => {
+          if (!pack.pkg[depType] || !pack.pkg[depType][depName]) {
+            nextDepType()
+            return
+          }
+
+          log.log('yarn unlinking ' + depName + ' from project ' + pack.name)
+          cp.exec('yarn unlink ' + depName, {cwd: pack.abspath}, nextDepType)
+        }, next)
+      }, next)
+    }, function (err) {
+      if (err) {
+        throw err
+      }
+
+      cb()
+    })
+  }
+}

--- a/scripts/sync.js
+++ b/scripts/sync.js
@@ -1,0 +1,92 @@
+const async = require('async')
+const lodash = require('lodash')
+const cp = require('child_process')
+const log = require('./helpers/log')
+const fs = require('fs')
+const path = require('path')
+
+const checkYarnVersion = require('./helpers/checkYarnVersion')
+const checkNodeVersion = require('./helpers/checkNodeVersion')
+const allPackages = require('./helpers/allPackages')
+const yarnInstall = require('./helpers/yarnInstall')
+const {linkAllPackages, linkDeps} = require('./helpers/yarnLink')
+const {unlinkDeps} = require('./helpers/yarnUnlink')
+
+checkYarnVersion()
+checkNodeVersion()
+
+const lastSyncFilename = path.join(global.process.cwd(), '.last-sync')
+let afterFilter = ''
+if (fs.existsSync(lastSyncFilename)) {
+  afterFilter = `--after='${require(lastSyncFilename).lastSyncDate}'`
+}
+
+const INSTALL_ATTEMPTS = 10
+const lastSyncDate = cp.execSync('date').toString().trim()
+
+const packageNamesRequiringSync = lodash.uniq(
+  cp.execSync(
+    `git whatchanged ${afterFilter} --pretty=format:"" --name-only packages/*/yarn.lock \
+       | sed '/^\\s*$/d' | sed 's/packages\\///g' | sed 's/\\/yarn.lock//g'`
+  )
+    .toString()
+    .split('\n')
+    .filter((v) => !!v)
+)
+
+const packagesRequiringSync = allPackages(packageNamesRequiringSync)
+
+const tryYarnInstall = (pack, cb) => {
+  log.log(`yarn install for ${pack.shortname}`)
+  let remainingTries = INSTALL_ATTEMPTS
+  while (remainingTries > 0) {
+    try {
+      yarnInstall(pack, cb)
+      break
+    } catch (e) {
+      log.err(`Encountered error during yarn install for ${pack.shortname}. Retrying....`)
+      remainingTries--
+    }
+  }
+
+  if (remainingTries === 0) {
+    throw new Error(`Unable to yarn install ${pack.shortname} after ${INSTALL_ATTEMPTS} attempts`)
+  }
+}
+
+if (packagesRequiringSync.length === 0) {
+  log.hat('nothing to sync!')
+  global.process.exit(0)
+}
+
+async.each(packagesRequiringSync, (pack, next) => {
+  if (!fs.existsSync(pack.abspath, 'yarn.lock')) {
+    // Don't e.g. sync modules that have since been removed.
+    next()
+    return
+  }
+
+  tryYarnInstall(pack, next)
+}, (err) => {
+  if (err) {
+    log.err(err)
+  }
+
+  async.series([
+    (done) => {
+      unlinkDeps(packagesRequiringSync, done)
+    },
+    (done) => {
+      linkAllPackages(() => {
+        linkDeps(packagesRequiringSync, (err) => {
+          if (err) {
+            throw err
+          }
+
+          log.hat('sync complete!')
+          fs.writeFile(lastSyncFilename, `module.exports = ${JSON.stringify({lastSyncDate})};`, done)
+        })
+      })
+    }
+  ])
+})

--- a/scripts/yarn-link.js
+++ b/scripts/yarn-link.js
@@ -1,41 +1,9 @@
-var async = require('async')
-var cp = require('child_process')
-var fs = require('fs')
-var _ = require('lodash')
-var log = require('./helpers/log')
-var allPackages = require('./helpers/allPackages')()
+const allPackages = require('./helpers/allPackages')()
+const log = require('./helpers/log')
+const {linkAllPackages, linkDeps} = require('./helpers/yarnLink')
 
-async.eachSeries(allPackages, function (pack, next) {
-  log.log('yarn linking ' + pack.name)
-  cp.execSync('yarn link', { cwd: pack.abspath, stdio: 'inherit' })
-  next()
-}, function () {
-  async.eachSeries(allPackages, function (pack, next) {
-    if (!pack.pkg) {
-      return next()
-    }
-
-    var depTypes = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']
-    depTypes.forEach((depType) => {
-      if (!pack.pkg[depType]) return
-
-      var pkgJsonPath = pack.abspath + '/package.json'
-
-      var pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'))
-
-      if (pkgJson[depType]) {
-        _.forOwn(pkgJson[depType], (version, dep) => {
-          _.forEach(allPackages, (innerPack) => {
-            // pkgname is like haiku-bytecode or @haiku/player - whatever appears in package.json
-            if (dep === innerPack.pkgname) {
-              log.log('yarn linking ' + dep + ' into project ' + pack.name)
-              cp.execSync('yarn link ' + dep, { cwd: pack.abspath, stdio: 'inherit' })
-            }
-          })
-        })
-      }
-    })
-
-    next()
+linkAllPackages(() => {
+  linkDeps(allPackages, () => {
+    log.log('yarn link complete')
   })
 })

--- a/scripts/yarn-unlink.js
+++ b/scripts/yarn-unlink.js
@@ -1,43 +1,9 @@
-var async = require('async')
-var lodash = require('lodash')
-var cp = require('child_process')
-var log = require('./helpers/log')
-var allPackages = require('./helpers/allPackages')()
-
-var groups = lodash.keyBy(allPackages, 'name')
+const log = require('./helpers/log')
+const allPackages = require('./helpers/allPackages')()
+const {unlinkDeps} = require('./helpers/yarnUnlink')
 
 log.hat(`it is ok if any 'yarn unlink' step fails with 'no registered module'`)
 
-async.eachSeries(allPackages, function (pack, next) {
-  if (!pack.pkg) {
-    return next()
-  }
-
-  var depTypes = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']
-  depTypes.forEach((depType) => {
-    if (!pack.pkg[depType]) return
-
-    for (var depName in groups) {
-      if (pack.pkg[depType][depName]) {
-        log.log('yarn unlinking ' + depName + ' from project ' + pack.name)
-        try {
-          cp.execSync('yarn unlink ' + depName, { cwd: pack.abspath })
-        } catch (exception) {
-          // empty
-        }
-      }
-    }
-  })
-
-  return next()
-}, function () {
-  async.eachSeries(allPackages, function (pack, next) {
-    log.log('yarn unlinking ' + pack.name)
-    try {
-      cp.execSync('yarn unlink', { cwd: pack.abspath })
-    } catch (exception) {
-      // empty
-    }
-    next()
-  })
+unlinkDeps(allPackages, () => {
+  log.log('yarn unlink complete')
 })


### PR DESCRIPTION
A much-needed upgrade for `yarn yarn-install && yarn relink`.

 - Extends the export from `scripts/helpers/allPackages.js` so it can be passed an array of package names to resolve.
 - Moves the "guts" of `yarn-install.js`, `yarn-link.js`, and `yarn-unlink` into helpers, and makes them async.
   - Anecdotally: making the work of `yarn relink` async led to a 7x performance improvement for the standalone command in a `yarn-install`'ed project.
   - Side note: I removed the cleanup work done by `yarn yarn-unlink`, which calls `yarn unlink` on each linked module. I think unlinking the dependencies from the packages is sufficient here. `yarn unlink` from the module root seems to just unregister the module from being linkable at all, which isn't necessary because `yarn link` is idempotent.
 - Creates a new yarn command, `yarn sync`, which does the following:
   - Reads a local lockfile (`.last-sync`) if it exists.
   - Identifies **only** the packages that have a changed `yarn.lock` since the last sync.
   - Does the equivalent work of `yarn install` (but with 10 retries per dep, :smile:) and `yarn relink` for that set of packages only.

BREAKING CHANGE: We are now using `--frozen-lockfile` in `yarn sync`/`yarn yarn-install`. This means that if `yarn.lock` is out of date, both of these commands will fail. I noticed that `yarn.lock` was out of date specifically with the `yarn.lock` not being bumped up to `"@haiku/player@2.3.19"` in plumbing, so we would want to identify what process elided that detail and fix it. (Whenever `yarn.lock` is out of date for a given package, `yarn install` is the answer.)

From some reductive benchmarking, if all your deps are up to date, this should take < 30s to run the first time and < 1s to run subsequent times.