### PR TITLE
fix: `yarn sync` should link/unlink pkgname, not name.

### DIFF
--- a/scripts/helpers/yarnLink.js
+++ b/scripts/helpers/yarnLink.js
@@ -5,7 +5,7 @@ const lodash = require('lodash')
 const allPackages = require('./allPackages')()
 const log = require('./log')
 
-const allDeps = lodash.map(allPackages, (pack) => pack.name)
+const allDeps = lodash.map(allPackages, (pack) => pack.pkgname)
 
 module.exports = {
   linkAllPackages: function linkPackages (cb) {

--- a/scripts/helpers/yarnUnlink.js
+++ b/scripts/helpers/yarnUnlink.js
@@ -4,7 +4,7 @@ const lodash = require('lodash')
 
 const log = require('./log')
 
-const allDeps = lodash.map(require('./allPackages')(), (pack) => pack.name)
+const allDeps = lodash.map(require('./allPackages')(), (pack) => pack.pkgname)
 
 module.exports = {
   unlinkDeps: function yarnUnlink (packages, cb) {


### PR DESCRIPTION
Not doing this causes a really "fun" bug due to not linking `@haiku/player`, leaving various copies of version 2.3.7 lying around (because `yarn.lock` is out of date ever since we stopped cutting packages to standalone repos, but there's a Trello ticket for this). The side effects of having an old version of Player in the app are…surprising. But we'll fix that with the Trello ticket, and the real fix is probably using yarn workspaces.

Fun new benchmark: sync from fresh clone and empty yarn cache = 430s.

In the unlikely event that you bricked your repo due to this bug, `yarn relink` should fix it after merging this commit.