### PR TITLE
Fix the URL returned by carbonite for reports

### DIFF
--- a/packages/haiku-serialization/src/utils/carbonite.js
+++ b/packages/haiku-serialization/src/utils/carbonite.js
@@ -102,7 +102,7 @@ function crashReport (orgName, projectName, projectPath) {
     .then(AWS3URL => _upload(AWS3URL, zipPath))
     .catch(error => console.log(error))
 
-  return `${AWS3Server}/${zipName}`
+  return `${AWS3Server}/${orgName}/${zipName}`
 }
 
 function sentryCallback (data) {


### PR DESCRIPTION
This fixes a bug introduced in 4cd169fb, making carbonite#crashReport
return the correct URL to where the project data is stored in S3.

It is important to set this URL properly, because Sentry uses
it for the reports.