### PR TITLE
tweak: Adds support for style.css, before.html, and after.html in Player demos.

### DIFF
--- a/packages/haiku-player/demo/templates/debug.html.handlebars
+++ b/packages/haiku-player/demo/templates/debug.html.handlebars
@@ -9,12 +9,15 @@
     html, body {
       margin: 0;
     }
+    {{{style}}}
   </style>
   <script src="/webpack/HaikuDOMAdapter.js"></script>
   <script src="/webpack/bytecode.js"></script>
 </head>
 <body>
+  {{{before}}}
   <div id="mount"></div>
+  {{{after}}}
   <script>
     window.HaikuDOMAdapter.default(window.bytecode)(document.getElementById('mount'));
   </script>

--- a/packages/haiku-player/demo/templates/demo.html.handlebars
+++ b/packages/haiku-player/demo/templates/demo.html.handlebars
@@ -11,6 +11,7 @@
       border: 1px solid black;
       height: 600px;
     }
+    {{{style}}}
   </style>
   <script src="/webpack/dom.js"></script>
   <script src="/webpack/reactDom.js"></script>
@@ -21,18 +22,20 @@
 
     <h1>{{demo}} | Haiku Player</h1>
 
-    {{#if note}}
-      <p>{{note}}</p>
-    {{/if}}
+    <p>{{{note}}}</p>
 
     <div class="row">
       <div class="col-md-6">
         <h2>vanilla</h2>
+        {{{before}}}
         <div class="mount" id="dom-mount"></div>
+        {{{after}}}
       </div>
       <div class="col-md-6">
         <h2>react</h2>
+        {{{before}}}
         <div class="mount" id="react-dom-mount"></div>
+        {{{after}}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
As discussed: park `after.html`, `before.html`, and/or `style.css` in the demo directory (same as `note.txt`), and it will now show up in both debug and demo views. 