### PR TITLE
Fix issues with right click actions on Timeline

### DIFF
--- a/packages/haiku-timeline/src/components/ConstantBody.js
+++ b/packages/haiku-timeline/src/components/ConstantBody.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Color from 'color'
 import Palette from './DefaultPalette'
+import Globals from './Globals'
 
 export default class ConstantBody extends React.Component {
   constructor (props) {
@@ -63,7 +64,10 @@ export default class ConstantBody extends React.Component {
         onMouseDown={(mouseEvent) => {
           mouseEvent.stopPropagation()
           this.props.keyframe.select({
-            skipDeselect: mouseEvent.shiftKey || mouseEvent.ctrlKey
+            skipDeselect:
+              Globals.isShiftKeyDown ||
+              Globals.isControlKeyDown ||
+              mouseEvent.nativeEvent.which === 3
           })
         }}
         style={{

--- a/packages/haiku-timeline/src/components/Globals.js
+++ b/packages/haiku-timeline/src/components/Globals.js
@@ -1,5 +1,8 @@
 const globals = {
-  mouse: { x: 0, y: 0 }
+  mouse: { x: 0, y: 0 },
+  // Control and shift keys are managed from Timeline.js
+  isShiftKeyDown: false,
+  isControlKeyDown: false
 }
 
 window.addEventListener('mousemove', (mouseMoveEvent) => {

--- a/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
+++ b/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import lodash from 'lodash'
 import { DraggableCore } from 'react-draggable'
+import Globals from './Globals'
 
 const THROTTLE_TIME = 17 // ms
 
@@ -54,7 +55,10 @@ export default class InvisibleKeyframeDragger extends React.Component {
         onMouseDown={(mouseEvent) => {
           mouseEvent.stopPropagation()
           this.props.keyframe.select({
-            skipDeselect: mouseEvent.shiftKey || mouseEvent.ctrlKey
+            skipDeselect:
+              Globals.isShiftKeyDown ||
+              Globals.isControlKeyDown ||
+              mouseEvent.nativeEvent.which === 3
           })
         }}>
         <span

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -22,7 +22,7 @@ import GaugeTimeReadout from './GaugeTimeReadout'
 import TimelineRangeScrollbar from './TimelineRangeScrollbar'
 import HorzScrollShadow from './HorzScrollShadow'
 
-require('./Globals') // Sorry, hack
+const Globals = require('./Globals') // Sorry, hack
 
 /* z-index guide
   keyframe: 1002
@@ -313,8 +313,12 @@ class Timeline extends React.Component {
       // case 13: //enter
       // delete
       case 8: return this.component.deleteSelectedKeyframes({ from: 'timeline' }) // Only if there are any
-      case 16: return this.updateKeyboardState({ isShiftKeyDown: true })
-      case 17: return this.updateKeyboardState({ isControlKeyDown: true })
+      case 16:
+        Globals.isShiftKeyDown = true
+        return this.updateKeyboardState({ isShiftKeyDown: true })
+      case 17:
+        Globals.isControlKeyDown = true
+        return this.updateKeyboardState({ isControlKeyDown: true })
       case 18: return this.updateKeyboardState({ isAltKeyDown: true })
       case 224: return this.updateKeyboardState({ isCommandKeyDown: true })
       case 91: return this.updateKeyboardState({ isCommandKeyDown: true })
@@ -333,8 +337,12 @@ class Timeline extends React.Component {
       // case 46: //delete
       // case 8: //delete
       // case 13: //enter
-      case 16: return this.updateKeyboardState({ isShiftKeyDown: false })
-      case 17: return this.updateKeyboardState({ isControlKeyDown: false })
+      case 16:
+        Globals.isShiftKeyDown = false
+        return this.updateKeyboardState({ isShiftKeyDown: false })
+      case 17:
+        Globals.isControlKeyDown = false
+        return this.updateKeyboardState({ isControlKeyDown: false })
       case 18: return this.updateKeyboardState({ isAltKeyDown: false })
       case 224: return this.updateKeyboardState({ isCommandKeyDown: false })
       case 91: return this.updateKeyboardState({ isCommandKeyDown: false })
@@ -741,8 +749,12 @@ class Timeline extends React.Component {
             overflowY: 'auto',
             overflowX: 'hidden'
           }}
-          onMouseUp={(mouseEvent) => {
-            if (!mouseEvent.shiftKey && !mouseEvent.ctrlKey) {
+          onMouseDown={(mouseEvent) => {
+            if (
+              Globals.isShiftKeyDown ||
+              Globals.isControlKeyDown ||
+              mouseEvent.nativeEvent.which === 3
+            ) {
               this.component.deselectAndDeactivateAllKeyframes()
             }
           }}>

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -4,6 +4,7 @@ import lodash from 'lodash'
 import Palette from './DefaultPalette'
 import { DraggableCore } from 'react-draggable'
 import KeyframeSVG from './icons/KeyframeSVG'
+import Globals from './Globals'
 
 import {
   EaseInBackSVG,
@@ -135,7 +136,11 @@ export default class TransitionBody extends React.Component {
         onMouseDown={(mouseEvent) => {
           mouseEvent.stopPropagation()
 
-          if (mouseEvent.ctrlKey || mouseEvent.shiftKey) {
+          if (
+            Globals.isShiftKeyDown ||
+            Globals.isControlKeyDown ||
+            mouseEvent.nativeEvent.which === 3
+          ) {
             // If others are already selected and we're doing context menu, don't deselect
             if (this.props.keyframe.areAnyOthersSelected()) {
               this.props.keyframe.select({
@@ -148,7 +153,10 @@ export default class TransitionBody extends React.Component {
           } else if (mouseEvent) {
             // But if we're e.g. dragging it, we need to select the next one so we move as a group
             this.props.keyframe.selectSelfAndSurrounds({
-              skipDeselect: mouseEvent.shiftKey || mouseEvent.ctrlKey
+              skipDeselect:
+                Globals.isShiftKeyDown ||
+                Globals.isControlKeyDown ||
+                mouseEvent.nativeEvent.which === 3
             })
           }
         }}>


### PR DESCRIPTION
This fixes issues with mouse events on the timeline by:

1. Tracking globally if the shift of the control keys are pressed
2. Switching listeners from `mouseup` from `mousedown` so we can
detect right clicks
3. Detecting right clicks