### PR TITLE
feat: Simplifies experiments and releases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 branches:
   only:
-    - staging
-    - production
+    - release
 
 os: osx
 osx_image: xcode8.3

--- a/README.md
+++ b/README.md
@@ -18,17 +18,18 @@ And add to `~/.ssh/config`:
       UseKeychain yes
       IdentityFile ~/.ssh/id_rsa
 
-**node/npm/yarn installation**
+**Node/Yarn installation**
 
-    $ rm -rf /usr/local/lib/node_modules/npm
+    $ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
     $ nvm install 8.4.0
     $ nvm alias default 8.4.0
-    $ brew install yarn --without-node
+    $ curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.0.2
 
-**git/yarn/packages setup**
+**Setup**
 
-    $ yarn install
-    $ yarn sync
+After you clone the repository, simply run:
+
+    $ yarn setup
 
 ## Development
 

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,0 +1,25 @@
+#!/usr/bin/env python2.7
+import sys
+from os import path
+import json
+import subprocess
+
+is_branch_checkout = sys.argv[3]
+if is_branch_checkout == '0':
+  # This is a file checkout. Nothing to do!
+  sys.exit(0)
+
+current_branch = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).strip()
+experiment_branch = current_branch if current_branch == 'release' else 'development'
+with open(path.join('packages', 'haiku-common', 'config', 'experiments.json')) as experiments_file:
+  experiments = json.load(experiments_file)
+
+if sys.argv[1] != sys.argv[2]:
+  print 'Syncing dependencies....'
+  subprocess.call(['yarn', 'sync'])
+
+print 'NOTE: you are on a {} branch.'.format(experiment_branch)
+print 'The following experiments are enabled:'
+print '\n'.join([
+  ' - {}'.format(experiment) for experiment in experiments if experiments[experiment].get(experiment_branch, False)
+])

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -1,0 +1,5 @@
+#!/usr/bin/env python2.7
+import subprocess
+
+print 'Syncing dependencies....'
+subprocess.call(['yarn', 'sync'])

--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -1,12 +1,9 @@
 {
   "LottieExportInGlobalMenu": {
-    "test": true,
     "development": true
   },
   "LottieExportOnPublish": {
-    "test": true,
     "development": true,
-    "staging": true,
-    "production": true
+    "release": true
   }
 }

--- a/packages/haiku-common/src/environments/index.ts
+++ b/packages/haiku-common/src/environments/index.ts
@@ -2,11 +2,20 @@
  * Runtime environment.
  * @enum {string}
  */
-export enum Environment {
+export const enum Environment {
   Test = 'test',
   Development = 'development',
   Staging = 'staging',
   Production = 'production',
+}
+
+/**
+ * Runtime environment type.
+ * @enum {string}
+ */
+export const enum EnvironmentType {
+  Development = 'development',
+  Release = 'release',
 }
 
 /**
@@ -15,3 +24,13 @@ export enum Environment {
  * If no environment is provided as an environment variable, assume production.
  */
 export const getEnvironment = () => global.process.env.NODE_ENV || Environment.Production;
+
+/**
+ * Gets the environment type.
+ */
+export const getEnvironmentType = () => {
+  const environment = getEnvironment();
+  return (environment === Environment.Staging || environment === Environment.Production)
+    ? EnvironmentType.Release
+    : EnvironmentType.Development;
+};

--- a/packages/haiku-common/src/experiments/index.ts
+++ b/packages/haiku-common/src/experiments/index.ts
@@ -1,4 +1,4 @@
-import {Environment, getEnvironment} from '../environments';
+import {EnvironmentType, getEnvironmentType} from '../environments';
 import {getExperimentConfig} from './config';
 
 /**
@@ -17,16 +17,15 @@ export enum Experiment {
  *
  *   {
  *     "ExperimentName": {
- *       "test": true,
- *       "staging": true,
- *       "production": false
+ *       "development": true,
+ *       "release": false
  *     },
  *     ...
  *   }
  *
  * We'll lazily read the config from experiments.json when it is requested for the first time.
  */
-type ExperimentConfig = {[key in Experiment]: {[key in Environment]: boolean}};
+type ExperimentConfig = {[key in Experiment]: {[key in EnvironmentType]: boolean}};
 let experimentConfig: ExperimentConfig;
 
 /**
@@ -51,5 +50,5 @@ export const experimentIsEnabled = (experiment: Experiment): boolean => {
     return experimentCache[experiment];
   }
 
-  return experimentCache[experiment] = experimentConfig[experiment][getEnvironment()] || false;
+  return experimentCache[experiment] = experimentConfig[experiment][getEnvironmentType()] || false;
 };

--- a/packages/haiku-common/test/experiments.test.ts
+++ b/packages/haiku-common/test/experiments.test.ts
@@ -17,7 +17,7 @@ tape('experimentIsEnabled', (test: tape.Test) => {
       'lib/experiments', {'./config': 'getExperimentConfig'});
     getExperimentConfig.returns({
       FooExperiment: {
-        test: true,
+        development: true,
       },
     });
     test.true(experimentIsEnabled('FooExperiment'));

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -31,16 +31,9 @@ module.exports = {
     legacy: process.env.HAIKU_INTERNAL_SLACK_LEGACY_TOKEN
   },
   deployer: {
-    production: {
+    release: {
       region: 'us-east-1',
       bucket: 'haiku-electron-releases-production',
-      user: 'haiku-electron-releases-writer-2',
-      key: process.env.HAIKU_RELEASE_WRITER_KEY,
-      secret: process.env.HAIKU_RELEASE_WRITER_SECRET
-    },
-    staging: {
-      region: 'us-east-1',
-      bucket: 'haiku-electron-releases-staging',
       user: 'haiku-electron-releases-writer-2',
       key: process.env.HAIKU_RELEASE_WRITER_KEY,
       secret: process.env.HAIKU_RELEASE_WRITER_SECRET
@@ -48,13 +41,6 @@ module.exports = {
     development: {
       region: 'us-east-1',
       bucket: 'haiku-electron-releases-development',
-      user: 'haiku-electron-releases-writer-2',
-      key: process.env.HAIKU_RELEASE_WRITER_KEY,
-      secret: process.env.HAIKU_RELEASE_WRITER_SECRET
-    },
-    test: {
-      region: 'us-east-1',
-      bucket: 'haiku-electron-releases-test',
       user: 'haiku-electron-releases-writer-2',
       key: process.env.HAIKU_RELEASE_WRITER_KEY,
       secret: process.env.HAIKU_RELEASE_WRITER_SECRET

--- a/scripts/distro-configure.js
+++ b/scripts/distro-configure.js
@@ -8,13 +8,13 @@ var writeHackyDynamicDistroConfig = require('./helpers/writeHackyDynamicDistroCo
 var forceNodeEnvProduction = require('./helpers/forceNodeEnvProduction')
 
 var ROOT = path.join(__dirname, '..')
-var ENVS = { test: true, development: true, staging: true, production: true }
+var ENVS = { development: true, release: true }
 
 forceNodeEnvProduction()
 
 var inputs = lodash.assign({
   branch: 'master',
-  environment: 'staging',
+  environment: 'development',
   uglify: false,
   upload: true,
   shout: true,
@@ -25,9 +25,9 @@ delete inputs.$0
 delete inputs._
 
 if (process.env.TRAVIS) {
-  // Always assume the in-app NODE_ENV will be 'staging' unless this is production
-  if (process.env.TRAVIS_BRANCH === 'production') {
-    inputs.environment = 'production'
+  // Always assume the in-app NODE_ENV will be 'development' unless this is a release
+  if (process.env.TRAVIS_BRANCH === 'release') {
+    inputs.environment = 'release'
   }
 }
 
@@ -36,13 +36,13 @@ if (!argv['non-interactive']) {
     {
       type: 'input',
       name: 'environment',
-      message: `Environment tag (helps specify the release bucket; affects autoupdate):`,
+      message: `Environment tag:`,
       default: inputs.environment
     },
     {
       type: 'confirm',
       name: 'uglify',
-      message: 'Obfuscate source code in release bundle ("yes" is required for production)?:',
+      message: 'Obfuscate source code in release bundle ("yes" is required for release)?:',
       default: inputs.uglify
     },
     {
@@ -60,8 +60,8 @@ if (!argv['non-interactive']) {
   ]).then(function (answers) {
     lodash.assign(inputs, answers)
 
-    if (inputs.uglify === false && inputs.environment === 'production') {
-      throw new Error(`refusing to create a non-obfuscated build for 'production'`)
+    if (inputs.uglify === false && inputs.environment === 'release') {
+      throw new Error(`refusing to create a non-obfuscated build for 'release'`)
     }
 
     if (!ENVS[inputs.environment]) {

--- a/scripts/distro-upload.js
+++ b/scripts/distro-upload.js
@@ -20,7 +20,7 @@ var bucket = deploy.deployer[environment].bucket
 
 var RELEASES_FOLDER = 'releases'
 
-uploadRelease(region, objkey, secret, bucket, RELEASES_FOLDER, platform, environment, branch, version, (err, { environment, platform, branch, countdown, version, urls }) => {
+uploadRelease(region, objkey, secret, bucket, RELEASES_FOLDER, platform, environment, branch, version, (err, { environment, version, urls }) => {
   if (err) throw err
 
   var slackMessage = `

--- a/scripts/helpers/checkNodeVersion.js
+++ b/scripts/helpers/checkNodeVersion.js
@@ -2,14 +2,16 @@ const cp = require('child_process')
 
 const log = require('./log')
 
-const NODE_VERSION = 'v8.4.0'
+const NODE_VERSION = '8.4.0'
 
 module.exports = () => {
   const nodeVersion = cp.execSync('node --version').toString().trim()
-  if (nodeVersion !== NODE_VERSION) {
-    log.warn(`WARNING: you are using node version ${nodeVersion}. We recommend version ${NODE_VERSION}.`)
+  if (nodeVersion !== `v${NODE_VERSION}`) {
+    log.warn(`WARNING: you are using node version ${nodeVersion}. We recommend version v${NODE_VERSION}.`)
     log.warn('Get it via:')
-    log.warn(`  curl -0 https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}.pkg > /tmp/node-${NODE_VERSION}.pkg && sudo installer -target / -pkg /tmp/node-${NODE_VERSION}`)
+    log.warn(`  curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash`)
+    log.warn(`  nvm install ${NODE_VERSION}`)
+    log.warn(`  nvm alias default ${NODE_VERSION}`)
     log.warn('You have been warned!\n')
   }
 }

--- a/scripts/helpers/runFlakyCommand.js
+++ b/scripts/helpers/runFlakyCommand.js
@@ -1,0 +1,19 @@
+const log = require('./log')
+
+module.exports = (command, commandAlias, attempts) => {
+  let remainingTries = attempts
+
+  while (remainingTries > 0) {
+    try {
+      command()
+      break
+    } catch (e) {
+      log.err(`Encountered error during ${commandAlias}. Retrying....`)
+      remainingTries--
+    }
+  }
+
+  if (remainingTries === 0) {
+    throw new Error(`Unable to ${commandAlias} after ${attempts} attempts`)
+  }
+}


### PR DESCRIPTION
 - Releases all operate off a single `release` branch (pending first-time creation).
 - Environments/experiments are simplified to be either `release` or `development`. (For edge-case backward compatibility/separation of testing concerns I left the concept of `staging` and `production` `NODE_ENV`s intact and didn't try to refactor anything related to `NODE_ENV`.)
 - Commandeers the then-deprecated, now-rebooted `yarn setup` command to install some Git hooks*, including a `post-checkout` that that tells you what experiments are enabled when you switch branches (and runs `yarn sync` if needed**), and `post-merge` that just always runs `yarn sync`.**
 - Updates README to be correct/complete.

**Retrofitting an existing codebase**: should be as simple as running `yarn setup` once.
**New process for releases**: merge `master` branch to `release` branch, and push `release` branch. Download `...-pending.zip` build for testing, and release to production by removing `...-pending.zip`.
**Warning**: if you have existing Git hooks, `yarn setup` will destroy them. So if you want to keep them, definitely copy them out first, then add/merge them in to `hooks/` in the repo root.

*I wrote the hooks in Python, mainly for easier readability. LMK if this doesn't work for you/anyone.
**With the changes in #81, we **should** now have a non-disruptive and no-thinking required basis for collaborating on a stable, dependencies-always-updated code base (but as always, let's expect edge-case bugs), and no longer have to think about running `yarn sync`.