### PR TITLE
Fixes for some Lottie edge cases

### DIFF
--- a/packages/haiku-formats/src/exporters/bodymovin/bodymovinEnums.ts
+++ b/packages/haiku-formats/src/exporters/bodymovin/bodymovinEnums.ts
@@ -18,6 +18,7 @@ export const enum LayerKey {
   Type = 'ty',
   Transform = 'ks',
   Index = 'ind',
+  LocalIndex = 'hix',
   Name = 'nm',
 }
 

--- a/packages/haiku-formats/src/exporters/bodymovin/bodymovinExporter.ts
+++ b/packages/haiku-formats/src/exporters/bodymovin/bodymovinExporter.ts
@@ -111,6 +111,12 @@ export class BodymovinExporter implements Exporter {
   private bytecodeParsed = false;
 
   /**
+   * Local layer index, for resolving z-index collisions.
+   * @type {number}
+   */
+  private localLayerIndex = 0;
+
+  /**
    * Core storage for the transformed output.
    * @type {any}
    */
@@ -432,6 +438,7 @@ export class BodymovinExporter implements Exporter {
       [LayerKey.InPoint]: 0,
       [LayerKey.StartTime]: 0,
       [LayerKey.Index]: this.zIndexForNode(node),
+      [LayerKey.LocalIndex]: ++this.localLayerIndex,
       [LayerKey.Type]: LayerType.Shape,
       [LayerKey.Transform]: {
         ...this.standardTransformsForTimeline(timeline),
@@ -1101,7 +1108,13 @@ export class BodymovinExporter implements Exporter {
     });
 
     // Stack elements in order of *descending* z-index.
-    this.layers.sort((layerA, layerB) => layerB[LayerKey.Index] - layerA[LayerKey.Index]);
+    this.layers.sort((layerA, layerB) => {
+      if (layerA[LayerKey.Index] === layerB[LayerKey.Index]) {
+        return layerB[LayerKey.LocalIndex] - layerA[LayerKey.LocalIndex];
+      }
+
+      return layerB[LayerKey.Index] - layerA[LayerKey.Index];
+    });
     this.bytecodeParsed = true;
   }
 

--- a/packages/haiku-formats/src/exporters/bodymovin/bodymovinTransformers.ts
+++ b/packages/haiku-formats/src/exporters/bodymovin/bodymovinTransformers.ts
@@ -4,6 +4,7 @@ import {
   DasharrayKey,
   DasharrayRole,
   FillRule,
+  LayerKey,
   StrokeLinecap,
   StrokeLinejoin,
 } from './bodymovinEnums';
@@ -134,5 +135,6 @@ export const dasharrayTransformer = (dasharray: string) => {
   return dashGaps.map((value, index) => ({
     [DasharrayKey.Role]: dasharrayRoles[index % 2],
     [DasharrayKey.Value]: getFixedPropertyValue(value),
+    [LayerKey.Name]: index.toString(),
   }));
 };

--- a/packages/haiku-formats/test/exporters/bodymovin.test.ts
+++ b/packages/haiku-formats/test/exporters/bodymovin.test.ts
@@ -692,8 +692,13 @@ tape('BodymovinExporter', (test: tape.Test) => {
 
   test.test('stacks elements in order of descending z-index', (test: tape.Test) => {
     const bytecode = baseBytecodeCopy();
-    // Shim in two SVG layers.
+    // Shim in three SVG layers.
     bytecode.template.children = [
+      {
+        elementName: 'svg',
+        attributes: {'haiku-id': 'svg0'},
+        children: [],
+      },
       {
         elementName: 'svg',
         attributes: {'haiku-id': 'svg1'},
@@ -705,6 +710,10 @@ tape('BodymovinExporter', (test: tape.Test) => {
         children: [],
       },
     ];
+    bytecode.timelines.Default['haiku:svg0'] = {
+      opacity: {0: {value: .25}},
+      'style.zIndex': {0: {value: 1}},
+    };
     bytecode.timelines.Default['haiku:svg1'] = {
       opacity: {0: {value: .5}},
       'style.zIndex': {0: {value: 1}},
@@ -717,13 +726,14 @@ tape('BodymovinExporter', (test: tape.Test) => {
     const {layers} = rawOutput(bytecode);
     test.equal(layers[0].ks.o.k, 100, 'elements with higher z-index come earlier');
     test.equal(layers[1].ks.o.k, 50, 'elements with lower z-index come later');
+    test.equal(layers[2].ks.o.k, 25, 'z-index conflicts are resolved based on original order');
     test.end();
   });
 
   test.test('simulates wrapper div with a background color as a rectangle', (test: tape.Test) => {
     const bytecode = baseBytecodeCopy();
     bytecode.timelines.Default['haiku:wrapper'].backgroundColor = {0: {value: '#000'}};
-    const {layers: [{ind, ty, shapes: [{it: [shape, _, fill]}]}]} = rawOutput(bytecode);
+    const {layers: [_, {ind, ty, shapes: [{it: [shape, __, fill]}]}]} = rawOutput(bytecode);
     test.equal(ind, 0, 'wrapper rectangle has z-index 0');
     test.equal(ty, 4, 'wrapper rectangle is an ordinary shape layer');
     test.equal(shape.ty, 'rc', 'wrapper rectangle is in fact a rectangle');


### PR DESCRIPTION
In this PR:

- Give dasharray components unique names. This is required for the Bodymovin player, for obscure Bodymovin internals types of reasons. Without this, editor.lottiefiles.com crashes on a fresh export of CheckTutorial, reported by @zackbrown.
- Fix z-index collisions (apparently we have some) by keeping and failing over to a "local" index derived from our DFS of the bytecode template. This fixes the "angry face doesn't turn red" bug on the `NewReactions` project, reported by Nad.