### PR TITLE
Fix the import path of interaction modes in stage

### DIFF
--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -10,7 +10,7 @@ import { BTN_STYLES } from '../styles/btnShared'
 import CopyToClipboard from 'react-copy-to-clipboard'
 import ToolSelector from './ToolSelector'
 import Toggle from './Toggle'
-import {InteractionMode} from 'haiku-common/lib/interaction-modes'
+import {InteractionMode} from '@haiku/player/lib/helpers/interactionModes'
 import {
   PublishSnapshotSVG,
   ConnectionIconSVG,


### PR DESCRIPTION
This module was originally hosted in `haiku-common` but got moved
into `haiku-player` during development, since the `lib` folder is
ignored, the built file was still on my computer and I didn't
notice this.

Thanks to Matthew for the report.