### PR TITLE
Use 1 instead of 0 for default values in edit mode

### DIFF
--- a/packages/haiku-player/src/ValueBuilder.ts
+++ b/packages/haiku-player/src/ValueBuilder.ts
@@ -512,8 +512,8 @@ INJECTABLES['$user'] = {
     } else {
       injectees.$user = {
         mouse: {
-          x: 0,
-          y: 0,
+          x: 1,
+          y: 1,
           down: 0,
           buttons: [0, 0, 0],
         },
@@ -751,13 +751,13 @@ export default function ValueBuilder(component) {
   HaikuHelpers.register('now', () => {
     isPreviewMode(this._component.config.options.interactionMode)
       ? this._component._context.getDeterministicTime()
-      : 0;
+      : 1;
   });
 
   HaikuHelpers.register('rand', () => {
     isPreviewMode(this._component.config.options.interactionMode)
       ? this._component._context.getDeterministicRand()
-      : 0;
+      : 1;
   });
 }
 


### PR DESCRIPTION
This will prevent the app crashing if for some reason the value
is user as a denominator in a division.

Probably worth discussing if `$helpers.now` should return 1 or not.