### PR TITLE
Merge in case of emergency: Hide preview mode

### DIFF
--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -7,8 +7,7 @@
     "production": true
   },
   "PreviewMode": {
-    "test": true,
-    "development": true,
-    "production": true
+    "development": false,
+    "production": false
   }
 }

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -23,13 +23,21 @@ const {
   InteractionMode,
   isPreviewMode
 } = require('@haiku/player/lib/helpers/interactionModes')
+const {
+  Experiment,
+  experimentIsEnabled
+} = require('haiku-common/lib/experiments')
 
 const WEBSOCKET_BATCH_INTERVAL = 250
 const KEYFRAME_MOVE_DEBOUNCE_TIME = 500
 
 const HAIKU_ID_ATTRIBUTE = 'haiku-id'
 const DEFAULT_SCENE_NAME = 'main' // e.g. code/main/*
-const DEFAULT_INTERACTION_MODE = InteractionMode.EDIT
+
+// Without the preview mode feature, the everything behaves as it was 'LIVE'
+const DEFAULT_INTERACTION_MODE = experimentIsEnabled(Experiment.PreviewMode)
+  ? InteractionMode.EDIT
+  : InteractionMode.LIVE
 
 /**
  * @class ActiveComponent
@@ -426,7 +434,10 @@ class ActiveComponent extends BaseModel {
   }
 
   isPreviewModeActive () {
-    return isPreviewMode(this._interactionMode)
+    // If preview mode is disabled, let the app think that it's just deactivated
+    return experimentIsEnabled(Experiment.PreviewMode)
+      ? isPreviewMode(this._interactionMode)
+      : false
   }
 
   /**


### PR DESCRIPTION
We can easily hide preview mode and get back to the old behavior
with this hack:

- Set the default mode to LIVE, stage was behaving just like live
before implementing preview mode
- Hard-code a `false` return value in `ActiveComponent#isPreviewMode`
which is the single source of truth to check for preview mode in
the app, this is also how the app was behaving previous merge

All the logic in the player remains intact.

Good thing is, all is handled via the experiments flag, so I'm wondering
if we should switch the flag to true and merge this even if we decide
to keep preview mode.