### PR TITLE
Taylor multi-select fixes

### DIFF
--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -1279,7 +1279,7 @@ class ActiveComponent extends BaseModel {
     keyframes.forEach((keyframe) => {
       // Only keyframes that have a next keyframe should get the curve assigned,
       // otherwise you'll see a "surprise curve" if you add a next keyframe
-      if (keyframe.next()) {
+      if (keyframe.next() && keyframe.next()._selected) {
         keyframe.changeCurve(curveName, metadata)
       }
     })

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -47,7 +47,10 @@ class Keyframe extends BaseModel {
       Keyframe.deselectAndDeactivateAllKeyframes()
     }
 
-    if (!this._selected || !Keyframe._selected[this.getUniqueKey()]) {
+    if (
+      (!this._selected || !this._selectedBody) ||
+      !Keyframe._selected[this.getUniqueKey()]
+    ) {
       this._selected = true
       if (config.selectConstBody) this._selectedBody = true
       if (config.directlySelected) this._directlySelected = true

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -194,19 +194,20 @@ class Keyframe extends BaseModel {
   }
 
   removeCurve (metadata) {
-    this.setCurve(null)
+    if (this.next() && this.next()._selected) {
+      this.setCurve(null)
+      this.component.splitSegment(
+        [this.element.getComponentId()],
+        this.timeline.getName(),
+        this.element.getNameString(),
+        this.row.getPropertyNameString(),
+        this.getMs(),
+        metadata,
+        () => {}
+      )
 
-    this.component.splitSegment(
-      [this.element.getComponentId()],
-      this.timeline.getName(),
-      this.element.getNameString(),
-      this.row.getPropertyNameString(),
-      this.getMs(),
-      metadata,
-      () => {}
-    )
-
-    this.row.emit('update', 'keyframe-remove-curve')
+      this.row.emit('update', 'keyframe-remove-curve')
+    }
 
     return this
   }

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -49,6 +49,8 @@ class Keyframe extends BaseModel {
 
     if (!this._selected || !Keyframe._selected[this.getUniqueKey()]) {
       this._selected = true
+      if (config.selectConstBody) this._selectedBody = true
+      if (config.directlySelected) this._directlySelected = true
       Keyframe._selected[this.getUniqueKey()] = this
       this.emitWithNeighbors('update', 'keyframe-selected')
     }
@@ -59,6 +61,8 @@ class Keyframe extends BaseModel {
   deselect () {
     if (this._selected || Keyframe._selected[this.getUniqueKey()]) {
       this._selected = false
+      this._selectedBody = false
+      this._directlySelected = false
       delete Keyframe._selected[this.getUniqueKey()]
       this.emitWithNeighbors('update', 'keyframe-deselected')
     }
@@ -74,6 +78,14 @@ class Keyframe extends BaseModel {
 
   isSelected () {
     return this._selected
+  }
+
+  isSelectedBody () {
+    return this._selectedBody
+  }
+
+  isDirectlySelected () {
+    return this._directlySelected
   }
 
   areAnyOthersSelected () {

--- a/packages/haiku-timeline/src/components/ConstantBody.js
+++ b/packages/haiku-timeline/src/components/ConstantBody.js
@@ -67,7 +67,8 @@ export default class ConstantBody extends React.Component {
             skipDeselect:
               Globals.isShiftKeyDown ||
               Globals.isControlKeyDown ||
-              mouseEvent.nativeEvent.which === 3
+              mouseEvent.nativeEvent.which === 3,
+            selectConstBody: true
           })
         }}
         style={{
@@ -84,7 +85,7 @@ export default class ConstantBody extends React.Component {
               position: 'absolute',
               zIndex: 2,
               width: '100%',
-              backgroundColor: (this.props.keyframe.isSelected())
+              backgroundColor: (this.props.keyframe.isSelectedBody())
                 ? Color(Palette.LIGHTEST_PINK).fade(0.5)
                 : Palette.DARKER_GRAY
             }} />

--- a/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
+++ b/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
@@ -58,7 +58,8 @@ export default class InvisibleKeyframeDragger extends React.Component {
             skipDeselect:
               Globals.isShiftKeyDown ||
               Globals.isControlKeyDown ||
-              mouseEvent.nativeEvent.which === 3
+              mouseEvent.nativeEvent.which === 3,
+            directlySelected: true
           })
         }}>
         <span

--- a/packages/haiku-timeline/src/components/SoloKeyframe.js
+++ b/packages/haiku-timeline/src/components/SoloKeyframe.js
@@ -60,7 +60,7 @@ export default class SoloKeyframe extends React.Component {
             ? Palette.BLUE
             : (this.props.keyframe.isWithinCollapsedProperty())
                 ? Palette.DARK_ROCK
-                : (this.props.keyframe.isActive() || this.props.keyframe.isSelected())
+                : (this.props.keyframe.isActive() || this.props.keyframe.isDirectlySelected())
                   ? Palette.LIGHTEST_PINK
                   : Palette.ROCK
           } />

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -751,9 +751,9 @@ class Timeline extends React.Component {
           }}
           onMouseDown={(mouseEvent) => {
             if (
-              Globals.isShiftKeyDown ||
-              Globals.isControlKeyDown ||
-              mouseEvent.nativeEvent.which === 3
+              !Globals.isShiftKeyDown &&
+              !Globals.isControlKeyDown &&
+              mouseEvent.nativeEvent.which != 3
             ) {
               this.component.deselectAndDeactivateAllKeyframes()
             }

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -136,29 +136,12 @@ export default class TransitionBody extends React.Component {
         onMouseDown={(mouseEvent) => {
           mouseEvent.stopPropagation()
 
-          if (
-            Globals.isShiftKeyDown ||
-            Globals.isControlKeyDown ||
-            mouseEvent.nativeEvent.which === 3
-          ) {
-            // If others are already selected and we're doing context menu, don't deselect
-            if (this.props.keyframe.areAnyOthersSelected()) {
-              this.props.keyframe.select({
-                skipDeselect: true
-              })
-            } else {
-              // If we're just adding a curve via the menu, don't select the next guy
-              this.props.keyframe.select()
-            }
-          } else if (mouseEvent) {
-            // But if we're e.g. dragging it, we need to select the next one so we move as a group
-            this.props.keyframe.selectSelfAndSurrounds({
-              skipDeselect:
-                Globals.isShiftKeyDown ||
-                Globals.isControlKeyDown ||
-                mouseEvent.nativeEvent.which === 3
-            })
-          }
+          this.props.keyframe.selectSelfAndSurrounds({
+            skipDeselect:
+              Globals.isShiftKeyDown ||
+              Globals.isControlKeyDown ||
+              mouseEvent.nativeEvent.which === 3
+          })
         }}>
         <span
           className='pill-container'


### PR DESCRIPTION
Could have sworn there was a nice `selectedKeyframes` and `selectedSegments` division when I threw multi-boop over the fence originally. 😛 All in all, it was **SO NICE** to develop on this reworked timeline today. Not going to miss that 3000K `timeline.js` anytime soon.

Fixes:
* Clicking anywhere on the timeline that is not a keyframe or segment should deselect any selected keyframes
* Clicking a tweened-segment should select both keyframes on either side of it. (this works for first selection but not on subsequent curve-clicked selections
* Clicking (selecting) a constant segment should not show its leading keyframe as selected.
* Can’t select a const seg if its keyframe is already selected.
* Selecting a single keyframe should not show a following constant segment as selected
* Dragging solo keyframes should only drag if directly selected
* Remove tween shouldn't remove unless keyframes on both sides of it are selected