### PR TITLE
tweak: Allow starting the app from detached HEAD mode.

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -47,7 +47,7 @@ delete inputs.$0
 // List of arguments following the command
 var args = argv._
 
-var _branch = cp.execSync('git symbolic-ref --short -q HEAD').toString().trim()
+var _branch = cp.execSync('git symbolic-ref --short -q HEAD || git rev-parse --short HEAD').toString().trim()
 log.log(`fyi, your current mono branch is ${JSON.stringify(_branch)}\n`)
 if (!inputs.branch) inputs.branch = _branch
 


### PR DESCRIPTION
In detached head mode, `yarn start`/`yarn go` crashes on `git symbolic-ref --short -q HEAD` for arcane Git reasons. This is a quick fix.