### PR TITLE
Fix preview mode + playback interactions

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -22,6 +22,8 @@ import AutoUpdater from './components/AutoUpdater'
 import EnvoyClient from 'haiku-sdk-creator/lib/envoy/client'
 import { EXPORTER_CHANNEL, ExporterFormat } from 'haiku-sdk-creator/lib/exporter'
 import { GLASS_CHANNEL } from 'haiku-sdk-creator/lib/glass'
+import {isPreviewMode} from '@haiku/player/lib/helpers/interactionModes'
+import Palette from './components/Palette.js'
 import ActivityMonitor from '../utils/activityMonitor.js'
 import {
   linkExternalAssetsOnDrop,
@@ -768,6 +770,22 @@ export default class Creator extends React.Component {
                     setDashboardVisibility={this.setDashboardVisibility.bind(this)}
                     switchActiveNav={this.switchActiveNav.bind(this)}
                     activeNav={this.state.activeNav}>
+                    {
+                      isPreviewMode(this.state.interactionMode) && (
+                        <div
+                          style={{
+                            opacity: 0.6,
+                            position: 'absolute',
+                            top: 34,
+                            left: 0,
+                            right: 0,
+                            bottom: 0,
+                            zIndex: 999999,
+                            backgroundColor: Palette.COAL
+                          }}
+                        />
+                      )
+                    }
                     {this.state.activeNav === 'library'
                       ? <Library
                         layout={this.layout}
@@ -801,7 +819,8 @@ export default class Creator extends React.Component {
                       organizationName={this.state.organizationName}
                       authToken={this.state.authToken}
                       username={this.state.username}
-                      password={this.state.password} />
+                      password={this.state.password}
+                      onPreviewModeToggled={(interactionMode) => { this.setState({interactionMode}) }} />
                     {(this.state.libraryItemDragging)
                       ? <div style={{ width: '100%', height: '100%', backgroundColor: 'white', opacity: 0.01, position: 'absolute', top: 0, left: 0 }} />
                       : '' }

--- a/packages/haiku-creator/src/react/components/Stage.js
+++ b/packages/haiku-creator/src/react/components/Stage.js
@@ -131,6 +131,7 @@ export default class Stage extends React.Component {
 
   onPreviewModeToggled (interactionMode) {
     this.setState({ interactionMode })
+    this.props.onPreviewModeToggled(interactionMode)
   }
 
   render () {

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -241,7 +241,8 @@ export class Glass extends React.Component {
       } else if (what === 'setInteractionMode') {
         // If we've toggled into preview mode, we have to force react to update the on-stage styles
         this.forceUpdate()
-        this._component.getCurrentTimeline().toggleFreezeAndGotoStart()
+        this._component.getCurrentTimeline().togglePreviewPlayback(this.isPreviewMode())
+
       }
 
       // Not sure if we really need to call this, since this is called in a raf loop

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -241,6 +241,7 @@ export class Glass extends React.Component {
       } else if (what === 'setInteractionMode') {
         // If we've toggled into preview mode, we have to force react to update the on-stage styles
         this.forceUpdate()
+        this._component.getCurrentTimeline().toggleFreezeAndGotoStart()
       }
 
       // Not sure if we really need to call this, since this is called in a raf loop

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -257,6 +257,16 @@ class Timeline extends BaseModel {
     return this
   }
 
+  toggleFreezeAndGotoStart () {
+    const timelineName = this.component.getCurrentTimelineName()
+    const timelineInstances = this.component.instance._timelineInstances
+    const timelineInstance = timelineInstances[timelineName]
+    timelineInstance.isFrozen()
+      ? timelineInstance.unfreeze()
+      : timelineInstance.freeze()
+    timelineInstance.seek(0)
+  }
+
   getDurationDragStart () {
     return this._durationDragStart
   }

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -257,14 +257,20 @@ class Timeline extends BaseModel {
     return this
   }
 
-  toggleFreezeAndGotoStart () {
+  togglePreviewPlayback (isPreviewMode) {
     const timelineName = this.component.getCurrentTimelineName()
     const timelineInstances = this.component.instance._timelineInstances
     const timelineInstance = timelineInstances[timelineName]
-    timelineInstance.isFrozen()
-      ? timelineInstance.unfreeze()
-      : timelineInstance.freeze()
-    timelineInstance.seek(0)
+
+    if (isPreviewMode) {
+      timelineInstance.unfreeze()
+       timelineInstance.gotoAndPlay(0)
+       timelineInstance.options.loop = true
+    } else {
+      timelineInstance.freeze()
+      timelineInstance.seek(0)
+      timelineInstance.options.loop = false
+    }
   }
 
   getDurationDragStart () {

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -54,6 +54,7 @@ const DEFAULTS = {
   isControlKeyDown: false,
   isAltKeyDown: false,
   avoidTimelinePointerEvents: false,
+  isPreviewModeActive: false,
   $update: { time: Date.now() } // legacy?
 }
 
@@ -135,7 +136,12 @@ class Timeline extends React.Component {
     })
 
     this.addEmitterListener(this.component, 'remote-update', (what) => {
-      this.forceUpdate()
+      if (what === 'setInteractionMode') {
+        // If we've toggled into preview mode
+        this.playbackSkipBack()
+        this.forceUpdate()
+        this.setState({isPreviewModeActive: !this.state.isPreviewModeActive})
+      }
     })
   }
 
@@ -737,8 +743,24 @@ class Timeline extends React.Component {
           height: 'calc(100% - 45px)',
           width: '100%',
           overflowY: 'hidden',
-          overflowX: 'hidden'
+          overflowX: 'hidden',
         }}>
+        {
+          this.state.isPreviewModeActive && (
+            <div
+              style={{
+                opacity: 0.6,
+                position: 'fixed',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                zIndex: 999999,
+                backgroundColor: Palette.COAL
+              }}
+            />
+          )
+        }
         <HorzScrollShadow
           timeline={this.component.getCurrentTimeline()} />
         {this.renderTopControls()}


### PR DESCRIPTION
This adds a few tweaks to the preview mode + timeline playback
interactions:

- Disable the timeline and the library if preview mode is on
- Enable the component to take control of the playback during
preview mode
- Fix playback issues in the timeline when switching between
modes

**Notes**

- Would be great if we can improve the response time when switching modes, feels too slow now.

![percy-2](https://user-images.githubusercontent.com/4419992/33020204-1f675cfc-cddc-11e7-823b-6324b1262406.gif)