### PR TITLE
Disable preview mode until the timeline is ready

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -64,6 +64,8 @@ export default class Creator extends React.Component {
     this.handleFindElementCoordinates = this.handleFindElementCoordinates.bind(this)
     this.handleFindWebviewCoordinates = this.handleFindWebviewCoordinates.bind(this)
     this.onAutoUpdateCheckComplete = this.onAutoUpdateCheckComplete.bind(this)
+    this.onTimlineMounted = this.onTimlineMounted.bind(this)
+    this.onTimelineUnmounted = this.onTimelineUnmounted.bind(this)
     this.layout = new EventEmitter()
     this.activityMonitor = new ActivityMonitor(window, this.onActivityReport.bind(this))
 
@@ -634,6 +636,14 @@ export default class Creator extends React.Component {
     })
   }
 
+  onTimlineMounted () {
+    this.setState({isTimelineReady: true})
+  }
+
+  onTimelineUnmounted () {
+    this.setState({isTimelineReady: false})
+  }
+
   renderStartupDefaultScreen () {
     return (
       <div style={{ position: 'absolute', width: '100%', height: '100%' }}>
@@ -771,6 +781,7 @@ export default class Creator extends React.Component {
                   <SideBar
                     setDashboardVisibility={this.setDashboardVisibility.bind(this)}
                     switchActiveNav={this.switchActiveNav.bind(this)}
+                    onNavigateToDashboard={this.onTimelineUnmounted}
                     activeNav={this.state.activeNav}>
                     {
                       isPreviewMode(this.state.interactionMode) && (
@@ -822,6 +833,7 @@ export default class Creator extends React.Component {
                       authToken={this.state.authToken}
                       username={this.state.username}
                       password={this.state.password}
+                      isTimelineReady={this.state.isTimelineReady}
                       onPreviewModeToggled={(interactionMode) => { this.setState({interactionMode}) }} />
                     {(this.state.libraryItemDragging)
                       ? <div style={{ width: '100%', height: '100%', backgroundColor: 'white', opacity: 0.01, position: 'absolute', top: 0, left: 0 }} />
@@ -837,7 +849,8 @@ export default class Creator extends React.Component {
                 username={this.state.username}
                 organizationName={this.state.organizationName}
                 createNotice={this.createNotice}
-                removeNotice={this.removeNotice} />
+                removeNotice={this.removeNotice}
+                onReady={this.onTimlineMounted} />
             </SplitPane>
           </div>
         </div>

--- a/packages/haiku-creator/src/react/components/SideBar.js
+++ b/packages/haiku-creator/src/react/components/SideBar.js
@@ -93,12 +93,17 @@ class SideBar extends React.Component {
     window.removeEventListener('resize', this.windowResizeHandler)
   }
 
+  goToDashboard () {
+    this.props.setDashboardVisibility(true)
+    this.props.onNavigateToDashboard()
+  }
+
   render () {
     return (
       <div style={STYLES.container} className='layout-box'>
         <div style={[STYLES.bar, {zIndex: 1, paddingLeft: this.state.isFullscreen ? 15 : 82}]} className='frame'>
           <LogoMiniSVG />
-          <button id='go-to-dashboard' key='dashboard' onClick={() => this.props.setDashboardVisibility(true)}
+          <button id='go-to-dashboard' key='dashboard' onClick={() => {this.goToDashboard()}}
             style={[
               BTN_STYLES.btnIcon, BTN_STYLES.btnIconHover, BTN_STYLES.btnText,
               {width: 'auto', position: 'absolute', right: 6}

--- a/packages/haiku-creator/src/react/components/Stage.js
+++ b/packages/haiku-creator/src/react/components/Stage.js
@@ -158,7 +158,8 @@ export default class Stage extends React.Component {
             password={this.props.password}
             receiveProjectInfo={this.props.receiveProjectInfo}
             tourClient={this.tourClient}
-            onPreviewModeToggled={this.onPreviewModeToggled.bind(this)} />
+            onPreviewModeToggled={this.onPreviewModeToggled.bind(this)}
+            isTimelineReady={this.props.isTimelineReady} />
           <div
             id='stage-mount'
             ref={(element) => { this.mount = element }}

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -509,6 +509,7 @@ class StageTitleBar extends React.Component {
           <Toggle
             onToggle={this.togglePreviewMode.bind(this)}
             style={STYLES.previewToggle}
+            disabled={!this.props.isTimelineReady}
           />
         }
 

--- a/packages/haiku-creator/src/react/components/Timeline.js
+++ b/packages/haiku-creator/src/react/components/Timeline.js
@@ -90,6 +90,7 @@ export default class Timeline extends React.Component {
 
     this.webview.addEventListener('dom-ready', () => {
       if (process.env.DEV === '1') this.webview.openDevTools()
+      if (typeof this.props.onReady === 'function') this.props.onReady()
     })
 
     while (this.mount.firstChild) this.mount.removeChild(this.mount.firstChild)
@@ -118,5 +119,6 @@ export default class Timeline extends React.Component {
 Timeline.propTypes = {
   folder: React.PropTypes.string.isRequired,
   haiku: React.PropTypes.object.isRequired,
-  envoy: React.PropTypes.object.isRequired
+  envoy: React.PropTypes.object.isRequired,
+  onReady: React.PropTypes.func
 }

--- a/packages/haiku-creator/src/react/components/Toggle.js
+++ b/packages/haiku-creator/src/react/components/Toggle.js
@@ -32,6 +32,10 @@ const STYLES = {
     fontSize: '12px',
     fontWeight: '400',
     color: Palette.ROCK
+  },
+  disabled: {
+    pointerEvents: 'none',
+    opacity: 0.5
   }
 }
 
@@ -80,8 +84,6 @@ class Toggle extends React.Component {
   }
 
   render () {
-    const activeStyles = this.state.active ? STYLES.wrapper.active : {}
-
     return (
       <Popover
         isOpen={this.state.isPopoverOpen}
@@ -94,7 +96,8 @@ class Toggle extends React.Component {
           style={[
             BTN_STYLES.btnText,
             STYLES.wrapper,
-            activeStyles,
+            this.state.active && STYLES.wrapper.active,
+            this.props.disabled && STYLES.disabled,
             this.props.style
           ]}
           onMouseEnter={this.openPopover}

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -442,7 +442,12 @@ class ActiveComponent extends BaseModel {
     })
     this.clearCaches()
     this.forceFlush()
-    this.emit((metadata.from === this.alias) ? 'update' : 'remote-update', 'setInteractionMode')
+
+    this.emit(
+      metadata.from === this.alias ? 'update' : 'remote-update',
+      'setInteractionMode',
+      {interactionMode: this._interactionMode}
+    )
 
     // FIXME: for some reason sometimes the `metadata` argument is missing
     if (typeof metadata === 'function') return metadata()

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -21,6 +21,7 @@ import Gauge from './Gauge'
 import GaugeTimeReadout from './GaugeTimeReadout'
 import TimelineRangeScrollbar from './TimelineRangeScrollbar'
 import HorzScrollShadow from './HorzScrollShadow'
+import {isPreviewMode} from '@haiku/player/lib/helpers/interactionModes'
 
 const Globals = require('./Globals') // Sorry, hack
 
@@ -147,15 +148,17 @@ class Timeline extends React.Component {
       }
     })
 
-    this.addEmitterListener(this.component, 'remote-update', (what) => {
+    this.addEmitterListener(this.component, 'remote-update', (what, data) => {
       if (what === 'setInteractionMode') {
         // If we've toggled into preview mode
-        if (this.state.isPreviewModeActive) {
+        const isPreviewModeActive = isPreviewMode(data.interactionMode)
+
+        if (!isPreviewModeActive) {
           this.playbackSkipBack()
           this.forceUpdate()
         }
 
-        this.setState({isPreviewModeActive: !this.state.isPreviewModeActive})
+        this.setState({isPreviewModeActive})
       }
     })
   }


### PR DESCRIPTION
This does two main things:

- Enables a state-based mechanism to know when the timeline
is ready and act accordingly. I think this will be useful in the
future if we add more UI elements
- Replaces a naive boolean toggle in the timeline logic with
better checking based on the current interaction mode

Asana ticket: https://app.asana.com/0/479779791675933/484205401192765