### PR TITLE
tweak: slackShout to #releases instead of #engineering-feed.

### DIFF
--- a/scripts/helpers/slackShout.js
+++ b/scripts/helpers/slackShout.js
@@ -7,7 +7,7 @@ module.exports = function shout (options, text, cb) {
     return slack.chat.postMessage({
       text: text,
       token: deploy.slack.legacy,
-      channel: 'engineering-feed',
+      channel: 'releases',
       username: 'Haiku Distro',
       icon_emoji: ':robot_face:'
     }, function (err) {


### PR DESCRIPTION
Simply changes the channel Travis announces release on from #engineering-feed to #releases. Low-friction quick change.