### PR TITLE
Fix caching of attributes in the player

### DIFF
--- a/packages/haiku-player/src/renderers/dom/assignAttributes.ts
+++ b/packages/haiku-player/src/renderers/dom/assignAttributes.ts
@@ -67,7 +67,7 @@ function setAttribute(el, key, val, cache) {
 }
 
 export default function assignAttributes(domElement, virtualElement, component, isPatchOperation) {
-  const cache = component.cache[getFlexId(virtualElement)]
+  const cache = component.cache[getFlexId(virtualElement)];
 
   if (!isPatchOperation) {
     // Remove any attributes from the previous run that aren't present this time around
@@ -80,8 +80,8 @@ export default function assignAttributes(domElement, virtualElement, component, 
           if (newValue === null || newValue === undefined || oldValue !== newValue) {
             domElement.removeAttribute(oldKey);
 
-            if(cache[oldKey]) {
-              cache[oldKey] = null
+            if (cache[oldKey]) {
+              cache[oldKey] = null;
             }
           }
         }

--- a/packages/haiku-player/src/renderers/dom/assignAttributes.ts
+++ b/packages/haiku-player/src/renderers/dom/assignAttributes.ts
@@ -67,6 +67,8 @@ function setAttribute(el, key, val, cache) {
 }
 
 export default function assignAttributes(domElement, virtualElement, component, isPatchOperation) {
+  const cache = component.cache[getFlexId(virtualElement)]
+
   if (!isPatchOperation) {
     // Remove any attributes from the previous run that aren't present this time around
     if (domElement.haiku && domElement.haiku.element) {
@@ -77,6 +79,10 @@ export default function assignAttributes(domElement, virtualElement, component, 
           // Removal of old styles is handled downstream; see assignStyle()
           if (newValue === null || newValue === undefined || oldValue !== newValue) {
             domElement.removeAttribute(oldKey);
+
+            if(cache[oldKey]) {
+              cache[oldKey] = null
+            }
           }
         }
       }
@@ -107,7 +113,7 @@ export default function assignAttributes(domElement, virtualElement, component, 
       continue;
     }
 
-    setAttribute(domElement, key, anotherNewValue, component.cache[getFlexId(virtualElement)]);
+    setAttribute(domElement, key, anotherNewValue, cache);
   }
 
   // Any 'hidden' eventHandlers we got need to be assigned now.

--- a/packages/haiku-player/src/renderers/dom/removeElement.ts
+++ b/packages/haiku-player/src/renderers/dom/removeElement.ts
@@ -2,7 +2,13 @@
  * Copyright (c) Haiku 2016-2017. All rights reserved.
  */
 
-export default function removeElement(domElement) {
+import getFlexId from './getFlexId';
+
+export default function removeElement(domElement, virtualElement, component) {
+  if (component.cache[getFlexId(virtualElement)]) {
+    component.cache[getFlexId(virtualElement)] = {};
+  }
+
   domElement.parentNode.removeChild(domElement);
   return domElement;
 }

--- a/packages/haiku-player/src/renderers/dom/renderTree.ts
+++ b/packages/haiku-player/src/renderers/dom/renderTree.ts
@@ -75,7 +75,7 @@ export default function renderTree(
     if (!virtualChild && !domChild) {
       // empty
     } else if (!virtualChild && domChild) {
-      removeElement(domChild);
+      removeElement(domChild, virtualElement, component);
     } else if (virtualChild) {
       if (!domChild) {
         const insertedElement = appendChild(null, virtualChild, domElement, virtualElement, component);


### PR DESCRIPTION
**About**

This PR is not too time consuming to review, however it needs extra effort from the reviewer to check the player demos since this could potentially break something

Asana Task: https://app.asana.com/0/479779791675933/490282277397364

**What**

For certain properties, we keep a cache to compare from in order
to render elements because most of the times it's expensive to
read those attributes from the DOM.

The problem was, the cache was not being cleared/updated when:

- The element is removed from the DOM.
- An attribute is removed from the element.

This fix adds logic to clean the cache in those scenarios