### PR TITLE
Perf: cache the return value of `getFlexId`

### DIFF
--- a/packages/haiku-player/src/renderers/dom/createTagNode.ts
+++ b/packages/haiku-player/src/renderers/dom/createTagNode.ts
@@ -16,6 +16,7 @@ export default function createTagNode(
   component,
 ) {
   const tagName = normalizeName(getTypeAsString(virtualElement));
+  const flexId = getFlexId(virtualElement);
   let newDomElement;
   if (allSvgElementNames[tagName]) {
     // SVG
@@ -30,8 +31,8 @@ export default function createTagNode(
     newDomElement.haiku = {};
   }
 
-  if (!component.cache[getFlexId(virtualElement)]) {
-    component.cache[getFlexId(virtualElement)] = {};
+  if (!component.cache[flexId]) {
+    component.cache[flexId] = {};
   }
 
   const incomingKey =

--- a/packages/haiku-player/src/renderers/dom/removeElement.ts
+++ b/packages/haiku-player/src/renderers/dom/removeElement.ts
@@ -2,11 +2,9 @@
  * Copyright (c) Haiku 2016-2017. All rights reserved.
  */
 
-import getFlexId from './getFlexId';
-
-export default function removeElement(domElement, virtualElement, component) {
-  if (component.cache[getFlexId(virtualElement)]) {
-    component.cache[getFlexId(virtualElement)] = {};
+export default function removeElement(domElement, flexId, component) {
+  if (component.cache[flexId]) {
+    component.cache[flexId] = {};
   }
 
   domElement.parentNode.removeChild(domElement);

--- a/packages/haiku-player/src/renderers/dom/renderTree.ts
+++ b/packages/haiku-player/src/renderers/dom/renderTree.ts
@@ -19,6 +19,8 @@ export default function renderTree(
   isPatchOperation,
   doSkipChildren,
 ) {
+  const flexId = getFlexId(virtualElement);
+
   component._addElementToHashTable(domElement, virtualElement);
 
   if (!domElement.haiku) {
@@ -31,8 +33,8 @@ export default function renderTree(
   // Must clone so we get a correct picture of differences in attributes between runs, e.g. for detecting attribute
   // removals
   domElement.haiku.element = cloneVirtualElement(virtualElement);
-  if (!component.cache[getFlexId(virtualElement)]) {
-    component.cache[getFlexId(virtualElement)] = {};
+  if (!component.cache[flexId]) {
+    component.cache[flexId] = {};
   }
 
   if (!Array.isArray(virtualChildren)) {
@@ -75,7 +77,7 @@ export default function renderTree(
     if (!virtualChild && !domChild) {
       // empty
     } else if (!virtualChild && domChild) {
-      removeElement(domChild, virtualElement, component);
+      removeElement(domChild, flexId, component);
     } else if (virtualChild) {
       if (!domChild) {
         const insertedElement = appendChild(null, virtualChild, domElement, virtualElement, component);

--- a/packages/haiku-player/src/renderers/dom/updateElement.ts
+++ b/packages/haiku-player/src/renderers/dom/updateElement.ts
@@ -21,6 +21,8 @@ export default function updateElement(
   component,
   isPatchOperation,
 ) {
+  const flexId = getFlexId(virtualElement);
+
   // If a text node, go straight to 'replace' since we don't know the tag name
   if (isTextNode(virtualElement)) {
     replaceElementWithText(domElement, virtualElement, component);
@@ -31,8 +33,8 @@ export default function updateElement(
     domElement.haiku = {};
   }
 
-  if (!component.cache[getFlexId(virtualElement)]) {
-    component.cache[getFlexId(virtualElement)] = {};
+  if (!component.cache[flexId]) {
+    component.cache[flexId] = {};
   }
 
   if (!domElement.haiku.element) {


### PR DESCRIPTION
**About**

This should be easy to review, there's no asana ticket associated with this.

**What**

Per @stristr [comment][comment-r153825825] it is a good idea to
cache the results of this instead of calling the function multiple times.

[comment-r153825825]: https://github.com/HaikuTeam/mono/pull/100#discussion_r153825825