### PR TITLE
Run `electron.remote.app.relaunch()` on update

### DIFF
--- a/packages/haiku-creator/src/utils/autoUpdate.js
+++ b/packages/haiku-creator/src/utils/autoUpdate.js
@@ -2,7 +2,7 @@ const qs = require('qs')
 const os = require('os')
 const electron = require('electron')
 const fetch = require('node-fetch')
-const {download, unzipAndOpen} = require('./fileManipulation')
+const {download, unzip} = require('./fileManipulation')
 
 const opts = {
   server: process.env.HAIKU_AUTOUPDATE_SERVER,
@@ -27,17 +27,22 @@ module.exports = {
           return reject(Error('Missing release/autoupdate environment variables'))
         }
 
+
         const tempPath = os.tmpdir()
         const zipPath = `${tempPath}/haiku.zip`
+        // FIXME: these paths are macOS specific, it's ok for now, but
+        // we should look into a cross platform solution
         const installationPath = '/Applications'
+        const execPath = '/Applications/Haiku.app/Contents/MacOS/Haiku'
 
         console.info('[autoupdater] About to download an update:', options, url)
 
         download(url, zipPath, progressCallback)
           .then(() => {
-            return unzipAndOpen(zipPath, installationPath, 'Haiku')
+            return unzip(zipPath, installationPath)
           })
           .then(() => {
+            electron.remote.app.relaunch({execPath})
             electron.remote.app.exit()
           })
           .catch(reject)

--- a/packages/haiku-creator/src/utils/fileManipulation.js
+++ b/packages/haiku-creator/src/utils/fileManipulation.js
@@ -36,16 +36,13 @@ module.exports = {
     })
   },
 
-  unzipAndOpen (zipPath, destination, filename) {
+  unzip (zipPath, destination) {
     const saneZipPath = JSON.stringify(zipPath)
     const saneDestination = JSON.stringify(destination)
     const unzipCommand = `unzip -o -qq ${saneZipPath} -d ${saneDestination}`
-    const openCommand = filename
-      ? `open --fresh -a ${saneDestination}/${filename}.app $1`
-      : 'echo'
 
     return new Promise((resolve, reject) => {
-      exec(`${unzipCommand} && sleep 1 && ${openCommand}`, {}, err => {
+      exec(unzipCommand, {}, err => {
         err ? reject(err) : resolve(true)
       })
     })

--- a/packages/haiku-creator/test/unit/fileManipulation.test.js
+++ b/packages/haiku-creator/test/unit/fileManipulation.test.js
@@ -7,7 +7,7 @@ const FIXTURES = `${ROOT}/test/fixtures`
 const FIXTURES_TMP = `${FIXTURES}/tmp`
 
 test('fileManipulation#unzip succesfully unzips a file', async (t) => {
-  await fileManipulation.unzipAndOpen (`${FIXTURES}/hello.md.zip`, FIXTURES_TMP)
+  await fileManipulation.unzip (`${FIXTURES}/hello.md.zip`, FIXTURES_TMP)
 
   t.ok(fs.existsSync(`${FIXTURES_TMP}/hello.md`), 'uncompressed file exists')
 
@@ -15,7 +15,7 @@ test('fileManipulation#unzip succesfully unzips a file', async (t) => {
 })
 
 test('fileManipulation#unzip succesfully unzips a file', async (t) => {
-  await fileManipulation.unzipAndOpen (`${FIXTURES}/hello.md.zip`, FIXTURES_TMP)
+  await fileManipulation.unzip (`${FIXTURES}/hello.md.zip`, FIXTURES_TMP)
 
   t.ok(fs.existsSync(`${FIXTURES_TMP}/hello.md`), 'uncompressed file exists')
 


### PR DESCRIPTION
`electron.remote.app.relaunch()` was removed in bf328fa3b as part of a
refactor of the autoupdater. My rationale for removing  it and using the
shell `open` command was to cover users that have launched Haiku before
the autoupdate from a folder that is not `/Applications`, since `relaunch()`
uses by default `process.execPath`.

Turns out that I am dumb enough to not read the full documentation,
`relaunch()` accepts a `execPath` option.

**Notes**

- There are a lot of hard-coded macOs-specific paths in this functionality,
my instinct says that it's good for now, but we should probably take a look
in the future.
- We still need to call `electron.remote.app.exit()` after `relaunch()`, per
the docs:

> Note that this method does not quit the app when executed,
> you have to call app.quit or app.exit after calling app.relaunch to
> make the app restart.