### PR TITLE
Use the right data type to ping inkstone

### DIFF
--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -829,9 +829,9 @@ export default class Plumbing extends StateObject {
     return this.sendFolderSpecificClientMethodQuery(folder, Q_MASTER, 'fetchProjectInfo', [projectName, maybeUsername, maybePassword, fetchOptions], cb)
   }
 
-  checkInkstoneUpdates (options = {}, cb) {
+  checkInkstoneUpdates (query = '', cb) {
     var authToken = sdkClient.config.getAuthToken()
-    return inkstone.updates.check(authToken, options, cb)
+    return inkstone.updates.check(authToken, query, cb)
   }
 
   listAssets (folder, cb) {


### PR DESCRIPTION
I fixed the source of the problem, but there is nothing to worry about this, we are using this endpoint as a backdoor to report to mixpanel, the autoupdater still uses squirrel-express as our single source of truth.

More info on why we did this in this quip document: https://haiku.quip.com/Hdy2AnRRJQtY

