### PR TITLE
Timeline bugfixes

### DIFF
--- a/changelog/CHANGELOG.md
+++ b/changelog/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 
+## 2.3.37
+
+### Features
+
+ * Add haiku-ui-common module.
+
+### Bug Fixes
+
+ * Add space after "An update is available."
+ * Always assume controlFlow properties are mutable.
+ * Recalculate the flat mana tree every time a full flush render is performed.
+
 ## 2.3.36
 
 ### Bug Fixes

--- a/changelog/changelog.json
+++ b/changelog/changelog.json
@@ -3324,5 +3324,27 @@
       "label": "fix",
       "message": "Updates put at the wrong level were interrupting draggable"
     }
+  },
+  "2.3.37": {
+    "c066796ddf255aa9a6130d8b6bdc9f47e82dabd1": {
+      "project": "haiku-player",
+      "label": "feat",
+      "message": "Add haiku-ui-common module."
+    },
+    "a1f9efbdb03c8f79579c829af83728da8ce91955": {
+      "project": "haiku-player",
+      "label": "fix",
+      "message": "Add space after \"An update is available.\""
+    },
+    "8398f0d939a7e6d6a5b4417fa4cd1c94060d5840": {
+      "project": "haiku-player",
+      "label": "fix",
+      "message": "Always assume controlFlow properties are mutable."
+    },
+    "59a2876c1c2816bb99e82c09bbd9efeffb2183ff": {
+      "project": "haiku-player",
+      "label": "fix",
+      "message": "Recalculate the flat mana tree every time a full flush render is performed."
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haiku/player",
-  "version": "2.3.35",
+  "version": "2.3.36",
   "description": "Haiku Player is a JavaScript library for building user interfaces",
   "homepage": "https://haiku.ai",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "haiku-mono",
   "private": true,
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "Haiku monorepo",
   "main": "index.js",
   "author": "Matthew Trost <matthew@trost.co>",

--- a/packages/haiku-bytecode/package.json
+++ b/packages/haiku-bytecode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku-bytecode",
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "Bytecode utilities",
   "main": "index.js",
   "scripts": {

--- a/packages/haiku-bytecode/src/actions/deleteKeyframe.js
+++ b/packages/haiku-bytecode/src/actions/deleteKeyframe.js
@@ -30,14 +30,13 @@ module.exports = function deleteKeyframe (bytecode, componentId, timelineName, p
   }
 
   var prev = list[curr.index - 1]
+  var next = list[curr.index + 1]
 
   // First delete our keyframe
   delete property[keyframeMs]
 
-  // Remove the curve from the previous keyframe since it has nothing to attach to now.
-  // In case of a middle keyframe (between two transitions) assume the user will create a new
-  // transition manually in this case
-  if (prev) {
+  // Remove the curve from the previous keyframe if it has no subsequent keyframe to attach to
+  if (prev && !next) {
     property[prev.start] = {}
     property[prev.start].value = prev.value
     if (prev.edited) property[prev.start].edited = true

--- a/packages/haiku-cli/package.json
+++ b/packages/haiku-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haiku/cli",
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "Haiku CLI",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/haiku-common/package.json
+++ b/packages/haiku-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku-common",
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "Common library for Haiku.",
   "main": "lib/index.js",
   "directories": {

--- a/packages/haiku-creator/package.json
+++ b/packages/haiku-creator/package.json
@@ -2,7 +2,7 @@
   "name": "haiku-creator-electron",
   "productName": "Haiku",
   "private": true,
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "Haiku Creator UI",
   "main": "index.js",
   "author": "Matthew Trost <matthew@haiku.ai>",

--- a/packages/haiku-creator/src/react/components/SideBar.js
+++ b/packages/haiku-creator/src/react/components/SideBar.js
@@ -103,7 +103,7 @@ class SideBar extends React.Component {
       <div style={STYLES.container} className='layout-box'>
         <div style={[STYLES.bar, {zIndex: 1, paddingLeft: this.state.isFullscreen ? 15 : 82}]} className='frame'>
           <LogoMiniSVG />
-          <button id='go-to-dashboard' key='dashboard' onClick={() => {this.goToDashboard()}}
+          <button id='go-to-dashboard' key='dashboard' onClick={() => { this.goToDashboard() }}
             style={[
               BTN_STYLES.btnIcon, BTN_STYLES.btnIconHover, BTN_STYLES.btnText,
               {width: 'auto', position: 'absolute', right: 6}

--- a/packages/haiku-creator/src/react/components/Stage.js
+++ b/packages/haiku-creator/src/react/components/Stage.js
@@ -102,7 +102,9 @@ export default class Stage extends React.Component {
     })
 
     this.webview.addEventListener('dom-ready', () => {
-      if (process.env.DEV === '1') this.webview.openDevTools()
+      if (process.env.DEV === '1') {
+        this.webview.openDevTools()
+      }
     })
 
     while (this.mount.firstChild) this.mount.removeChild(this.mount.firstChild)

--- a/packages/haiku-creator/src/react/components/Timeline.js
+++ b/packages/haiku-creator/src/react/components/Timeline.js
@@ -89,7 +89,9 @@ export default class Timeline extends React.Component {
     })
 
     this.webview.addEventListener('dom-ready', () => {
-      if (process.env.DEV === '1') this.webview.openDevTools()
+      if (process.env.DEV === '1') {
+        this.webview.openDevTools()
+      }
       if (typeof this.props.onReady === 'function') this.props.onReady()
     })
 

--- a/packages/haiku-formats/package.json
+++ b/packages/haiku-formats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku-formats",
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "Formatting-related utilities for Haiku.",
   "main": "lib/index.js",
   "directories": {

--- a/packages/haiku-glass/package.json
+++ b/packages/haiku-glass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku-glass",
-  "version": "2.3.36",
+  "version": "2.3.37",
   "private": true,
   "authors": [
     "Matthew Trost <matthew@haiku.ai>",

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -141,7 +141,7 @@ export class Glass extends React.Component {
     window.addEventListener('drop', linkExternalAssetsOnDrop.bind(this), false)
   }
 
-  handleRequestElementCoordinates({selector, webview}) {
+  handleRequestElementCoordinates ({selector, webview}) {
     requestElementCoordinates({
       currentWebview: 'glass',
       requestedWebview: webview,
@@ -242,7 +242,6 @@ export class Glass extends React.Component {
         // If we've toggled into preview mode, we have to force react to update the on-stage styles
         this.forceUpdate()
         this._component.getCurrentTimeline().togglePreviewPlayback(this.isPreviewMode())
-
       }
 
       // Not sure if we really need to call this, since this is called in a raf loop

--- a/packages/haiku-player/package.json
+++ b/packages/haiku-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haiku/player",
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "Haiku Player is a JavaScript library for building user interfaces",
   "homepage": "https://haiku.ai",
   "directories": {

--- a/packages/haiku-player/test/unit/layout.parseCssTransformString.test.js
+++ b/packages/haiku-player/test/unit/layout.parseCssTransformString.test.js
@@ -68,6 +68,7 @@ test('layout.parseCssTransformString', function (t) {
         "scale.z": 1
       }
     ],
+<<<<<<< HEAD
     [
       'translate(3.14)',
       {
@@ -81,6 +82,8 @@ test('layout.parseCssTransformString', function (t) {
         "scale.y": 2.72,
       }
     ],
+=======
+>>>>>>> 012d1149bd0b482eedc93f9d3bbbb2501f2a592d
   ]
 
   t.plan(data.length)

--- a/packages/haiku-player/test/unit/layout.parseCssTransformString.test.js
+++ b/packages/haiku-player/test/unit/layout.parseCssTransformString.test.js
@@ -68,7 +68,6 @@ test('layout.parseCssTransformString', function (t) {
         "scale.z": 1
       }
     ],
-<<<<<<< HEAD
     [
       'translate(3.14)',
       {
@@ -82,8 +81,6 @@ test('layout.parseCssTransformString', function (t) {
         "scale.y": 2.72,
       }
     ],
-=======
->>>>>>> 012d1149bd0b482eedc93f9d3bbbb2501f2a592d
   ]
 
   t.plan(data.length)

--- a/packages/haiku-plumbing/package.json
+++ b/packages/haiku-plumbing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku-plumbing",
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "Haiku plumbing (serializer, processes, etc)",
   "authors": [
     "Zack Brown <zack@haiku.ai>",

--- a/packages/haiku-sdk-client/package.json
+++ b/packages/haiku-sdk-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haiku/sdk-client",
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "Haiku SDK for Client",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/haiku-sdk-creator/package.json
+++ b/packages/haiku-sdk-creator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku-sdk-creator",
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "SDK into Haiku",
   "main": "lib/index.js",
   "directories": {

--- a/packages/haiku-sdk-inkstone/package.json
+++ b/packages/haiku-sdk-inkstone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haiku/sdk-inkstone",
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "Haiku SDK for Inkstone",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/haiku-serialization/package.json
+++ b/packages/haiku-serialization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku-serialization",
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "Serialization utilities",
   "main": "index.js",
   "scripts": {

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -1337,6 +1337,11 @@ class ActiveComponent extends BaseModel {
       }
     }
 
+    const rowsNeedingZerothKeyframe = Row.fetchAndUnsetRowsToEnsureZerothKeyframe()
+    rowsNeedingZerothKeyframe.forEach((row) => {
+      row.ensureZerothKeyframe(this.metadata)
+    })
+
     return this
   }
 

--- a/packages/haiku-serialization/src/bll/BaseModel.js
+++ b/packages/haiku-serialization/src/bll/BaseModel.js
@@ -247,6 +247,10 @@ function createCollection (klass, collection, opts) {
     })
   }
 
+  klass.collection = () => {
+    return collection
+  }
+
   klass.count = () => {
     return klass.all().length
   }

--- a/packages/haiku-serialization/src/bll/BaseModel.js
+++ b/packages/haiku-serialization/src/bll/BaseModel.js
@@ -162,7 +162,6 @@ class BaseModel extends EventEmitter {
   sameAs (other) {
     if (!other) return false
     if (this === other) return true
-    if (this.getPrimaryKey() === other.getPrimaryKey()) return true
     return false
   }
 

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -185,6 +185,10 @@ class Keyframe extends BaseModel {
       }
     }
 
+    // I'm adding the zeroth keyframe only after the keyframe move action is complete,
+    // otherwise the cleared cache in React will result in the dragging action to be stopped
+    this.row._needsToEnsureZerothKeyframe = true
+
     return this
   }
 

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -289,11 +289,11 @@ class Keyframe extends BaseModel {
   }
 
   getUniqueKey () {
-    return `${this.row.getPropertyNameString()}-${this.getIndex()}-${this.getMs()}`
+    return `${this.getUniqueKeyWithoutTimeIncluded()}-${this.getMs()}`
   }
 
   getUniqueKeyWithoutTimeIncluded () {
-    return `${this.row.getPropertyNameString()}-${this.getIndex()}`
+    return `${this.row.getUniqueKey()}-${this.getIndex()}`
   }
 
   isWithinCollapsedRow () {

--- a/packages/haiku-serialization/src/bll/Row.js
+++ b/packages/haiku-serialization/src/bll/Row.js
@@ -810,4 +810,13 @@ Row.first = function first () {
   return Row.find({ place: 0 })
 }
 
+Row.fetchAndUnsetRowsToEnsureZerothKeyframe = () => {
+  const rows = []
+  Row.where({ _needsToEnsureZerothKeyframe: true }).forEach((row) => {
+    row._needsToEnsureZerothKeyframe = false
+    rows.push(row)
+  })
+  return rows
+}
+
 module.exports = Row

--- a/packages/haiku-serialization/src/bll/Row.js
+++ b/packages/haiku-serialization/src/bll/Row.js
@@ -514,6 +514,15 @@ class Row extends BaseModel {
     return this.property && this.property.name
   }
 
+  getFallbackValue () {
+    if (this.property) {
+      if (this.property.fallback !== undefined) {
+        return this.property.fallback
+      }
+    }
+    return 1 // Possibly safer and more obvious than 0?
+  }
+
   isClusterActivated (item) {
     return false // TODO
   }

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -264,8 +264,8 @@ class Timeline extends BaseModel {
 
     if (isPreviewMode) {
       timelineInstance.unfreeze()
-       timelineInstance.gotoAndPlay(0)
-       timelineInstance.options.loop = true
+      timelineInstance.gotoAndPlay(0)
+      timelineInstance.options.loop = true
     } else {
       timelineInstance.freeze()
       timelineInstance.seek(0)

--- a/packages/haiku-serialization/src/svg/getSvgOptimizer.js
+++ b/packages/haiku-serialization/src/svg/getSvgOptimizer.js
@@ -19,7 +19,7 @@ module.exports = () => {
       'removeUselessStrokeAndFill',
       'removeNonInheritableGroupAttrs',
       'moveElemsAttrsToGroup',
-      'collapseGroups',
-    ],
+      'collapseGroups'
+    ]
   })
 }

--- a/packages/haiku-serialization/src/utils/requestElementCoordinates.js
+++ b/packages/haiku-serialization/src/utils/requestElementCoordinates.js
@@ -1,4 +1,4 @@
-module.exports = function requestElementCoordinates(
+module.exports = function requestElementCoordinates (
   {currentWebview, requestedWebview, selector, isMockMode, tourClient},
   maxNumberOfTries = 15,
   currentNumberOfTries = 0

--- a/packages/haiku-state-object/package.json
+++ b/packages/haiku-state-object/package.json
@@ -1,7 +1,7 @@
 {
   "name": "haiku-state-object",
   "private": true,
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "Minimal wrapper for managing state",
   "main": "index.js",
   "author": "Matthew Trost <matthew@haiku.ai>",

--- a/packages/haiku-testing/package.json
+++ b/packages/haiku-testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku-testing",
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "Testing utilities for Haiku.",
   "main": "lib/index.js",
   "directories": {

--- a/packages/haiku-timeline/package.json
+++ b/packages/haiku-timeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku-timeline",
-  "version": "2.3.36",
+  "version": "2.3.37",
   "private": true,
   "license": "UNLICENSED",
   "authors": [

--- a/packages/haiku-timeline/src/components/PropertyInputField.js
+++ b/packages/haiku-timeline/src/components/PropertyInputField.js
@@ -29,6 +29,10 @@ export default class PropertyInputField extends React.Component {
       this.forceUpdate()
     } else if (what === 'row-deselected') {
       this.forceUpdate()
+    } else if (what === 'keyframe-delete') {
+      this.forceUpdate()
+    } else if (what === 'keyframe-create') {
+      this.forceUpdate()
     }
   }
 

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -748,7 +748,7 @@ class Timeline extends React.Component {
           height: 'calc(100% - 45px)',
           width: '100%',
           overflowY: 'hidden',
-          overflowX: 'hidden',
+          overflowX: 'hidden'
         }}>
         {
           this.state.isPreviewModeActive && (

--- a/packages/haiku-ui-common/package.json
+++ b/packages/haiku-ui-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haiku-ui-common",
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "Common UI components for Haiku projects.",
   "main": "lib/index.js",
   "directories": {

--- a/packages/haiku-websockets/package.json
+++ b/packages/haiku-websockets/package.json
@@ -1,7 +1,7 @@
 {
   "name": "haiku-websockets",
   "private": true,
-  "version": "2.3.36",
+  "version": "2.3.37",
   "description": "Websocket classes and utilities",
   "main": "index.js",
   "author": "Matthew Trost <matthew@haiku.ai>",

--- a/test/unit/layout.parseCssTransformString.test.js
+++ b/test/unit/layout.parseCssTransformString.test.js
@@ -47,7 +47,27 @@ test('layout.parseCssTransformString', function (t) {
         'scale.y': 0,
         'scale.z': 0
       }
-    ]
+    ],
+    [
+      'translate(33.000000, 92.000000) rotate(10.000000) translate(-33.000000, -92.000000) translate(-2.000000, 1.000000)',
+      {
+        "translation.x": 14.33,
+        "translation.y": -3.7,
+        "rotation.z": 0.17
+      }
+    ],
+    [
+      'translate(43.270256, 92.695192) scale(-1, 1) rotate(10.000000) translate(-43.270256, -92.695192) translate(8.270256, 1.695192)',
+      {
+        "translation.x": 61.94,
+        "translation.y": -3,
+        "rotation.y": 3.14,
+        "rotation.z": 2.97,
+        "scale.x": -1,
+        "scale.y": 1,
+        "scale.z": 1
+      }
+    ],
   ]
 
   t.plan(data.length)


### PR DESCRIPTION
WIP; not ready for merge yet.

Just a series of quick bug-fixes that shouldn't require deep code review.

- Create a keyframe 0 when keyframes are created/deleted > 0
- Create a keyframe 0 when the keyframe is dragged
- When the keyframe 0 is deleted, ensure the new keyframe 0 value is the default value
- Ensure the UI updates properly when interior keyframes are created/deleted
- Fix bug causing keyframe curves to be removed on disk but not in UI upon keyframe deletion
- Fix keyframe UI render bugs after pasting an element due to non-unique-at-location React key

UX notes:

- Instead of just "always showing a fake keyframe 0" logic, I'm creating one on-demand. This makes the UI a lot less cluttered. (There is no keyframe 0 unless there really 'needs' to be one due to a user explicitly editing a timeline row.)

- Keyframe drag logic is tricky, and so, on short notice/deadline, the best I can do to accommodate creating keyframe 0 when a keyframe previously-at-0 is dragged, is to do so once the dragging action is complete (debounce fires). The effect is that when the user drags keyframes, only once the action is are complete does keyframe 0 appear. In practice I think this is fine, maybe even the desired UI. But the side effect is that, if the playhead is sitting at time 0, this may result in an on-stage element's property changing dramatically _after_ the movement is done. (For example, since position.x's default value is 0, suppose they dragged property.x's previously-at-0 keyframe which had a value of 456.)