### PR TITLE
fix: ensure {sizing: "cover"} always applies scaling.

### DIFF
--- a/packages/haiku-player/src/HaikuComponent.ts
+++ b/packages/haiku-player/src/HaikuComponent.ts
@@ -1475,23 +1475,12 @@ function computeAndApplyPresetSizing(element, container, mode, deltas) {
 
       // We're looking for the smaller of two scales that ensures the entire box is covered.
       // The rounding is necessary to avoid precision issues, where we end up comparing e.g. 2.0000000000001 to 2
-      if (
-        ~~(scaleDiffX * elementWidth) >= containerWidth &&
-        ~~(scaleDiffX * elementHeight) >= containerHeight
-      ) {
+      if (~~(scaleDiffX * elementHeight) >= containerHeight) {
         coverScaleToUse = scaleDiffX;
-      }
-      if (
-        ~~(scaleDiffY * elementWidth) >= containerWidth &&
-        ~~(scaleDiffY * elementHeight) >= containerHeight
-      ) {
-        if (coverScaleToUse === null) {
-          coverScaleToUse = scaleDiffY;
-        } else {
-          if (scaleDiffY <= coverScaleToUse) {
-            coverScaleToUse = scaleDiffY;
-          }
-        }
+      } else if (~~(scaleDiffY * elementWidth) >= containerWidth) {
+        coverScaleToUse = scaleDiffY;
+      } else {
+        coverScaleToUse = Math.max(scaleDiffX, scaleDiffY);
       }
 
       if (element.layout.scale.x !== coverScaleToUse) {

--- a/packages/haiku-player/src/HaikuContext.ts
+++ b/packages/haiku-player/src/HaikuContext.ts
@@ -234,7 +234,7 @@ HaikuContext.prototype.performPatchRender = function performPatchRender() {
     return void (0);
   }
 
-  const container = this.config.options.sizing
+  const container = this.config.options.sizing && this.config.options.sizing !== 'normal'
     ? this._renderer.createContainer(this._mount)
     : this._renderer.getLastContainer();
   const patches = this.component.patch(container, this.config.options);


### PR DESCRIPTION
This is a fast fix for {sizing: "cover"} that seems to work and should cover edge cases where you'd get a `null` scaling factor causing items to disappear at certain zoom levels/resolutions, mostly where the animation and container width/height are extremely close to each other.

Note: I removed the `~~(scaleDiffX * elementWidth) >= containerWidth`-type conditions because `scaleDiffX` is *defined* as `containerWidth / elementWidth`. I think most edge cases I saw were from cases where this was coming out false purely due to a rounding error.