### PR TITLE
"Faster" publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ config.js
 source/*
 ~tmp
 .last-sync
-.last-compile
+packages/*/.last-compile

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Matthew Trost <matthew@trost.co>",
   "license": "UNLICENSED",
   "scripts": {
-    "go": "yarn start -- --default",
+    "go": "yarn start default",
     "setup": "node ./scripts/setup.js",
     "changelog": "node ./scripts/changelog.js",
     "start": "node ./scripts/start.js",

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -298,9 +298,8 @@ class StageTitleBar extends React.Component {
     if (this.state.snapshotSaveError) return void (0)
     if (this.state.isSnapshotSaveInProgress) return void (0)
     if (this.state.snapshotMergeConflicts) return void (0)
-    if (this.state.showSharePopover) return void (0)
 
-    this.setState({showSharePopover: !this.state.showSharePopover})
+    this.setState({showSharePopover: true})
 
     if (this.props.tourClient) this.props.tourClient.next()
 
@@ -319,13 +318,7 @@ class StageTitleBar extends React.Component {
           console.error('unknown problem fetching project')
         }
 
-        // We might only care about this if it comes up during a save... #FIXME ??
-        if (projectInfoFetchError.message === 'Timed out waiting for project share info') {
-          // ?
-          return void (0) // Gotta return here - don't want to fall through as though we actually got projectInfo below
-        } else {
-          return this.setState({ projectInfoFetchError })
-        }
+        return this.setState({ projectInfoFetchError })
       }
 
       this.setState({ projectInfo })
@@ -358,19 +351,11 @@ class StageTitleBar extends React.Component {
     return this.requestSaveProject((snapshotSaveError, snapshotData) => {
       if (snapshotSaveError) {
         console.error(snapshotSaveError)
-        if (snapshotSaveError.message === 'Timed out waiting for project share info') {
-          this.props.createNotice({
-            type: 'warning',
-            title: 'Hmm...',
-            message: 'Publishing your project seems to be taking a long time. 😢 Please try again in a few moments. If you see this message again, contact Haiku for support.'
-          })
-        } else {
-          this.props.createNotice({
-            type: 'danger',
-            title: 'Oh no!',
-            message: 'We were unable to publish your project. 😢 Please try again in a few moments. If you still see this error, contact Haiku for support.'
-          })
-        }
+        this.props.createNotice({
+          type: 'danger',
+          title: 'Oh no!',
+          message: 'We were unable to publish your project. 😢 Please try again in a few moments. If you still see this error, contact Haiku for support.'
+        })
         return this.setState({ isSnapshotSaveInProgress: false, snapshotSaveResolutionStrategyName: 'normal', snapshotSaveError }, () => {
           return setTimeout(() => this.setState({ snapshotSaveError: null }), 2000)
         })

--- a/packages/haiku-glass/src/electron.js
+++ b/packages/haiku-glass/src/electron.js
@@ -17,7 +17,7 @@ const params = {
   plumbing: process.env.HAIKU_PLUMBING_URL
 }
 
-if (process.env.MOCK_ENVOY === '1') {
+if (process.env.MOCK_ENVOY) {
   params.envoy = { mock: true }
 }
 

--- a/packages/haiku-timeline/src/electron.js
+++ b/packages/haiku-timeline/src/electron.js
@@ -21,7 +21,7 @@ var params = {
   plumbing: process.env.HAIKU_PLUMBING_URL
 }
 
-if (process.env.MOCK_ENVOY === '1') {
+if (process.env.MOCK_ENVOY) {
   params.envoy = { mock: true }
 }
 

--- a/scripts/compile-all.js
+++ b/scripts/compile-all.js
@@ -1,17 +1,40 @@
-var cp = require('child_process')
-var allPackages = require('./helpers/allPackages')()
+const async = require('async')
+const cp = require('child_process')
+const fs = require('fs')
+const path = require('path')
+
+const allPackages = require('./helpers/allPackages')()
+const log = require('./helpers/log')
 
 if (!process.env.NODE_ENV) {
   // babel-cli requires this to be set for reasons I don't know
   process.env.NODE_ENV = 'development'
 }
 
-allPackages.forEach((pack) => {
-  if (pack.pkg && pack.pkg.scripts) {
-    if (pack.pkg.scripts.compile) {
-      cp.execSync('yarn run compile', { cwd: pack.abspath, stdio: 'inherit' })
-    } else if (pack.pkg.scripts.transpile) {
-      cp.execSync('yarn run transpile', { cwd: pack.abspath, stdio: 'inherit' })
+async.each(allPackages, (pack, done) => {
+  if (pack.pkg && pack.pkg.scripts && pack.pkg.scripts.compile) {
+    const lastCompileFilename = path.join(pack.abspath, '.last-compile')
+    let timeFilter = ''
+    if (fs.existsSync(lastCompileFilename)) {
+      const lastCompile = require(lastCompileFilename)
+      if (lastCompile.hasOwnProperty('lastCompileTime')) {
+        timeFilter = `-newermt '${lastCompile.lastCompileTime}'`
+      }
     }
+    const filesChanged = Number(
+      cp.execSync(`find ${pack.abspath}/src -type f ${timeFilter} | wc -l | tr -d ' '`).toString().trim()
+    )
+
+    if (filesChanged > 0) {
+      log.warn(`Detected ${filesChanged} changed file(s) in ${pack.shortname}. Compiling....`)
+      cp.execSync('yarn run compile', { cwd: pack.abspath, stdio: 'inherit' })
+    } else {
+      log.log(`No changes in ${pack.shortname} since last compile. Skipping....`)
+    }
+
+    const lastCompileTime = cp.execSync('date').toString().trim()
+    fs.writeFile(lastCompileFilename, `module.exports = ${JSON.stringify({lastCompileTime})};`, done)
+  } else {
+    done()
   }
 })


### PR DESCRIPTION
Reviewer(s) should ideally run this locally against a local copy of the API changes in [Inkstone #8](https://github.com/HaikuTeam/inkstone/pull/8), but at the very least a very thorough read will be needed.

I had to restart mono so many times that I decided to cherry-pick my (technically still WIP but working) `yarn start` speed-up into here. I'll revert it before merging this if it's not done and everything else is good to go.

This PR is focused on the `saveProject` cluster of functionality, and strips out all the "wait for share link" functionality in favor of shimming in a new, auth-required "create snapshot for project and sha" call as soon as everything has been committed. Because both async call series involved (the one in `MasterGitProject` and the one in `Master`) were looking for the "share info" previously returned at the end of waiting, I opted to leave that basic functionality in place and defer the part where we actually push to a silent and unmonitored process. The idea is that literally every part of waiting, including finding out if publishing worked, will now happen on the share page instead of inside the app—and in the parlance of [Inkstone #8](https://github.com/HaikuTeam/inkstone/pull/8), a Snapshot that was updated five minutes ago but isn't "locked" probably broke on local push.

Also, please note that there is a breaking change in `@haiku/sdk-inkstone` in the *removal* of `snapshot.awaitSnapshotLink`, now called `snapshot.getSnapshotLink`. I tried to leave the API as stable as possible other than that (e.g. it basically does the same thing, except without "awaiting").