### PR TITLE
fix: Ensure correct first rendering on Dashboard v2 thumbnails.

### DIFF
--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -9,6 +9,7 @@ import { FadingCircle } from 'better-react-spinkit'
 import Palette from './Palette'
 import Toast from './notifications/Toast'
 import ProjectLoader from './ProjectLoader'
+import ProjectPreview from './ProjectPreview'
 import { ShareSVG, StackMenuSVG, UserIconSVG, LogOutSVG, LogoMicroSVG } from './Icons'
 import { DASH_STYLES } from '../styles/dashShared'
 import { BTN_STYLES } from '../styles/btnShared'
@@ -172,10 +173,7 @@ class ProjectBrowser extends React.Component {
         {this.state.projectsList.map((projectObject, index) => {
           const project = this.state.projectsList[index]
           const projectPath = path.join(HOMEDIR_PATH, 'projects', this.props.organizationName, project.projectName)
-          const thumbnail = projectPath + '/preview.html'
-          const hasThumb = fs.existsSync(thumbnail)
-          const standalone = projectPath + '/index.standalone.js'
-          const hasStandalone = fs.existsSync(standalone)
+          const bytecodePath = path.join(projectPath, 'code', 'main', 'code.js')
           if (!fs.existsSync(projectPath) && !project.successfulSessionAdd) {
             return false
           }
@@ -189,18 +187,18 @@ class ProjectBrowser extends React.Component {
                 projectsList[index].isMenuActive = false
                 this.setState({ projectsList })
               }}>
-              <div id='thumbnail'
+              <div
                 style={[
                   DASH_STYLES.thumb,
                   (project.isMenuActive ||
                   project.isHovered
                   ) && DASH_STYLES.blurred
                 ]}>
-                {(hasThumb && hasStandalone) &&
-                  <iframe src={thumbnail} scrolling="no" />
+                {fs.existsSync(bytecodePath) &&
+                  <ProjectPreview bytecodePath={bytecodePath} />
                 }
               </div>
-              <div id='scrim'
+              <div
                 style={[
                   DASH_STYLES.scrim,
                   (project.isMenuActive ||

--- a/packages/haiku-creator/src/react/components/ProjectPreview.js
+++ b/packages/haiku-creator/src/react/components/ProjectPreview.js
@@ -11,6 +11,9 @@ class ProjectPreview extends React.Component {
     this.bytecode = null
     this.mount = null
     try {
+      if (require.cache.hasOwnProperty(props.bytecodePath)) {
+        delete require.cache[props.bytecodePath]
+      }
       this.bytecode = require(props.bytecodePath)
     } catch (e) {
       // noop. Probably caught a broken project that didn't finish npm install or init correctly.

--- a/packages/haiku-creator/src/react/components/ProjectPreview.js
+++ b/packages/haiku-creator/src/react/components/ProjectPreview.js
@@ -8,18 +8,29 @@ class ProjectPreview extends React.Component {
 
   constructor(props) {
     super(props)
-    this.bytecode = require(props.bytecodePath)
+    this.bytecode = null
     this.mount = null
+    try {
+      this.bytecode = require(props.bytecodePath)
+    } catch (e) {
+      // noop. Probably caught a broken project that didn't finish npm install or init correctly.
+    }
   }
 
   componentDidMount() {
-    HaikuDOMAdapter(this.bytecode)(
-      this.mount,
-      {
-        sizing: 'cover',
-        loop: true
+    if (this.bytecode && this.mount) {
+      try {
+        HaikuDOMAdapter(this.bytecode)(
+          this.mount,
+          {
+            sizing: 'cover',
+            loop: true
+          }
+        )
+      } catch (e) {
+        // noop. Probably caught a backward-incompatible change that doesn't work with the current version of Player.
       }
-    )
+    }
   }
 
   render() {

--- a/packages/haiku-creator/src/react/components/ProjectPreview.js
+++ b/packages/haiku-creator/src/react/components/ProjectPreview.js
@@ -1,0 +1,35 @@
+import React, { PropTypes } from 'react'
+import HaikuDOMAdapter from '@haiku/player/dom'
+
+class ProjectPreview extends React.Component {
+  static propTypes = {
+    bytecodePath: PropTypes.string.isRequired
+  }
+
+  constructor(props) {
+    super(props)
+    this.bytecode = require(props.bytecodePath)
+    this.mount = null
+  }
+
+  componentDidMount() {
+    HaikuDOMAdapter(this.bytecode)(
+      this.mount,
+      {
+        sizing: 'cover',
+        loop: true
+      }
+    )
+  }
+
+  render() {
+    return (
+      <div
+        style={{width: '100%', height: 190, margin: '0 auto'}}
+        ref={(mount) => this.mount = mount}
+     />
+    )
+  }
+}
+
+export default ProjectPreview

--- a/packages/haiku-creator/src/react/styles/dashShared.js
+++ b/packages/haiku-creator/src/react/styles/dashShared.js
@@ -97,7 +97,9 @@ export const DASH_STYLES = {
     borderTopLeftRadius: 5,
     borderTopRightRadius: 5,
     transform: 'translate3d(0,0,0)',
-    transition: 'transform 140ms ease'
+    transition: 'transform 140ms ease',
+    margin: 0,
+    width: '100%'
   },
   blurred: {
     filter: 'blur(13px)',

--- a/packages/haiku-plumbing/src/ProjectFolder.js
+++ b/packages/haiku-plumbing/src/ProjectFolder.js
@@ -459,7 +459,7 @@ export function buildProjectContent (_ignoredLegacyArg, projectPath, projectName
           <title>${projectNameSafe} | Preview | Haiku</title>
           <style>
             .container { margin: 0 auto; width: 100%; }
-            #mount { width: 100%; height: 190px; margin: 0 auto; }
+            #mount { width: 100%; margin: 0 auto; }
             body { margin: 0; }
           </style>
         </head>
@@ -470,7 +470,7 @@ export function buildProjectContent (_ignoredLegacyArg, projectPath, projectName
           <script src="./index.standalone.js"></script>
           <script>
             ${standaloneName}(document.getElementById('mount'), {
-              sizing: 'cover',
+              sizing: 'contain',
               loop: true
             })
           </script>


### PR DESCRIPTION
Tiny fix to load the Dashboard v2 previews directly from bytecode instead of iframe'ing in preview.html.

Three main advantages:
 - Existing projects benefit from the performance optimizations in Player we recently introduced.
 - Existing projects have `sizing: 'cover'`.
 - Only one global Haiku animation frame, so probably a much lower overall footprint regardless of perf optimizations.