### PR TITLE
tweak: Put dashboard previews in edit mode, to suppress possible eventHandler and summonable weirdness.

### DIFF
--- a/packages/haiku-creator/src/react/components/ProjectPreview.js
+++ b/packages/haiku-creator/src/react/components/ProjectPreview.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react'
 import HaikuDOMAdapter from '@haiku/player/dom'
+import {InteractionMode} from '@haiku/player/lib/helpers/interactionModes'
 
 class ProjectPreview extends React.Component {
   static propTypes = {
@@ -27,7 +28,8 @@ class ProjectPreview extends React.Component {
           this.mount,
           {
             sizing: 'cover',
-            loop: true
+            loop: true,
+            interactionMode: InteractionMode.EDIT
           }
         )
       } catch (e) {


### PR DESCRIPTION
API already provides this option and edit mode already has been tested, so a cursory review is fine.