### PR TITLE
fix: Hack into Node's module loader to bypass require() in dash thumbs.

### DIFF
--- a/packages/haiku-creator/src/react/components/ProjectPreview.js
+++ b/packages/haiku-creator/src/react/components/ProjectPreview.js
@@ -1,19 +1,46 @@
+import fs from 'fs'
+import Module from 'module'
 import React, { PropTypes } from 'react'
+
 import HaikuDOMAdapter from '@haiku/player/dom'
 import {InteractionMode} from '@haiku/player/lib/helpers/interactionModes'
+
+const renderMissingLocalProjectMessage = (projectName) => {
+  switch (projectName) {
+    case 'CheckTutorial':
+      return (
+        <p>Click to load tutorial project</p>
+      )
+    case 'Move':
+    case 'Moto':
+      return (
+        <p>Click to load sample project</p>
+      )
+    default:
+      // TODO: Do we want to display a message or anything else if the project isn't
+      // already present locally?
+      return <p />
+  }
+}
 
 class ProjectPreview extends React.Component {
   constructor (props) {
     super(props)
     this.bytecode = null
     this.mount = null
+    // TODO: Try to get the bytecode from CDN or eager clone if not yet available.
+    this.hasBytecode = fs.existsSync(props.bytecodePath)
+    if (!this.hasBytecode) {
+      return
+    }
+
     try {
-      if (require.cache.hasOwnProperty(props.bytecodePath)) {
-        delete require.cache[props.bytecodePath]
-      }
-      this.bytecode = require(props.bytecodePath)
+      const bytecode = new Module('', module.parent)
+      bytecode.paths = Module._nodeModulePaths(global.process.cwd())
+      bytecode._compile(fs.readFileSync(props.bytecodePath).toString(), '')
+      this.bytecode = bytecode.exports
     } catch (e) {
-      // noop. Probably caught a broken project that didn't finish npm install or init correctly.
+      // noop. Probably caught a project incompatible with bleeding edge player.
     }
   }
 
@@ -35,6 +62,20 @@ class ProjectPreview extends React.Component {
   }
 
   render () {
+    if (!this.hasBytecode) {
+      return (
+        <div
+          style={{
+            margin: '85px auto 0',
+            width: '100%',
+            textAlign: 'center'
+          }}
+        >
+          {renderMissingLocalProjectMessage(this.props.projectName)}
+        </div>
+      )
+    }
+
     return (
       <div
         style={{width: '100%', height: 190, margin: '0 auto'}}

--- a/packages/haiku-creator/src/react/components/ProjectThumbnail.js
+++ b/packages/haiku-creator/src/react/components/ProjectThumbnail.js
@@ -1,6 +1,5 @@
 import { shell } from 'electron'
 import path from 'path'
-import fs from 'fs'
 import Radium from 'radium'
 import React from 'react'
 import Palette from './Palette'
@@ -8,29 +7,10 @@ import ProjectPreview from './ProjectPreview'
 import { StackMenuSVG } from './Icons'
 import { DASH_STYLES } from '../styles/dashShared'
 
-const renderMissingLocalProjectMessage = (projectName) => {
-  switch (projectName) {
-    case 'CheckTutorial':
-      return (
-        <p>Click to load tutorial project</p>
-      )
-    case 'Move':
-    case 'Moto':
-      return (
-        <p>Click to load sample project</p>
-      )
-    default:
-      // TODO: Do we want to display a message or anything else if the project isn't
-      // already present locally?
-      return <p />
-  }
-}
-
 class ProjectThumbnail extends React.Component {
   constructor (props) {
     super(props)
     this.bytecodePath = path.join(this.props.projectPath, 'code', 'main', 'code.js')
-    this.hasBytecode = fs.existsSync(this.bytecodePath)
     this.state = {
       isMenuActive: false,
       isHovered: false
@@ -55,18 +35,7 @@ class ProjectThumbnail extends React.Component {
             DASH_STYLES.thumb,
             (this.state.isMenuActive || this.state.isHovered) && DASH_STYLES.blurred
           ]}>
-          {this.hasBytecode
-            ? <ProjectPreview bytecodePath={this.bytecodePath} />
-            : <div
-              style={{
-                margin: '85px auto 0',
-                width: '100%',
-                textAlign: 'center'
-              }}
-              >
-              {renderMissingLocalProjectMessage(this.props.projectName)}
-            </div>
-          }
+          <ProjectPreview bytecodePath={this.bytecodePath} />
         </div>
         <div
           key='scrim'


### PR DESCRIPTION
Heavy on the hack but should be a quick and readable CL.

So, turns out we were still using the version of player that was `npm install`'ed in the local project folder in dashboard thumbs because we were using `require()`. (See [Project dashboard thumbnails not appearing](https://app.asana.com/0/479779791675933/497587971544080/f) for background.) ~~This is probably at the root of the spinning fans we experienced during testing, so that's fixed here too!~~*

There's a better/simpler way, and as a bonus we don't even have to mess around with the `require()` cache—just compile the module directly using the mostly undocumented and private module API!

Although this might seem scary, it really seems to be fine, and produces the intended effect.

*Actually, shouldn't mean much for perf. We were only using the project's player for (maybe) its `Haiku.inject`.