### PR TITLE
Fixtures for template projects

### DIFF
--- a/packages/haiku-creator/src/react/bytecode-fixtures/CheckTutorial.js
+++ b/packages/haiku-creator/src/react/bytecode-fixtures/CheckTutorial.js
@@ -1,0 +1,330 @@
+module.exports = {
+  metadata: {
+    uuid: 'HAIKU_SHARE_UUID',
+    type: 'haiku',
+    name: 'CheckTutorial',
+    relpath: 'code/main/code.js',
+    player: '2.3.6',
+    version: '0.0.1',
+    organization: 'Template',
+    project: 'CheckTutorial',
+    branch: 'master'
+  },
+
+  options: {},
+  states: {},
+  eventHandlers: {},
+  timelines: {
+    Default: {
+      'haiku:040e0b5bc34d': {
+        'style.WebkitTapHighlightColor': { '0': { value: 'rgba(0,0,0,0)' } },
+        'style.position': { '0': { value: 'relative' } },
+        'style.overflowX': { '0': { value: 'hidden' } },
+        'style.overflowY': { '0': { value: 'hidden' } },
+        'sizeAbsolute.x': { '0': { value: 280, edited: true } },
+        'sizeAbsolute.y': { '0': { value: 250, edited: true } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } }
+      },
+      'haiku:ece4163f0652': {
+        viewBox: { '0': { value: '0 0 113 113' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 113 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 113 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': { '0': { value: 84.5, edited: true } },
+        'translation.y': { '0': { value: 74.5, edited: true } },
+        'style.zIndex': { '0': { value: 1 } },
+        'scale.x': {
+          '0': { value: 1.5752212389380542, edited: true },
+          '333': { value: 0.3, edited: true, curve: 'easeInCubic' },
+          '967': { value: 2.4, edited: true }
+        },
+        'scale.y': {
+          '0': { value: 1.5752212389380542, edited: true },
+          '333': { value: 0.3, edited: true, curve: 'easeInCubic' },
+          '983': { value: 2.4, edited: true }
+        },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '467': { value: 0, edited: true, curve: 'linear' },
+          '583': { value: 1, edited: true },
+          '817': { value: 1, edited: true, curve: 'linear' },
+          '867': { value: 0, edited: true }
+        }
+      },
+      'haiku:6a97bc9649c0': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:e0c04a7740a9': {
+        stroke: { '0': { value: '#A9ED65' } },
+        'stroke-width': { '0': { value: '3' } },
+        cx: { '0': { value: '56.5' } },
+        cy: { '0': { value: '56.5' } },
+        r: { '0': { value: '55' } }
+      },
+      'haiku:352ac4d91592': {
+        viewBox: { '0': { value: '0 0 101 101' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 101 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 101 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': { '0': { value: 91, edited: true } },
+        'translation.y': { '0': { value: 82, edited: true } },
+        'style.zIndex': { '0': { value: 2 } },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '467': { value: 0, edited: true, curve: 'linear' },
+          '667': { value: 1, edited: true },
+          '833': { value: 1, edited: true, curve: 'linear' },
+          '950': { value: 0, edited: true }
+        },
+        'scale.x': {
+          '0': { value: 1 },
+          '450': { value: 0.5, edited: true, curve: 'easeInCubic' },
+          '983': { value: 1.8, edited: true }
+        },
+        'scale.y': {
+          '0': { value: 1 },
+          '450': { value: 0.5, edited: true, curve: 'easeInCubic' },
+          '983': { value: 1.8, edited: true }
+        },
+        'rotation.z': {
+          '0': { value: 0 },
+          '450': { value: 0, edited: true, curve: 'easeInCirc' },
+          '983': { value: 1, edited: true }
+        }
+      },
+      'haiku:121842734298': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } },
+        'stroke-linecap': { '0': { value: 'round' } },
+        'stroke-dasharray': { '0': { value: '1,14' } }
+      },
+      'haiku:063da83ae28f': {
+        stroke: { '0': { value: '#4F9008' } },
+        'stroke-width': { '0': { value: '5' } },
+        cx: { '0': { value: '50.5' } },
+        cy: { '0': { value: '50.5' } },
+        r: { '0': { value: '47.5' } }
+      },
+      'haiku:46386631b4c6': {
+        viewBox: { '0': { value: '0 0 81 71' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 81 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 71 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': { '0': { value: 99, edited: true } },
+        'translation.y': { '0': { value: 95, edited: true } },
+        'style.zIndex': { '0': { value: 3 } },
+        'scale.x': {
+          '0': {
+            value: 3.2535002608241848,
+            edited: true,
+            curve: 'easeOutBack'
+          },
+          '500': { value: 2.049382716049383, edited: true }
+        },
+        'scale.y': {
+          '0': {
+            value: 3.2535002608241848,
+            edited: true,
+            curve: 'easeOutBack'
+          },
+          '500': { value: 2.049382716049383, edited: true }
+        },
+        opacity: { '0': { value: 1, edited: true } }
+      },
+      'haiku:27c437626b60': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:f0954800074b': {
+        d: {
+          '0': {
+            value: 'M26.037877,51.7310269 L13.8011724,38.6087679 L13.8011724,38.6087679 C10.9762427,35.5794017 6.2303982,35.4136731 3.20103198,38.2386028 C0.171665758,41.0635325 0.00593721457,45.8093771 2.83086692,48.8387433 L19.1988276,66.3912321 C19.7449669,66.9768948 20.3629021,67.4555265 21.0263501,67.8262094 C21.2476626,68.0680456 21.4873805,68.2981618 21.7453333,68.5146099 L21.7453333,68.5146099 L21.7453333,68.5146099 C24.9183933,71.1771234 29.6490603,70.7632436 32.3115737,67.5901837 L32.3115737,67.5901837 L78.632421,12.3871475 C81.2949345,9.21408749 80.8810548,4.48342053 77.7079948,1.82090707 L77.7079948,1.82090707 C74.5349348,-0.841606384 69.8042678,-0.427726654 67.1417544,2.74533332 L26.037877,51.7310269 Z'
+          }
+        },
+        fill: { '0': { value: 'url(#linearGradient-1-aee1a6)' } }
+      },
+      'haiku:10f06a73c6e9': {
+        x1: { '0': { value: '50%' } },
+        y1: { '0': { value: '0%' } },
+        x2: { '0': { value: '50%' } },
+        y2: { '0': { value: '100%' } }
+      },
+      'haiku:56e0c335ae46': {
+        'stop-color': { '0': { value: '#B4EC51' } },
+        offset: { '0': { value: '0%' } }
+      },
+      'haiku:8ec8f02a54d8': {
+        'stop-color': { '0': { value: '#429321' } },
+        offset: { '0': { value: '100%' } }
+      }
+    }
+  },
+
+  template: {
+    elementName: 'div',
+    attributes: { 'haiku-title': 'CheckTutorial', 'haiku-id': '040e0b5bc34d' },
+    children: [
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/checkmark.sketch.contents/slices/ring.svg',
+          'haiku-id': 'ece4163f0652',
+          'haiku-title': 'ring'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': 'a72b94dcceb7' },
+            children: ['ring']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': 'a01896e74ef7' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '5998f53463e9' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '6a97bc9649c0' },
+            children: [
+              {
+                elementName: 'circle',
+                attributes: { id: 'ring', 'haiku-id': 'e0c04a7740a9' },
+                children: []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/checkmark.sketch.contents/slices/ring-dots.svg',
+          'haiku-id': '352ac4d91592',
+          'haiku-title': 'ring-dots'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': 'a767b31f3d62' },
+            children: ['ring-dots']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '46ea3e1b461f' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '8d969aa62e6e' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '121842734298' },
+            children: [
+              {
+                elementName: 'circle',
+                attributes: { id: 'ring-dots', 'haiku-id': '063da83ae28f' },
+                children: []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/checkmark.sketch.contents/slices/checkmark.svg',
+          'haiku-id': '46386631b4c6',
+          'haiku-title': 'checkmark'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': 'a461349b8264' },
+            children: ['checkmark']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '06797e24bf9d' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': 'ad1494846dc3' },
+            children: [
+              {
+                elementName: 'linearGradient',
+                attributes: {
+                  id: 'linearGradient-1-aee1a6',
+                  'haiku-id': '10f06a73c6e9'
+                },
+                children: [
+                  {
+                    elementName: 'stop',
+                    attributes: { 'haiku-id': '56e0c335ae46' },
+                    children: []
+                  },
+                  {
+                    elementName: 'stop',
+                    attributes: { 'haiku-id': '8ec8f02a54d8' },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '27c437626b60' },
+            children: [
+              {
+                elementName: 'path',
+                attributes: { id: 'checkmark', 'haiku-id': 'f0954800074b' },
+                children: []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/haiku-creator/src/react/bytecode-fixtures/Moto.js
+++ b/packages/haiku-creator/src/react/bytecode-fixtures/Moto.js
@@ -1,0 +1,1057 @@
+module.exports = {
+  metadata: {
+    relpath: 'bytecode.js',
+    type: 'haiku',
+    name: 'Moto',
+    uuid: 'HAIKU_SHARE_UUID',
+    version: '0.0.3',
+    organization: 'Template',
+    project: 'Moto',
+    branch: 'master'
+  },
+
+  options: {},
+  properties: [],
+  eventHandlers: [],
+  timelines: {
+    Default: {
+      'haiku:cc9a7f1a63bb': {
+        'style.WebkitTapHighlightColor': { '0': { value: 'rgba(0,0,0,0)' } },
+        'style.margin': { '0': { value: '0 auto' } },
+        'sizeAbsolute.x': {
+          '0': { value: 664, edited: true },
+          '17': { value: 664, edited: true }
+        },
+        'sizeAbsolute.y': {
+          '0': { value: 381, edited: true },
+          '17': { value: 381, edited: true }
+        },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } },
+        'style.position': { '0': { value: 'relative' } },
+        'style.overflowX': { '0': { value: 'hidden' } },
+        'style.overflowY': { '0': { value: 'hidden' } }
+      },
+      'haiku:ec10e8993f6e': {
+        'sizeAbsolute.x': { '0': { value: 664 } },
+        'sizeAbsolute.y': { '0': { value: 381 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } },
+        viewBox: { '0': { value: '0 0 664 381' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'translation.x': {
+          '0': { value: 0, edited: true },
+          '17': { value: 0, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 0, edited: true },
+          '17': { value: 0, edited: true }
+        },
+        'style.zIndex': { '0': { value: 1 } }
+      },
+      'haiku:daf9041c2c88': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:852203c86be4': {
+        fill: { '0': { value: '#DFC9F8' } },
+        x: { '0': { value: '0' } },
+        y: { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 664 } },
+        'sizeAbsolute.y': { '0': { value: 381 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } }
+      },
+      'haiku:35713d151eb1': {
+        'sizeAbsolute.x': { '0': { value: 145 } },
+        'sizeAbsolute.y': { '0': { value: 148 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } },
+        viewBox: { '0': { value: '0 0 145 148' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'translation.x': { '0': { value: 486, edited: true } },
+        'translation.y': { '0': { value: 18, edited: true } },
+        'style.zIndex': { '0': { value: 2 } },
+        'rotation.z': {
+          '0': { value: 0, curve: 'linear' },
+          '6983': { value: -5, edited: true }
+        }
+      },
+      'haiku:1c85cfe5ff2e': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:cc578fa29f11': {
+        'translation.x': { '0': { value: 3 } },
+        'translation.y': { '0': { value: 0 } },
+        'origin.x': { '0': { value: 0.5 } },
+        'origin.y': { '0': { value: 0.5 } },
+        'align.x': { '0': { value: 0.5 } },
+        'align.y': { '0': { value: 0.5 } },
+        'mount.x': { '0': { value: 0.5 } },
+        'mount.y': { '0': { value: 0.5 } }
+      },
+      'haiku:4fbe0b5c2654': {
+        fill: { '0': { value: '#E97897' } },
+        cx: { '0': { value: '69' } },
+        cy: { '0': { value: '74' } },
+        r: { '0': { value: '36' } }
+      },
+      'haiku:a265c8f1d444': {
+        d: {
+          '0': {
+            value: 'M107.440871,41.1179674 C106.055511,42.466023 103.83964,42.435782 102.491584,41.0504221 C101.143528,39.6650622 101.173769,37.4491911 102.559129,36.1011355 L117.059129,21.991584 C118.444489,20.6435284 120.66036,20.6737695 122.008416,22.0591294 C123.356472,23.4444893 123.326231,25.6603603 121.940871,27.008416 L107.440871,41.1179674 Z M73,23.5 C73,25.4329966 71.4329966,27 69.5,27 C67.5670034,27 66,25.4329966 66,23.5 L66,3.5 C66,1.56700338 67.5670034,0 69.5,0 C71.4329966,0 73,1.56700338 73,3.5 L73,23.5 Z M119,78.1095515 C117.067003,78.1095515 115.5,76.5425481 115.5,74.6095515 C115.5,72.6765548 117.067003,71.1095515 119,71.1095515 L138.5,71.1095515 C140.432997,71.1095515 142,72.6765548 142,74.6095515 C142,76.5425481 140.432997,78.1095515 138.5,78.1095515 L119,78.1095515 Z M102.111886,112.058693 C100.698759,110.739775 100.622388,108.525013 101.941307,107.111886 C103.260225,105.698759 105.474987,105.622388 106.888114,106.941307 L121.888114,120.941307 C123.301241,122.260225 123.377612,124.474987 122.058693,125.888114 C120.739775,127.301241 118.525013,127.377612 117.111886,126.058693 L102.111886,112.058693 Z'
+          }
+        },
+        fill: { '0': { value: '#FFFFFF' } },
+        'fill-rule': { '0': { value: 'nonzero' } }
+      },
+      'haiku:97cfc8a61c7c': {
+        d: { '0': { value: 'M34.5,38.5 L19.5,24.5' } },
+        stroke: { '0': { value: '#FFFFFF' } },
+        'stroke-width': { '0': { value: '7' } },
+        'stroke-linecap': { '0': { value: 'round' } }
+      },
+      'haiku:ee8304c92e35': {
+        d: { '0': { value: 'M20.5,73.5 L0.5,73.5' } },
+        stroke: { '0': { value: '#FFFFFF' } },
+        'stroke-width': { '0': { value: '7' } },
+        'stroke-linecap': { '0': { value: 'round' } }
+      },
+      'haiku:73f76838e799': {
+        d: { '0': { value: 'M34.5,109.5 L19.5,123.5' } },
+        stroke: { '0': { value: '#FFFFFF' } },
+        'stroke-width': { '0': { value: '7' } },
+        'stroke-linecap': { '0': { value: 'round' } }
+      },
+      'haiku:99055fbf8beb': {
+        d: { '0': { value: 'M69.5,124.5 L69.5,144.5' } },
+        stroke: { '0': { value: '#FFFFFF' } },
+        'stroke-width': { '0': { value: '7' } },
+        'stroke-linecap': { '0': { value: 'round' } }
+      },
+      'haiku:5af951a2c3ce': {
+        'sizeAbsolute.x': { '0': { value: 1331 } },
+        'sizeAbsolute.y': { '0': { value: 203 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } },
+        viewBox: { '0': { value: '0 0 1331 203' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'translation.x': {
+          '0': { value: 0, edited: true },
+          '17': { value: 1, edited: true, curve: 'linear' },
+          '7000': { value: -668, edited: true }
+        },
+        'translation.y': { '0': { value: 82.5, edited: true } },
+        'style.zIndex': { '0': { value: 3 } }
+      },
+      'haiku:768e2bd21912': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:85c5ae036e16': {
+        d: {
+          '0': {
+            value: 'M665.147128,99.6241602 L665.147128,98.8483562 L692.472212,123.635077 L766.147919,63.0509165 L836.51989,98.8483562 L906.973405,77.096934 L973.672591,13.8591421 L1011.86085,48.0651044 L1074.20931,0.911285246 L1142.60684,61.9563257 L1181.62324,25.424358 L1222.6992,63.0509165 L1263.4295,43.5571187 L1330.67482,98.8483562 L1330.67482,201.84791 L665.527691,201.84791 L665.527691,202.936624 L0,202.936624 L0,99.937071 L27.3250842,124.723791 L101.000791,64.1396313 L171.372762,99.937071 L241.826277,78.1856487 L308.525463,14.9478569 L346.713719,49.1538192 L409.062187,2 L477.459709,63.0450405 L516.47611,26.5130728 L557.55207,64.1396313 L598.282369,44.6458334 L665.147128,99.6241602 Z'
+          }
+        },
+        fill: { '0': { value: '#CCA4FB' } }
+      },
+      'haiku:e0643e9fb9fb': {
+        'sizeAbsolute.x': { '0': { value: 1875 } },
+        'sizeAbsolute.y': { '0': { value: 116 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } },
+        viewBox: { '0': { value: '0 0 1875 116' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'translation.x': {
+          '0': { value: 2, edited: true, curve: 'linear' },
+          '6983': { value: -1213, edited: true }
+        },
+        'translation.y': { '0': { value: 170, edited: true } },
+        'style.zIndex': { '0': { value: 4 } }
+      },
+      'haiku:791c2b8fd46e': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:9bc6ec751da2': {
+        d: {
+          '0': {
+            value: 'M937.674818,115.468312 L1874.67482,115.468312 L1874.67482,63.9685355 L1861.85821,68.0943948 L1855.5012,46.0698156 L1847.337,72.7689936 L1836.17598,76.3618957 L1831.2916,74.936523 L1825.82931,61.4481725 L1820.6522,71.8317082 L1790.58016,63.056012 L1785.43196,43.3595779 L1779.27132,59.7558411 L1765.48452,55.7325419 L1760.03201,40.1535799 L1754.77626,52.6076336 L1749.31517,51.0139639 L1744.47223,27.9848807 L1737.87533,47.675561 L1732.37285,46.0698156 L1679.86901,55.548046 L1672.13718,36.3229167 L1665.6637,58.1124514 L1658.77977,59.355169 L1652.74011,45.5225202 L1647.18576,61.4481725 L1633.22442,63.9685355 L1601.84361,60.5303199 L1595.90117,38.5769096 L1590.24696,59.2597423 L1583.20867,58.4885965 L1577.11971,41.7271798 L1571.93213,57.2530912 L1566.25858,56.6314726 L1560.99462,32.0752723 L1555.18089,56.6314726 L1533.96111,53.0928244 L1495.50468,40.1535799 L1490.0843,15 L1484.22296,36.3576747 L1474.01381,32.0752723 L1469.43193,19.504891 L1466.19435,30.2916747 L1439.98733,21.4739284 L1433.52541,23.5280103 L1427.75162,7.45935415 L1422.13464,27.1488463 L1415.94365,29.1168057 L1411.04909,15 L1405.63444,32.3938427 L1386.18316,38.5769096 L1361.31626,31.9027502 L1357.23531,15 L1351.65911,29.310814 L1346.71888,27.9848807 L1341.81885,7.45935415 L1335.88139,25.0761475 L1322.45492,21.4725457 L1319.10912,-0.0775794995 L1313.21766,18.9933078 L1298.3392,15 L1268.74251,24.3742607 L1263.34518,9.91596286 L1257.82602,27.8318795 L1237.0349,34.41712 L1231.79841,9.91596286 L1225.73373,37.9965806 L1201.97261,45.5225202 L1198.55305,44.386254 L1195.48478,30.2916747 L1191.80862,42.1451846 L1175.8395,36.8388983 L1173.2057,23.5280103 L1169.72827,34.8082336 L1152.97686,29.2420028 L1148.37361,7.45935415 L1142.3406,28.771751 L1115.88188,37.3729605 L1109.72948,18.9933078 L1103.9239,41.2602648 L1089.12894,46.0698156 L1073.17218,43.3595779 L1067.11837,25.0761475 L1058.98813,40.9504327 L1031.74323,36.3229167 L1022.47137,39.0284 L1017.7771,15 L1011.07921,42.3525801 L996.071754,46.731682 L990.460446,32.0752723 L986.596175,49.4966106 L971.343805,53.9471786 L965.312094,40.1535799 L959.884635,57.2909092 L937,63.9685355 L937,64.2633492 L924.858214,68.1719743 L918.501202,46.1473951 L910.337001,72.8465731 L899.175979,76.4394752 L894.291595,75.0141025 L888.829306,61.525752 L883.652198,71.9092877 L853.580156,63.1335915 L848.431959,43.4371574 L842.271324,59.8334206 L828.484517,55.8101214 L823.032013,40.2311594 L817.776264,52.6852131 L812.315171,51.0915434 L807.472229,28.0624602 L800.875327,47.7531405 L795.372853,46.1473951 L742.869005,55.6256255 L735.137175,36.4004962 L728.663701,58.1900309 L721.779773,59.4327485 L715.740107,45.6000997 L710.185759,61.525752 L696.224423,64.046115 L664.843607,60.6078994 L658.901165,38.6544891 L653.246963,59.3373218 L646.208666,58.566176 L640.119711,41.8047593 L634.93213,57.3306707 L629.258576,56.7090521 L623.99462,32.1528518 L618.180885,56.7090521 L596.961105,53.1704039 L558.504683,40.2311594 L553.084299,15.0775795 L547.222964,36.4352542 L537.013812,32.1528518 L532.431928,19.5824705 L529.194349,30.3692542 L502.987334,21.5515079 L496.525409,23.6055898 L490.751623,7.53693365 L485.134642,27.2264258 L478.943649,29.1943852 L474.049089,15.0775795 L468.634437,32.4714222 L449.183162,38.6544891 L424.316265,31.9803297 L420.235309,15.0775795 L414.659106,29.3883935 L409.718882,28.0624602 L404.818854,7.53693365 L398.881386,25.153727 L385.454917,21.5501252 L382.109124,0 L376.217656,19.0708873 L361.339201,15.0775795 L331.742512,24.4518402 L326.345183,9.99354236 L320.826018,27.909459 L300.034905,34.4946995 L294.798406,9.99354236 L288.733728,38.0741601 L264.972612,45.6000997 L261.553051,44.4638335 L258.484779,30.3692542 L254.808616,42.2227641 L238.839497,36.9164778 L236.205703,23.6055898 L232.72827,34.8858131 L215.976856,29.3195823 L211.373612,7.53693365 L205.340604,28.8493305 L178.881881,37.45054 L172.729475,19.0708873 L166.9239,41.3378443 L152.128938,46.1473951 L136.17218,43.4371574 L130.118365,25.153727 L121.98813,41.0280122 L94.743232,36.4004962 L85.4713745,39.1059795 L80.7771009,15.0775795 L74.0792054,42.4301596 L59.0717544,46.8092615 L53.4604463,32.1528518 L49.5961746,49.5741901 L34.3438051,54.0247581 L28.3120945,40.2311594 L22.8846351,57.3684887 L0,64.046115 L0,115.545892 L937.674818,115.545892 L937.674818,115.468312 Z'
+          }
+        },
+        fill: { '0': { value: '#BA8EEF' } }
+      },
+      'haiku:50be8b8d8d68': {
+        'sizeAbsolute.x': { '0': { value: 71 } },
+        'sizeAbsolute.y': { '0': { value: 61 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } },
+        viewBox: { '0': { value: '0 0 71 61' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'translation.x': {
+          '0': { value: -98, edited: true, curve: 'easeOutBack' },
+          '983': { value: 157, edited: true },
+          '1433': { value: 157, edited: true, curve: 'easeInOutBack' },
+          '2533': { value: 296, edited: true },
+          '2900': { value: 296, edited: true, curve: 'easeInOutBack' },
+          '4550': { value: 535, edited: true },
+          '4567': { value: 535, edited: true, curve: 'easeOutCubic' },
+          '5833': { value: 462, edited: true, curve: 'easeInOutCubic' },
+          '7000': { value: 684, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 306.5, edited: true },
+          '33': { value: 304.5, edited: true },
+          '1533': { value: 304.5, edited: true, curve: 'easeInOutCirc' },
+          '2183': { value: 298.5, edited: true }
+        },
+        'style.zIndex': { '0': { value: 5 } },
+        'rotation.z': {
+          '0': { value: 0 },
+          '1100': {
+            value: -0.012986282920172343,
+            edited: true,
+            curve: 'easeInOutCubic'
+          },
+          '1283': {
+            value: -0.16216698249270012,
+            edited: true,
+            curve: 'easeOutBounce'
+          },
+          '1517': { value: 0.009676937583457335, edited: true },
+          '2683': {
+            value: -0.021119970034216617,
+            edited: true,
+            curve: 'easeInOutCubic'
+          },
+          '2867': {
+            value: -0.35544847744314145,
+            edited: true,
+            curve: 'easeOutBounce'
+          },
+          '3067': { value: -0.012164296566126165, edited: true }
+        }
+      },
+      'haiku:c4c209968eb1': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:b80fbb265e17': {
+        'translation.x': { '0': { value: 2 } },
+        'translation.y': { '0': { value: 0 } },
+        'origin.x': { '0': { value: 0.5 } },
+        'origin.y': { '0': { value: 0.5 } },
+        'align.x': { '0': { value: 0.5 } },
+        'align.y': { '0': { value: 0.5 } },
+        'mount.x': { '0': { value: 0.5 } },
+        'mount.y': { '0': { value: 0.5 } }
+      },
+      'haiku:9fc3f3d15a2a': {
+        stroke: { '0': { value: '#59429B' } },
+        'stroke-width': { '0': { value: '4' } },
+        fill: { '0': { value: '#FFFFFF' } },
+        cx: { '0': { value: '9' } },
+        cy: { '0': { value: '50' } },
+        r: { '0': { value: '9' } }
+      },
+      'haiku:9837d3e87f6c': {
+        stroke: { '0': { value: '#59429B' } },
+        'stroke-width': { '0': { value: '4' } },
+        fill: { '0': { value: '#FFFFFF' } },
+        cx: { '0': { value: '58' } },
+        cy: { '0': { value: '50' } },
+        r: { '0': { value: '9' } }
+      },
+      'haiku:89693021ef05': {
+        d: {
+          '0': {
+            value: 'M19.6286214,36.3727324 L3.41352075,36.5014089 C3.41352075,36.5014089 3.061071,27.8457241 7.63362116,27.8457241 C12.2061713,27.8457241 16.0189249,27.9641048 16.0189249,27.9641048 L24.850433,48.4675004 L35.9602073,48.4675004 L54.8806322,35.5570706 L51.8689241,22.6396002 L58.5601129,50.7933788'
+          }
+        },
+        stroke: { '0': { value: '#59429B' } },
+        'stroke-width': { '0': { value: '3' } },
+        'stroke-linecap': { '0': { value: 'round' } }
+      },
+      'haiku:dc1ddefa5f17': {
+        d: {
+          '0': {
+            value: 'M60.7349356,36.3758027 C60.7349356,36.3758027 64.3082232,31.0366595 59.6103627,26.4500314 C56.4387969,24.5015553 56.556144,36.3758027 56.556144,36.3758027 L60.7349356,36.3758027 Z'
+          }
+        },
+        stroke: { '0': { value: '#59429B' } },
+        'stroke-width': { '0': { value: '3' } },
+        fill: { '0': { value: '#FFFFFF' } },
+        'stroke-linecap': { '0': { value: 'round' } }
+      },
+      'haiku:30c414713ccc': {
+        d: {
+          '0': {
+            value: 'M34.9332199,35.965405 C34.9332199,35.965405 33.0627641,28.4067059 42.143556,28.2319356 C51.2243479,28.0571653 52.8679394,28.2319356 52.8679394,28.2319356'
+          }
+        },
+        stroke: { '0': { value: '#59429B' } },
+        'stroke-width': { '0': { value: '3' } },
+        'stroke-linecap': { '0': { value: 'round' } }
+      },
+      'haiku:8bafc8a19e9e': {
+        d: { '0': { value: 'M19.0854036,36.4110749 L54.6066758,36.1347184' } },
+        stroke: { '0': { value: '#59429B' } },
+        'stroke-width': { '0': { value: '3' } },
+        'stroke-linecap': { '0': { value: 'round' } }
+      },
+      'haiku:356cbc45061b': {
+        d: {
+          '0': {
+            value: 'M26.1267,14.5377037 C20.7970325,28.0774853 19.7547581,27.6047024 20.2890058,31.9585167 C20.8232535,36.312331 27.8520112,33.7894637 32.4465542,38.1084244 C37.0410971,42.4273852 43.1837858,46.4358362 43.1837858,46.4358362 L48.4273776,41.8578583 C48.4273776,41.8578583 47.3066362,38.4013516 45.245211,40.129605 C43.1837858,41.8578583 34.4204257,29.8768611 32.8703608,29.3655859 C31.320296,28.8543107 34.4361399,20.4712709 34.4361399,18.8640727 C34.4361399,17.2568744 41.8502586,23.1151984 46.8529435,24.0822022 C51.8556285,25.049206 53.5814747,23.5915694 53.5814747,23.5915694 C53.5814747,23.5915694 54.8440014,21.4445314 52.3511072,21.1975815 C49.858213,20.9506316 48.3163343,23.9547426 37.4987511,15.2373261 C35.1749975,12.7463732 36.2759295,10.035068 36.2759295,10.035068 C36.2759295,10.035068 37.372242,7.37134488 37.6232428,6.7550374 C37.8742436,6.13872992 29.7409761,7.00437862 29.7409761,7.00437862 C29.7409761,7.00437862 27.6240501,10.2683232 26.1267,14.5377037 Z'
+          }
+        },
+        fill: { '0': { value: '#BA8EEF' } }
+      },
+      'haiku:0dd1373d913a': {
+        d: {
+          '0': {
+            value: 'M39,5.5 C39,2.46243388 36.5375661,0 33.5,0 C30.4624339,0 28,2.46243388 28,5.5 C28,5.83897896 26.8049302,5.85281632 24.4877236,6.83997698 C22.5745494,7.65501447 20.9814487,8.9810681 25.1754107,8.27147963 C26.3937487,8.06534553 27.3916154,7.82311623 29.445493,7.42540577 C32.8112146,6.77367139 39,7.83741036 39,5.5 Z'
+          }
+        },
+        fill: { '0': { value: '#E97897' } }
+      },
+      'haiku:6a966ddb2cb4': {
+        'sizeAbsolute.x': { '0': { value: 79 } },
+        'sizeAbsolute.y': { '0': { value: 14 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } },
+        viewBox: { '0': { value: '0 0 79 14' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'translation.x': {
+          '0': { value: 62, edited: true, curve: 'easeInOutCubic' },
+          '1683': { value: 76, edited: true, curve: 'easeOutCubic' },
+          '4083': { value: 97, edited: true, curve: 'easeInOutCubic' },
+          '7000': { value: 62, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 75, edited: true, curve: 'easeInOutCirc' },
+          '1683': { value: 54.5, edited: true, curve: 'easeInOutCirc' },
+          '7000': { value: 75, edited: true }
+        },
+        'style.zIndex': { '0': { value: 6 } }
+      },
+      'haiku:c4d620a11658': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:15af37aae4b3': {
+        fill: { '0': { value: '#FFFFFF' } },
+        x: { '0': { value: '0' } },
+        y: { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 79 } },
+        'sizeAbsolute.y': { '0': { value: 14 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } },
+        rx: { '0': { value: '7' } }
+      },
+      'haiku:0c56a63783da': {
+        'sizeAbsolute.x': { '0': { value: 79 } },
+        'sizeAbsolute.y': { '0': { value: 14 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } },
+        viewBox: { '0': { value: '0 0 79 14' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'translation.x': {
+          '0': { value: 185, edited: true, curve: 'easeInOutCubic' },
+          '2433': { value: 210.993354645002, edited: true },
+          '2533': { value: 212, edited: true, curve: 'easeInOutCubic' },
+          '4800': { value: 218, edited: true, curve: 'easeInOutCubic' },
+          '6983': { value: 189, edited: true },
+          '7050': { value: 185, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 85, edited: true, curve: 'easeInOutCubic' },
+          '2533': { value: 62.5, edited: true, curve: 'easeInOutCubic' },
+          '4750': { value: 85.5, edited: true, curve: 'easeInOutCubic' },
+          '7050': { value: 85, edited: true }
+        },
+        'style.zIndex': { '0': { value: 7 } },
+        'scale.x': { '0': { value: 1.1772151898734171, edited: true } },
+        'scale.y': { '0': { value: 1.1428571428571428, edited: true } }
+      },
+      'haiku:011f1eec29ff': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:20b916f458e7': {
+        fill: { '0': { value: '#FFFFFF' } },
+        x: { '0': { value: '0' } },
+        y: { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 79 } },
+        'sizeAbsolute.y': { '0': { value: 14 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } },
+        rx: { '0': { value: '7' } }
+      },
+      'haiku:e33a15bfe59f': {
+        'sizeAbsolute.x': { '0': { value: 14 } },
+        'sizeAbsolute.y': { '0': { value: 14 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } },
+        viewBox: { '0': { value: '0 0 14 14' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'translation.x': {
+          '0': { value: 152.5, edited: true },
+          '1300': { value: 149, edited: true, curve: 'easeInOutCubic' },
+          '1550': { value: 80, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 344, edited: true },
+          '1300': { value: 344, edited: true, curve: 'easeOutCirc' },
+          '1550': { value: 320, edited: true }
+        },
+        'style.zIndex': { '0': { value: 8 } },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '1300': { value: 1, edited: true },
+          '1417': { value: 1, edited: true, curve: 'linear' },
+          '1550': { value: 0, edited: true }
+        },
+        'scale.x': {
+          '0': { value: 1 },
+          '1300': { value: 0.1, edited: true, curve: 'linear' },
+          '1550': { value: 1.7, edited: true }
+        },
+        'scale.y': {
+          '0': { value: 1 },
+          '1300': { value: 0.1, edited: true, curve: 'linear' },
+          '1550': { value: 1.7, edited: true }
+        }
+      },
+      'haiku:eb8a4845c4ba': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } },
+        'fill-opacity': { '0': { value: '0.669999957' } }
+      },
+      'haiku:b4f4ac642e60': {
+        fill: { '0': { value: '#FFFFFF' } },
+        cx: { '0': { value: '7' } },
+        cy: { '0': { value: '7' } },
+        r: { '0': { value: '7' } }
+      },
+      'haiku:ba90c216517a': {
+        'sizeAbsolute.x': { '0': { value: 14 } },
+        'sizeAbsolute.y': { '0': { value: 14 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } },
+        viewBox: { '0': { value: '0 0 14 14' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'translation.x': { '0': { value: 331.9375, edited: true } },
+        'translation.y': { '0': { value: 678.5703125, edited: true } },
+        'style.zIndex': { '0': { value: 9 } }
+      },
+      'haiku:38aa78c8a5b1': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } },
+        'fill-opacity': { '0': { value: '0.669999957' } }
+      },
+      'haiku:278b306c2b69': {
+        fill: { '0': { value: '#FFFFFF' } },
+        cx: { '0': { value: '7' } },
+        cy: { '0': { value: '7' } },
+        r: { '0': { value: '7' } }
+      },
+      'haiku:f0cbd1e72e50': {
+        'sizeAbsolute.x': { '0': { value: 14 } },
+        'sizeAbsolute.y': { '0': { value: 14 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } },
+        viewBox: { '0': { value: '0 0 14 14' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'translation.x': {
+          '0': { value: 100, edited: true },
+          '1383': { value: 147.5, edited: true, curve: 'easeInOutCubic' },
+          '1500': { value: 110, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 310, edited: true },
+          '1383': { value: 340, edited: true, curve: 'easeInOutCubic' },
+          '1550': { value: 323, edited: true }
+        },
+        'style.zIndex': { '0': { value: 10 } },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '1383': { value: 1, edited: true },
+          '1417': { value: 1, edited: true, curve: 'linear' },
+          '1550': { value: 0, edited: true }
+        },
+        'scale.x': {
+          '0': { value: 1 },
+          '1383': { value: 0.1, edited: true, curve: 'linear' },
+          '1550': { value: 2.7, edited: true }
+        },
+        'scale.y': {
+          '0': { value: 1 },
+          '1383': { value: 0.1, edited: true, curve: 'linear' },
+          '1550': { value: 2.7, edited: true }
+        }
+      },
+      'haiku:2eb8ffff1840': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } },
+        'fill-opacity': { '0': { value: '0.669999957' } }
+      },
+      'haiku:c9d27570d5a6': {
+        fill: { '0': { value: '#FFFFFF' } },
+        cx: { '0': { value: '7' } },
+        cy: { '0': { value: '7' } },
+        r: { '0': { value: '7' } }
+      }
+    }
+  },
+
+  template: {
+    elementName: 'div',
+    attributes: { 'haiku-title': 'bytecode', 'haiku-id': 'cc9a7f1a63bb' },
+    children: [
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/moto-mountains.sketch.contents/slices/bg.svg',
+          'haiku-id': 'ec10e8993f6e',
+          'haiku-title': 'bg'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': '7c2d8c40b8ae' },
+            children: ['bg']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '517395892f58' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '6681cc6c00b7' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': 'daf9041c2c88' },
+            children: [
+              {
+                elementName: 'rect',
+                attributes: { id: 'bg', 'haiku-id': '852203c86be4' },
+                children: []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/moto-mountains.sketch.contents/slices/sun.svg',
+          'haiku-id': '35713d151eb1',
+          'haiku-title': 'sun'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': 'e6ab3d96bea9' },
+            children: ['sun']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': 'e22de510efbf' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '06f3faf4f4e9' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '1c85cfe5ff2e' },
+            children: [
+              {
+                elementName: 'g',
+                attributes: { id: 'sun', 'haiku-id': 'cc578fa29f11' },
+                children: [
+                  {
+                    elementName: 'circle',
+                    attributes: { id: 'Oval', 'haiku-id': '4fbe0b5c2654' },
+                    children: []
+                  },
+                  {
+                    elementName: 'path',
+                    attributes: {
+                      id: 'Combined-Shape',
+                      'haiku-id': 'a265c8f1d444'
+                    },
+                    children: []
+                  },
+                  {
+                    elementName: 'path',
+                    attributes: { id: 'Line', 'haiku-id': '97cfc8a61c7c' },
+                    children: []
+                  },
+                  {
+                    elementName: 'path',
+                    attributes: { id: 'Line-Copy', 'haiku-id': 'ee8304c92e35' },
+                    children: []
+                  },
+                  {
+                    elementName: 'path',
+                    attributes: {
+                      id: 'Line-Copy-2',
+                      'haiku-id': '73f76838e799'
+                    },
+                    children: []
+                  },
+                  {
+                    elementName: 'path',
+                    attributes: {
+                      id: 'Line-Copy-3',
+                      'haiku-id': '99055fbf8beb'
+                    },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/moto-mountains.sketch.contents/slices/mountain-range.svg',
+          'haiku-id': '5af951a2c3ce',
+          'haiku-title': 'mountain-range'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': 'd9e4d53f262e' },
+            children: ['mountain-range']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': 'e0f7f2f50b2a' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '7d8bcfb4ae5b' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '768e2bd21912' },
+            children: [
+              {
+                elementName: 'path',
+                attributes: {
+                  id: 'mountain-range',
+                  'haiku-id': '85c5ae036e16'
+                },
+                children: []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/moto-mountains.sketch.contents/slices/tree-range.svg',
+          'haiku-id': 'e0643e9fb9fb',
+          'haiku-title': 'tree-range'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': '7ef163049af5' },
+            children: ['tree-range']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '9c68d2ef772b' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '93b70af0ba7c' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '791c2b8fd46e' },
+            children: [
+              {
+                elementName: 'path',
+                attributes: { id: 'tree-range', 'haiku-id': '9bc6ec751da2' },
+                children: []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/moto-mountains.sketch.contents/slices/moto.svg',
+          'haiku-id': '50be8b8d8d68',
+          'haiku-title': 'moto'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': '60810a72f807' },
+            children: ['moto']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '3f79879c812c' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': 'c83b46312d99' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': 'c4c209968eb1' },
+            children: [
+              {
+                elementName: 'g',
+                attributes: { id: 'moto', 'haiku-id': 'b80fbb265e17' },
+                children: [
+                  {
+                    elementName: 'circle',
+                    attributes: { id: 'Oval-3', 'haiku-id': '9fc3f3d15a2a' },
+                    children: []
+                  },
+                  {
+                    elementName: 'circle',
+                    attributes: {
+                      id: 'Oval-3-Copy',
+                      'haiku-id': '9837d3e87f6c'
+                    },
+                    children: []
+                  },
+                  {
+                    elementName: 'path',
+                    attributes: { id: 'Path-2', 'haiku-id': '89693021ef05' },
+                    children: []
+                  },
+                  {
+                    elementName: 'path',
+                    attributes: { id: 'Path-4', 'haiku-id': 'dc1ddefa5f17' },
+                    children: []
+                  },
+                  {
+                    elementName: 'path',
+                    attributes: { id: 'Path-5', 'haiku-id': '30c414713ccc' },
+                    children: []
+                  },
+                  {
+                    elementName: 'path',
+                    attributes: { id: 'Path-6', 'haiku-id': '8bafc8a19e9e' },
+                    children: []
+                  },
+                  {
+                    elementName: 'path',
+                    attributes: { id: 'Path-7', 'haiku-id': '356cbc45061b' },
+                    children: []
+                  },
+                  {
+                    elementName: 'path',
+                    attributes: { id: 'Oval-4', 'haiku-id': '0dd1373d913a' },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/moto-mountains.sketch.contents/slices/goodCLoud.svg',
+          'haiku-id': '6a966ddb2cb4',
+          'haiku-title': 'goodCLoud'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': '34c8fd93d17b' },
+            children: ['goodCLoud']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '5376117a1e9d' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': 'c5a666a0afff' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': 'c4d620a11658' },
+            children: [
+              {
+                elementName: 'rect',
+                attributes: { id: 'goodCLoud', 'haiku-id': '15af37aae4b3' },
+                children: []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/moto-mountains.sketch.contents/slices/goodCLoud.svg',
+          'haiku-id': '0c56a63783da',
+          'haiku-title': 'goodCLoud'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': '7873166e3baa' },
+            children: ['goodCLoud']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '56d3486a89dd' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': 'c6486f2bb6ed' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '011f1eec29ff' },
+            children: [
+              {
+                elementName: 'rect',
+                attributes: { id: 'goodCLoud', 'haiku-id': '20b916f458e7' },
+                children: []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/moto-mountains.sketch.contents/slices/smoke.svg',
+          'haiku-id': 'e33a15bfe59f',
+          'haiku-title': 'smoke'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': 'b4b855a7cd20' },
+            children: ['smoke']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': 'cde5b1b4a453' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '33bffbe0e1c8' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': 'eb8a4845c4ba' },
+            children: [
+              {
+                elementName: 'circle',
+                attributes: { id: 'smoke', 'haiku-id': 'b4f4ac642e60' },
+                children: []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/moto-mountains.sketch.contents/slices/smoke.svg',
+          'haiku-id': 'ba90c216517a',
+          'haiku-title': 'smoke'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': 'db51c57e9399' },
+            children: ['smoke']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '5a0fc80d07e3' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '8258c6317cf8' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '38aa78c8a5b1' },
+            children: [
+              {
+                elementName: 'circle',
+                attributes: { id: 'smoke', 'haiku-id': '278b306c2b69' },
+                children: []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/moto-mountains.sketch.contents/slices/smoke.svg',
+          'haiku-id': 'f0cbd1e72e50',
+          'haiku-title': 'smoke'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': '31fd6451abfa' },
+            children: ['smoke']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '73034d6b5a5a' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '70065cd947b8' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '2eb8ffff1840' },
+            children: [
+              {
+                elementName: 'circle',
+                attributes: { id: 'smoke', 'haiku-id': 'c9d27570d5a6' },
+                children: []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/haiku-creator/src/react/bytecode-fixtures/Move.js
+++ b/packages/haiku-creator/src/react/bytecode-fixtures/Move.js
@@ -1,0 +1,1191 @@
+module.exports = {
+  metadata: {
+    uuid: 'HAIKU_SHARE_UUID',
+    type: 'haiku',
+    name: 'Move',
+    relpath: 'bytecode.js',
+    version: '0.0.1',
+    organization: 'Template',
+    project: 'Move',
+    branch: 'master',
+    player: '2.0.132'
+  },
+
+  options: {},
+  properties: [],
+  eventHandlers: [],
+  timelines: {
+    Default: {
+      'haiku:91083482b04d': {
+        'style.WebkitTapHighlightColor': { '0': { value: 'rgba(0,0,0,0)' } },
+        'style.position': { '0': { value: 'relative' } },
+        'style.overflowX': { '0': { value: 'hidden' } },
+        'style.overflowY': { '0': { value: 'hidden' } },
+        'sizeAbsolute.x': { '0': { value: 550 } },
+        'sizeAbsolute.y': { '0': { value: 400 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } },
+        backgroundColor: { '0': { value: 'rgb(29, 55, 67)', edited: true } },
+        opacity: { '0': { value: 1 }, '17': { value: 1, edited: true } }
+      },
+      'haiku:5bfd10a365ed': {
+        viewBox: { '0': { value: '0 0 56 56' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 56 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 56 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': {
+          '0': { value: 554, edited: true, curve: 'linear' },
+          '750': { value: 221, edited: true, curve: 'easeInOutCubic' },
+          '883': { value: 228, edited: true },
+          '1833': { value: 228, edited: true, curve: 'easeInBack' },
+          '2250': { value: 622, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 14.5, edited: true, curve: 'easeOutBounce' },
+          '750': { value: 170, edited: true }
+        },
+        'style.zIndex': { '0': { value: 1 } },
+        'scale.x': {
+          '0': { value: 1 },
+          '250': { value: 1, edited: true, curve: 'easeOutCubic' },
+          '267': { value: 1.4, edited: true, curve: 'easeInCubic' },
+          '300': { value: 1, edited: true },
+          '517': { value: 1, edited: true, curve: 'easeOutCubic' },
+          '550': { value: 1.2, edited: true, curve: 'easeInCubic' },
+          '583': { value: 1, edited: true }
+        },
+        'scale.y': {
+          '0': { value: 1 },
+          '250': { value: 1, edited: true, curve: 'easeOutCubic' },
+          '267': { value: 0.6, edited: true, curve: 'easeInCubic' },
+          '300': { value: 1, edited: true },
+          '517': { value: 1, edited: true, curve: 'easeOutCubic' },
+          '550': { value: 0.8, edited: true, curve: 'easeInCubic' },
+          '583': { value: 1, edited: true }
+        },
+        'rotation.z': {
+          '0': { value: 0, curve: 'linear' },
+          '267': { value: -3.14, edited: true, curve: 'linear' },
+          '550': {
+            value: function () {
+              return -3.14 * 2
+            },
+            edited: true,
+            curve: 'easeOutCubic'
+          },
+          '750': { value: -9.7, edited: true, curve: 'easeInOutCubic' },
+          '883': { value: -9.42, edited: true },
+          '1833': { value: 0, edited: true, curve: 'easeInOutSine' },
+          '1983': { value: -0.1, edited: true, curve: 'easeInSine' },
+          '2083': { value: 0, edited: true }
+        }
+      },
+      'haiku:5b213ab9bbdf': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:f381da39280d': {
+        fill: { '0': { value: '#FFFFFF' } },
+        'translation.x': { '0': { value: -216 } },
+        'translation.y': { '0': { value: -156 } }
+      },
+      'haiku:23962fd3e6f7': {
+        d: {
+          '0': {
+            value: 'M264.143,163.399 C268.981024,168.291691 271.4,175.138623 271.4,183.94 C271.4,192.741377 268.981024,199.588309 264.143,204.481 C259.304976,209.373691 252.567377,211.82 243.93,211.82 C238.244638,211.82 233.338354,210.726678 229.211,208.54 C225.083646,206.353322 221.913011,203.169021 219.699,198.987 C217.484989,194.804979 216.378,189.789363 216.378,183.94 C216.378,178.090637 217.484989,173.075021 219.699,168.893 C221.913011,164.710979 225.083646,161.526678 229.211,159.34 C233.338354,157.153322 238.244638,156.06 243.93,156.06 C252.567377,156.06 259.304976,158.506309 264.143,163.399 Z M237.821,173.649 C236.536327,175.808344 235.894,179.238643 235.894,183.94 C235.894,188.641357 236.536327,192.071656 237.821,194.231 C239.105673,196.390344 241.141986,197.47 243.93,197.47 C246.718014,197.47 248.74066,196.390344 249.998,194.231 C251.25534,192.071656 251.884,188.641357 251.884,183.94 C251.884,179.238643 251.25534,175.808344 249.998,173.649 C248.74066,171.489656 246.718014,170.41 243.93,170.41 C241.141986,170.41 239.105673,171.489656 237.821,173.649 Z'
+          }
+        }
+      },
+      'haiku:676aa843ca1c': {
+        viewBox: { '0': { value: '0 0 70 55' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 70 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 55 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': {
+          '0': { value: 110, edited: true },
+          '750': { value: 147, edited: true },
+          '1883': { value: 147, edited: true, curve: 'easeInBack' },
+          '2300': { value: 615, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 162, edited: true },
+          '750': { value: 170, edited: true }
+        },
+        'style.zIndex': { '0': { value: 3 } },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '750': { value: 1, edited: true }
+        },
+        'scale.x': {
+          '0': { value: 1 },
+          '750': { value: 0.1, edited: true, curve: 'easeOutBack' },
+          '1000': { value: 1, edited: true }
+        },
+        'scale.y': {
+          '0': { value: 1 },
+          '750': { value: 0.1, edited: true, curve: 'easeOutBack' },
+          '1000': { value: 1, edited: true }
+        },
+        'rotation.z': {
+          '0': { value: 0 },
+          '1883': { value: 0, edited: true, curve: 'easeInOutSine' },
+          '2033': { value: -0.1, edited: true, curve: 'easeInSine' },
+          '2133': { value: 0, edited: true }
+        }
+      },
+      'haiku:c2569068439f': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:7567dd09dbf7': {
+        fill: { '0': { value: '#FFFFFF' } },
+        'translation.x': { '0': { value: -140 } },
+        'translation.y': { '0': { value: -156 } }
+      },
+      'haiku:cbb866760178': {
+        points: {
+          '0': {
+            value: '209.636 211 192.99 211 192.99 192.222 193.236 174.018 192.99 174.018 182.494 211 167.242 211 156.91 174.018 156.582 174.018 156.828 192.222 156.828 211 140.1 211 140.1 156.88 166.832 156.88 173.064 180.906 175.442 190.992 175.606 190.992 177.984 180.906 184.216 156.88 209.636 156.88'
+          }
+        }
+      },
+      'haiku:0802a4738af0': {
+        viewBox: { '0': { value: '0 0 60 55' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 60 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 55 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': {
+          '0': { value: 324, edited: true },
+          '750': { value: 288, edited: true },
+          '1783': { value: 288, edited: true, curve: 'easeInBack' },
+          '2200': { value: 616, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 175, edited: true },
+          '750': { value: 168, edited: true }
+        },
+        'style.zIndex': { '0': { value: 5 } },
+        'scale.x': {
+          '0': { value: 1 },
+          '883': { value: 0.1, edited: true, curve: 'easeOutBack' },
+          '1133': { value: 1, edited: true }
+        },
+        'scale.y': {
+          '0': { value: 1 },
+          '883': { value: 0.1, edited: true, curve: 'easeOutBack' },
+          '1133': { value: 1, edited: true }
+        },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '883': { value: 1, edited: true }
+        },
+        'rotation.z': {
+          '0': { value: 0 },
+          '1783': { value: 0, edited: true, curve: 'easeInOutSine' },
+          '1933': { value: -0.1, edited: true, curve: 'easeInSine' },
+          '2033': { value: 0, edited: true }
+        }
+      },
+      'haiku:129389353e52': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:f22dc401e7ab': {
+        fill: { '0': { value: '#FFFFFF' } },
+        'translation.x': { '0': { value: -273 } },
+        'translation.y': { '0': { value: -156 } }
+      },
+      'haiku:420e630b3df4': {
+        points: {
+          '0': {
+            value: '314.344 211 291.63 211 273.344 156.88 293.27 156.88 300.732 186.482 303.356 197.06 305.816 186.646 313.442 156.88 332.63 156.88'
+          }
+        }
+      },
+      'haiku:c8d0231b6708': {
+        viewBox: { '0': { value: '0 0 47 55' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 47 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 55 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': {
+          '0': { value: 409.5, edited: true },
+          '750': { value: 355.5, edited: true },
+          '1733': { value: 355.5, edited: true, curve: 'easeInBack' },
+          '2150': { value: 626.5, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 165, edited: true },
+          '750': { value: 168, edited: true }
+        },
+        'style.zIndex': { '0': { value: 6 } },
+        'scale.x': {
+          '0': { value: 1 },
+          '1017': { value: 0.1, edited: true, curve: 'easeOutBack' },
+          '1267': { value: 1, edited: true }
+        },
+        'scale.y': {
+          '0': { value: 1 },
+          '1017': { value: 0.1, edited: true, curve: 'easeOutBack' },
+          '1267': { value: 1, edited: true }
+        },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '1017': { value: 1, edited: true }
+        },
+        'rotation.z': {
+          '0': { value: 0 },
+          '1733': { value: 0, edited: true, curve: 'easeInOutSine' },
+          '1883': { value: -0.1, edited: true, curve: 'easeInSine' },
+          '1983': { value: 0, edited: true }
+        }
+      },
+      'haiku:4e5ea6d40bf2': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:092dedd1b841': {
+        fill: { '0': { value: '#FFFFFF' } },
+        'translation.x': { '0': { value: -336 } },
+        'translation.y': { '0': { value: -156 } }
+      },
+      'haiku:d3925e0ff576': {
+        points: {
+          '0': {
+            value: '382.02 196.978 382.02 211 336.1 211 336.1 156.88 381.036 156.88 381.036 170.902 355.206 170.902 355.206 177.626 376.034 177.626 376.034 190.582 355.206 190.582 355.206 196.978'
+          }
+        }
+      },
+      'haiku:45100a5481ae': {
+        viewBox: { '0': { value: '0 0 8 8' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 8 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 8 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': {
+          '0': { value: 455, edited: true },
+          '267': { value: 460, edited: true, curve: 'linear' },
+          '483': { value: 445, edited: true },
+          '500': { value: 435, edited: true },
+          '883': { value: 183, edited: true, curve: 'linear' },
+          '1217': { value: 208, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 204, edited: true },
+          '267': { value: 203, edited: true, curve: 'easeInOutCirc' },
+          '500': { value: 168, edited: true },
+          '883': { value: 177, edited: true, curve: 'easeOutCirc' },
+          '1217': { value: 142, edited: true }
+        },
+        'style.zIndex': { '0': { value: 8 } },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '267': { value: 1, edited: true },
+          '450': { value: 1, edited: true, curve: 'linear' },
+          '583': { value: 0, edited: true },
+          '883': { value: 1, edited: true },
+          '1100': { value: 1, edited: true, curve: 'linear' },
+          '1217': { value: 0, edited: true }
+        }
+      },
+      'haiku:49141efedd32': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:0a1b4b252759': {
+        fill: { '0': { value: '#FF5883' } },
+        'translation.x': { '0': { value: -136 } },
+        'translation.y': { '0': { value: -258 } }
+      },
+      'haiku:8f5a624e29cb': {
+        cx: { '0': { value: '140' } },
+        cy: { '0': { value: '262' } },
+        r: { '0': { value: '4' } }
+      },
+      'haiku:5fe5a8c6c68c': {
+        viewBox: { '0': { value: '0 0 14 14' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 14 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 14 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': {
+          '0': { value: 482, edited: true },
+          '267': { value: 466, edited: true, curve: 'linear' },
+          '500': { value: 459, edited: true },
+          '550': { value: 332, edited: true, curve: 'linear' },
+          '800': { value: 359, edited: true },
+          '1183': { value: 374, edited: true, curve: 'linear' },
+          '1467': { value: 414, edited: true },
+          '2217': { value: 173, edited: true, curve: 'linear' },
+          '2833': { value: 403, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 202, edited: true },
+          '267': { value: 198, edited: true, curve: 'easeInOutCirc' },
+          '500': { value: 157, edited: true },
+          '550': { value: 205, edited: true, curve: 'easeInOutCirc' },
+          '800': { value: 181, edited: true },
+          '1183': { value: 169, edited: true, curve: 'easeOutCirc' },
+          '1467': { value: 144, edited: true },
+          '2217': { value: 209, edited: true, curve: 'easeInCirc' },
+          '2833': { value: 145, edited: true }
+        },
+        'style.zIndex': { '0': { value: 9 } },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '267': { value: 1, edited: true },
+          '450': { value: 1, edited: true, curve: 'easeOutCubic' },
+          '533': { value: 0, edited: true },
+          '550': { value: 1, edited: true },
+          '750': { value: 1, edited: true, curve: 'easeOutCubic' },
+          '883': { value: 0, edited: true },
+          '1183': { value: 1, edited: true },
+          '1383': { value: 1, edited: true, curve: 'linear' },
+          '1467': { value: 0, edited: true },
+          '2217': { value: 1, edited: true },
+          '2667': { value: 1, edited: true, curve: 'linear' },
+          '2833': { value: 0, edited: true }
+        }
+      },
+      'haiku:aebe42ca1928': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:6c868f89d96c': {
+        'stroke-width': { '0': { value: '2.5' } },
+        stroke: { '0': { value: '#00DEE2' } },
+        'translation.x': { '0': { value: -182 } },
+        'translation.y': { '0': { value: -279 } }
+      },
+      'haiku:0eb8534c4653': {
+        cx: { '0': { value: '189' } },
+        cy: { '0': { value: '286' } },
+        r: { '0': { value: '5.75' } }
+      },
+      'haiku:1dfa2abb91b4': {
+        viewBox: { '0': { value: '0 0 14 14' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 14 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 14 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': {
+          '0': { value: 497.58, edited: true },
+          '267': { value: 466.58, edited: true, curve: 'linear' },
+          '500': { value: 478.58, edited: true },
+          '883': { value: 163.57999999999998, edited: true, curve: 'linear' },
+          '1217': { value: 107.57999999999998, edited: true },
+          '2217': { value: 237.57999999999998, edited: true, curve: 'linear' },
+          '2583': { value: 407.3887431693989, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 200.86, edited: true },
+          '267': { value: 199.86, edited: true, curve: 'easeInOutCirc' },
+          '500': { value: 172.86, edited: true },
+          '883': { value: 172.86, edited: true, curve: 'easeOutCirc' },
+          '1217': { value: 137.86, edited: true },
+          '2217': { value: 207.86, edited: true, curve: 'easeInCirc' },
+          '2583': { value: 137.86, edited: true }
+        },
+        'style.zIndex': { '0': { value: 10 } },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '267': { value: 1, edited: true },
+          '450': { value: 1, edited: true, curve: 'easeOutCubic' },
+          '567': { value: 0, edited: true },
+          '883': { value: 1, edited: true },
+          '1100': { value: 1, edited: true, curve: 'easeOutCubic' },
+          '1217': { value: 0, edited: true },
+          '2217': { value: 1, edited: true },
+          '2417': { value: 1, edited: true, curve: 'linear' },
+          '2583': { value: 0, edited: true }
+        }
+      },
+      'haiku:c991cf5a0eb2': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:3a151b485792': {
+        'stroke-width': { '0': { value: '2.5' } },
+        stroke: { '0': { value: '#FFD300' } },
+        'translation.x': { '0': { value: -153 } },
+        'translation.y': { '0': { value: -279 } }
+      },
+      'haiku:8bfa3e9b1b5a': {
+        cx: { '0': { value: '160' } },
+        cy: { '0': { value: '286' } },
+        r: { '0': { value: '5.75' } }
+      },
+      'haiku:47bc0ed0fa1a': {
+        viewBox: { '0': { value: '0 0 8 8' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 8 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 8 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': {
+          '0': { value: 359.14, edited: true },
+          '550': { value: 341.14, edited: true, curve: 'linear' },
+          '800': { value: 326.14, edited: true },
+          '1033': { value: 326.14, edited: true, curve: 'linear' },
+          '1350': { value: 309.14, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 206.42000000000002, edited: true },
+          '550': {
+            value: 207.42000000000002,
+            edited: true,
+            curve: 'easeInOutCirc'
+          },
+          '800': { value: 172.42000000000002, edited: true },
+          '1033': {
+            value: 172.42000000000002,
+            edited: true,
+            curve: 'easeOutCirc'
+          },
+          '1350': { value: 116.42000000000002, edited: true }
+        },
+        'style.zIndex': { '0': { value: 12 } },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '550': { value: 1, edited: true },
+          '750': { value: 1, edited: true, curve: 'easeOutCubic' },
+          '883': { value: 0, edited: true },
+          '1033': { value: 1, edited: true },
+          '1250': { value: 1, edited: true, curve: 'linear' },
+          '1350': { value: 0, edited: true }
+        }
+      },
+      'haiku:ba5c6ffbaeb0': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:f4e03fd44100': {
+        fill: { '0': { value: '#FFD300' } },
+        'translation.x': { '0': { value: -156 } },
+        'translation.y': { '0': { value: -258 } }
+      },
+      'haiku:fdba317520fc': {
+        cx: { '0': { value: '160' } },
+        cy: { '0': { value: '262' } },
+        r: { '0': { value: '4' } }
+      },
+      'haiku:e4bd0da8cd6d': {
+        viewBox: { '0': { value: '0 0 8 8' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 8 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 8 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': {
+          '0': { value: 336.1, edited: true },
+          '1033': { value: 306.42, edited: true, curve: 'linear' },
+          '1350': { value: 336.42, edited: true },
+          '2217': { value: 261.42, edited: true, curve: 'linear' },
+          '2650': { value: 332.42, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 177.3, edited: true },
+          '1033': { value: 177.3, edited: true, curve: 'easeOutCirc' },
+          '1350': { value: 147.3, edited: true },
+          '2217': { value: 213.3, edited: true, curve: 'easeInCirc' },
+          '2650': { value: 163.3, edited: true }
+        },
+        'style.zIndex': { '0': { value: 13 } },
+        'scale.x': { '0': { value: 1 }, '1033': { value: 1.08, edited: true } },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '1033': { value: 1, edited: true },
+          '1233': { value: 1, edited: true, curve: 'linear' },
+          '1350': { value: 0, edited: true },
+          '2217': { value: 1, edited: true },
+          '2500': { value: 1, edited: true, curve: 'linear' },
+          '2650': { value: 0, edited: true }
+        }
+      },
+      'haiku:c23b4d7fad03': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:570a14aa6c2f': {
+        fill: { '0': { value: '#00DEE2' } },
+        'translation.x': { '0': { value: -175 } },
+        'translation.y': { '0': { value: -258 } }
+      },
+      'haiku:fb24d7a0428a': {
+        cx: { '0': { value: '179' } },
+        cy: { '0': { value: '262' } },
+        r: { '0': { value: '4' } }
+      },
+      'haiku:3c4f0a039417': {
+        viewBox: { '0': { value: '0 0 14 14' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 14 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 14 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': {
+          '0': { value: 328.62, edited: true },
+          '1033': { value: 328.62, edited: true, curve: 'linear' },
+          '1350': { value: 296.62, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 175.58, edited: true },
+          '1033': { value: 175.58, edited: true, curve: 'easeOutCirc' },
+          '1350': { value: 140.58, edited: true }
+        },
+        'style.zIndex': { '0': { value: 14 } },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '1033': { value: 1, edited: true },
+          '1233': { value: 1, edited: true, curve: 'linear' },
+          '1350': { value: 0, edited: true }
+        }
+      },
+      'haiku:c56cf1b3b34d': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:15d2afcedf22': {
+        'stroke-width': { '0': { value: '2.5' } },
+        stroke: { '0': { value: '#FF5883' } },
+        'translation.x': { '0': { value: -129 } },
+        'translation.y': { '0': { value: -279 } }
+      },
+      'haiku:4bce6e0c211d': {
+        cx: { '0': { value: '136' } },
+        cy: { '0': { value: '286' } },
+        r: { '0': { value: '5.75' } }
+      },
+      'haiku:3b978060f2d6': {
+        viewBox: { '0': { value: '0 0 8 8' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 8 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 8 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': {
+          '0': { value: 405.86, edited: true },
+          '1183': { value: 385.86, edited: true, curve: 'linear' },
+          '1467': { value: 372.86, edited: true },
+          '2217': { value: 202.86, edited: true, curve: 'linear' },
+          '2783': { value: 407.86, edited: true }
+        },
+        'translation.y': {
+          '0': { value: 172.18, edited: true },
+          '1183': { value: 172.18, edited: true, curve: 'easeOutCirc' },
+          '1467': { value: 147.18, edited: true },
+          '2217': { value: 213.18, edited: true, curve: 'easeInCirc' },
+          '2783': { value: 134.98444741236045, edited: true },
+          '3317': { value: 163.18, edited: true }
+        },
+        'style.zIndex': { '0': { value: 15 } },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '1183': { value: 1, edited: true },
+          '1383': { value: 1, edited: true, curve: 'linear' },
+          '1467': { value: 0, edited: true },
+          '2217': { value: 1, edited: true },
+          '2617': { value: 1, edited: true, curve: 'linear' },
+          '2783': { value: 0, edited: true }
+        }
+      },
+      'haiku:bb2ea33ce59b': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:2783962bf034': {
+        fill: { '0': { value: '#FF5883' } },
+        'translation.x': { '0': { value: -136 } },
+        'translation.y': { '0': { value: -258 } }
+      },
+      'haiku:e0651d9b2b05': {
+        cx: { '0': { value: '140' } },
+        cy: { '0': { value: '262' } },
+        r: { '0': { value: '4' } }
+      }
+    }
+  },
+
+  template: {
+    elementName: 'div',
+    attributes: { 'haiku-title': 'Move', 'haiku-id': '91083482b04d' },
+    children: [
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/Move.sketch.contents/slices/O.svg',
+          'haiku-id': '5bfd10a365ed',
+          'haiku-title': 'O'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': 'e0493b3c81f7' },
+            children: ['O']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': 'e459ffb0969b' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '326c97c8594a' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '5b213ab9bbdf' },
+            children: [
+              {
+                elementName: 'g',
+                attributes: { id: 'Artboard', 'haiku-id': 'f381da39280d' },
+                children: [
+                  {
+                    elementName: 'path',
+                    attributes: { id: 'O', 'haiku-id': '23962fd3e6f7' },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/Move.sketch.contents/slices/M.svg',
+          'haiku-id': '676aa843ca1c',
+          'haiku-title': 'M'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': 'a69b11998f09' },
+            children: ['M']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': 'bc3aa319e526' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '92300bd7d503' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': 'c2569068439f' },
+            children: [
+              {
+                elementName: 'g',
+                attributes: { id: 'Artboard', 'haiku-id': '7567dd09dbf7' },
+                children: [
+                  {
+                    elementName: 'polygon',
+                    attributes: { id: 'M', 'haiku-id': 'cbb866760178' },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/Move.sketch.contents/slices/V.svg',
+          'haiku-id': '0802a4738af0',
+          'haiku-title': 'V'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': '5a806bdd4bca' },
+            children: ['V']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '140c3b81f64b' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '4fa3f05cd850' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '129389353e52' },
+            children: [
+              {
+                elementName: 'g',
+                attributes: { id: 'Artboard', 'haiku-id': 'f22dc401e7ab' },
+                children: [
+                  {
+                    elementName: 'polygon',
+                    attributes: { id: 'V', 'haiku-id': '420e630b3df4' },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/Move.sketch.contents/slices/E.svg',
+          'haiku-id': 'c8d0231b6708',
+          'haiku-title': 'E'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': '25c4eae2c83c' },
+            children: ['E']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '5902b561616e' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '2bbeecfd6b50' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '4e5ea6d40bf2' },
+            children: [
+              {
+                elementName: 'g',
+                attributes: { id: 'Artboard', 'haiku-id': '092dedd1b841' },
+                children: [
+                  {
+                    elementName: 'polygon',
+                    attributes: { id: 'E', 'haiku-id': 'd3925e0ff576' },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/Move.sketch.contents/slices/circle red.svg',
+          'haiku-title': 'circle red',
+          'haiku-id': '45100a5481ae'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': '8d077312acdc' },
+            children: ['circle red']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '12700170fe69' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': 'a8d84b1506a9' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '49141efedd32' },
+            children: [
+              {
+                elementName: 'g',
+                attributes: { id: 'Artboard', 'haiku-id': '0a1b4b252759' },
+                children: [
+                  {
+                    elementName: 'circle',
+                    attributes: {
+                      id: 'circle-red',
+                      'haiku-id': '8f5a624e29cb'
+                    },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/Move.sketch.contents/slices/ring teal.svg',
+          'haiku-title': 'ring teal',
+          'haiku-id': '5fe5a8c6c68c'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': '22c67952cec3' },
+            children: ['ring teal']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '5747b15d6691' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '0725fb50ccad' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': 'aebe42ca1928' },
+            children: [
+              {
+                elementName: 'g',
+                attributes: { id: 'Artboard', 'haiku-id': '6c868f89d96c' },
+                children: [
+                  {
+                    elementName: 'circle',
+                    attributes: { id: 'ring-teal', 'haiku-id': '0eb8534c4653' },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/Move.sketch.contents/slices/ring yellow.svg',
+          'haiku-title': 'ring yellow',
+          'haiku-id': '1dfa2abb91b4'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': '95845db38809' },
+            children: ['ring yellow']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '4ee44eea0439' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '3e658a0d7210' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': 'c991cf5a0eb2' },
+            children: [
+              {
+                elementName: 'g',
+                attributes: { id: 'Artboard', 'haiku-id': '3a151b485792' },
+                children: [
+                  {
+                    elementName: 'circle',
+                    attributes: {
+                      id: 'ring-yellow',
+                      'haiku-id': '8bfa3e9b1b5a'
+                    },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/Move.sketch.contents/slices/circle yellow.svg',
+          'haiku-title': 'circle yellow',
+          'haiku-id': '47bc0ed0fa1a'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': '85e03095ce89' },
+            children: ['circle yellow']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': 'e53fb2b46b2d' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': 'ebfa151556c6' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': 'ba5c6ffbaeb0' },
+            children: [
+              {
+                elementName: 'g',
+                attributes: { id: 'Artboard', 'haiku-id': 'f4e03fd44100' },
+                children: [
+                  {
+                    elementName: 'circle',
+                    attributes: {
+                      id: 'circle-yellow',
+                      'haiku-id': 'fdba317520fc'
+                    },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/Move.sketch.contents/slices/circle teal.svg',
+          'haiku-title': 'circle teal',
+          'haiku-id': 'e4bd0da8cd6d'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': 'fd5776bd3bd3' },
+            children: ['circle teal']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': 'a9a31fd01e02' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '8863b86c18c1' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': 'c23b4d7fad03' },
+            children: [
+              {
+                elementName: 'g',
+                attributes: { id: 'Artboard', 'haiku-id': '570a14aa6c2f' },
+                children: [
+                  {
+                    elementName: 'circle',
+                    attributes: {
+                      id: 'circle-teal',
+                      'haiku-id': 'fb24d7a0428a'
+                    },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/Move.sketch.contents/slices/ring red.svg',
+          'haiku-title': 'ring red',
+          'haiku-id': '3c4f0a039417'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': '0691fc2c65cb' },
+            children: ['ring red']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '13c7a3f26b52' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '799e79e1f0eb' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': 'c56cf1b3b34d' },
+            children: [
+              {
+                elementName: 'g',
+                attributes: { id: 'Artboard', 'haiku-id': '15d2afcedf22' },
+                children: [
+                  {
+                    elementName: 'circle',
+                    attributes: { id: 'ring-red', 'haiku-id': '4bce6e0c211d' },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/Move.sketch.contents/slices/circle red.svg',
+          'haiku-title': 'circle red',
+          'haiku-id': '3b978060f2d6'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': 'e8a02e95413e' },
+            children: ['circle red']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': 'b7afecc9e845' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': 'dd61e075b435' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': 'bb2ea33ce59b' },
+            children: [
+              {
+                elementName: 'g',
+                attributes: { id: 'Artboard', 'haiku-id': '2783962bf034' },
+                children: [
+                  {
+                    elementName: 'circle',
+                    attributes: {
+                      id: 'circle-red',
+                      'haiku-id': 'e0651d9b2b05'
+                    },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/haiku-creator/src/react/bytecode-fixtures/TourCheckTutorial.js
+++ b/packages/haiku-creator/src/react/bytecode-fixtures/TourCheckTutorial.js
@@ -1,0 +1,339 @@
+module.exports = {
+  metadata: {
+    uuid: '92c97d04-f3c5-4a41-8656-e14ad3112867',
+    type: 'haiku',
+    name: 'CheckTutorial',
+    relpath: 'code/main/code.js',
+    player: '2.3.39',
+    version: '0.0.20',
+    organization: 'zack2',
+    project: 'CheckTutorial',
+    branch: 'master'
+  },
+
+  options: {},
+  states: {},
+
+  eventHandlers: {},
+  timelines: {
+    Default: {
+      'haiku:040e0b5bc34d': {
+        'style.WebkitTapHighlightColor': { '0': { value: 'rgba(0,0,0,0)' } },
+        'style.position': { '0': { value: 'relative' } },
+        'style.overflowX': { '0': { value: 'hidden' } },
+        'style.overflowY': { '0': { value: 'hidden' } },
+        'sizeAbsolute.x': { '0': { value: 280, edited: true } },
+        'sizeAbsolute.y': { '0': { value: 250, edited: true } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'sizeMode.z': { '0': { value: 1 } }
+      },
+      'haiku:ece4163f0652': {
+        viewBox: { '0': { value: '0 0 113 113' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 113 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 113 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': { '0': { value: 84.5, edited: true } },
+        'translation.y': { '0': { value: 74.5, edited: true } },
+        'style.zIndex': { '0': { value: 1 } },
+        'scale.x': {
+          '0': { value: 1.5752212389380542, edited: true },
+          '333': { value: 0.3, edited: true, curve: 'easeInCubic' },
+          '967': { value: 2.4, edited: true }
+        },
+        'scale.y': {
+          '0': { value: 1.5752212389380542, edited: true },
+          '333': { value: 0.3, edited: true, curve: 'easeInCubic' },
+          '983': { value: 2.4, edited: true }
+        },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '467': { value: 0, edited: true, curve: 'linear' },
+          '583': { value: 1, edited: true },
+          '817': { value: 1, edited: true, curve: 'linear' },
+          '867': { value: 0, edited: true }
+        }
+      },
+      'haiku:6a97bc9649c0': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:e0c04a7740a9': {
+        stroke: { '0': { value: '#F8E71C' } },
+        'stroke-width': { '0': { value: '3' } },
+        cx: { '0': { value: '56.5' } },
+        cy: { '0': { value: '56.5' } },
+        r: { '0': { value: '55' } }
+      },
+      'haiku:352ac4d91592': {
+        viewBox: { '0': { value: '0 0 101 101' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 101 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 101 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': { '0': { value: 91, edited: true } },
+        'translation.y': { '0': { value: 82, edited: true } },
+        'style.zIndex': { '0': { value: 2 } },
+        opacity: {
+          '0': { value: 0, edited: true },
+          '467': { value: 0, edited: true, curve: 'linear' },
+          '667': { value: 1, edited: true },
+          '833': { value: 1, edited: true, curve: 'linear' },
+          '950': { value: 0, edited: true }
+        },
+        'scale.x': {
+          '0': { value: 1 },
+          '450': { value: 0.5, edited: true, curve: 'easeInCubic' },
+          '983': { value: 1.8, edited: true }
+        },
+        'scale.y': {
+          '0': { value: 1 },
+          '450': { value: 0.5, edited: true, curve: 'easeInCubic' },
+          '983': { value: 1.8, edited: true }
+        },
+        'rotation.z': {
+          '0': { value: 0 },
+          '450': { value: 0, edited: true, curve: 'easeInCirc' },
+          '983': { value: 1, edited: true }
+        }
+      },
+      'haiku:121842734298': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } },
+        'stroke-linecap': { '0': { value: 'round' } },
+        'stroke-dasharray': { '0': { value: '1,14' } }
+      },
+      'haiku:063da83ae28f': {
+        stroke: { '0': { value: '#D0021B' } },
+        'stroke-width': { '0': { value: '5' } },
+        cx: { '0': { value: '50.5' } },
+        cy: { '0': { value: '50.5' } },
+        r: { '0': { value: '47.5' } }
+      },
+      'haiku:46386631b4c6': {
+        viewBox: { '0': { value: '0 0 81 71' } },
+        'style.position': { '0': { value: 'absolute' } },
+        'style.margin': { '0': { value: '0' } },
+        'style.padding': { '0': { value: '0' } },
+        'style.border': { '0': { value: '0' } },
+        'sizeAbsolute.x': { '0': { value: 81 } },
+        'sizeMode.x': { '0': { value: 1 } },
+        'sizeAbsolute.y': { '0': { value: 71 } },
+        'sizeMode.y': { '0': { value: 1 } },
+        'translation.x': { '0': { value: 99, edited: true } },
+        'translation.y': { '0': { value: 96, edited: true } },
+        'style.zIndex': { '0': { value: 3 } },
+        'scale.x': {
+          '0': {
+            value: 3.5285828551556295,
+            edited: true,
+            curve: 'easeOutElastic'
+          },
+          '850': { value: 2.049382716049383, edited: true }
+        },
+        'scale.y': {
+          '0': {
+            value: 3.5285828551556295,
+            edited: true,
+            curve: 'easeOutBack'
+          },
+          '500': { value: 2.049382716049383, edited: true }
+        },
+        opacity: {
+          '0': {
+            value: 0.025,
+            edited: true,
+            curve: 'easeOutCubic'
+          },
+          '267': { value: 1, edited: true },
+          '283': { value: 1, edited: true }
+        }
+      },
+      'haiku:27c437626b60': {
+        stroke: { '0': { value: 'none' } },
+        'stroke-width': { '0': { value: '1' } },
+        fill: { '0': { value: 'none' } },
+        'fill-rule': { '0': { value: 'evenodd' } }
+      },
+      'haiku:f0954800074b': {
+        d: {
+          '0': {
+            value: 'M26.037877,51.7310269 L13.8011724,38.6087679 L13.8011724,38.6087679 C10.9762427,35.5794017 6.2303982,35.4136731 3.20103198,38.2386028 C0.171665758,41.0635325 0.00593721457,45.8093771 2.83086692,48.8387433 L19.1988276,66.3912321 C19.7449669,66.9768948 20.3629021,67.4555265 21.0263501,67.8262094 C21.2476626,68.0680456 21.4873805,68.2981618 21.7453333,68.5146099 L21.7453333,68.5146099 L21.7453333,68.5146099 C24.9183933,71.1771234 29.6490603,70.7632436 32.3115737,67.5901837 L32.3115737,67.5901837 L78.632421,12.3871475 C81.2949345,9.21408749 80.8810548,4.48342053 77.7079948,1.82090707 L77.7079948,1.82090707 C74.5349348,-0.841606384 69.8042678,-0.427726654 67.1417544,2.74533332 L26.037877,51.7310269 Z'
+          }
+        },
+        fill: { '0': { value: 'url(#linearGradient-1-aee1a6)' } }
+      },
+      'haiku:10f06a73c6e9': {
+        x1: { '0': { value: '50%' } },
+        y1: { '0': { value: '0%' } },
+        x2: { '0': { value: '50%' } },
+        y2: { '0': { value: '100%' } }
+      },
+      'haiku:56e0c335ae46': {
+        'stop-color': { '0': { value: '#B4EC51' } },
+        offset: { '0': { value: '0%' } }
+      },
+      'haiku:8ec8f02a54d8': {
+        'stop-color': { '0': { value: '#429321' } },
+        offset: { '0': { value: '100%' } }
+      }
+    }
+  },
+
+  template: {
+    elementName: 'div',
+    attributes: { 'haiku-title': 'CheckTutorial', 'haiku-id': '040e0b5bc34d' },
+    children: [
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/checkmark.sketch.contents/slices/ring.svg',
+          'haiku-id': 'ece4163f0652',
+          'haiku-title': 'ring'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': 'a72b94dcceb7' },
+            children: ['ring']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': 'a01896e74ef7' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '5998f53463e9' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '6a97bc9649c0' },
+            children: [
+              {
+                elementName: 'circle',
+                attributes: { id: 'ring', 'haiku-id': 'e0c04a7740a9' },
+                children: []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/checkmark.sketch.contents/slices/ring-dots.svg',
+          'haiku-id': '352ac4d91592',
+          'haiku-title': 'ring-dots'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': 'a767b31f3d62' },
+            children: ['ring-dots']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '46ea3e1b461f' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': '8d969aa62e6e' },
+            children: []
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '121842734298' },
+            children: [
+              {
+                elementName: 'circle',
+                attributes: { id: 'ring-dots', 'haiku-id': '063da83ae28f' },
+                children: []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          version: '1.1',
+          xmlns: 'http://www.w3.org/2000/svg',
+          'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+          source: 'designs/checkmark.sketch.contents/slices/checkmark.svg',
+          'haiku-id': '46386631b4c6',
+          'haiku-title': 'checkmark'
+        },
+        children: [
+          {
+            elementName: 'title',
+            attributes: { 'haiku-id': 'a461349b8264' },
+            children: ['checkmark']
+          },
+          {
+            elementName: 'desc',
+            attributes: { 'haiku-id': '06797e24bf9d' },
+            children: ['Created with sketchtool.']
+          },
+          {
+            elementName: 'defs',
+            attributes: { 'haiku-id': 'ad1494846dc3' },
+            children: [
+              {
+                elementName: 'linearGradient',
+                attributes: {
+                  id: 'linearGradient-1-aee1a6',
+                  'haiku-id': '10f06a73c6e9'
+                },
+                children: [
+                  {
+                    elementName: 'stop',
+                    attributes: { 'haiku-id': '56e0c335ae46' },
+                    children: []
+                  },
+                  {
+                    elementName: 'stop',
+                    attributes: { 'haiku-id': '8ec8f02a54d8' },
+                    children: []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            elementName: 'g',
+            attributes: { id: 'Page-1', 'haiku-id': '27c437626b60' },
+            children: [
+              {
+                elementName: 'path',
+                attributes: { id: 'checkmark', 'haiku-id': 'f0954800074b' },
+                children: []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/haiku-creator/src/react/components/ProjectPreview.js
+++ b/packages/haiku-creator/src/react/components/ProjectPreview.js
@@ -15,6 +15,7 @@ class ProjectPreview extends React.Component {
     super(props)
     this.bytecode = null
     this.mount = null
+    this.timeline = null
   }
 
   componentWillMount () {
@@ -34,7 +35,7 @@ class ProjectPreview extends React.Component {
   componentDidMount () {
     if (this.bytecode && this.mount) {
       try {
-        HaikuDOMAdapter(this.bytecode)(
+        this.timeline = HaikuDOMAdapter(this.bytecode)(
           this.mount,
           {
             sizing: 'cover',
@@ -42,11 +43,27 @@ class ProjectPreview extends React.Component {
             interactionMode: InteractionMode.EDIT,
             autoplay: false
           }
-        )
+        ).getDefaultTimeline()
       } catch (exception) {
         // noop. Probably caught a backward-incompatible change that doesn't work with the current version of Player.
       }
     }
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (!this.timeline || this.props.playing === nextProps.playing) {
+      return
+    }
+
+    if (nextProps.playing) {
+      this.timeline.play()
+    } else {
+      this.timeline.pause()
+    }
+  }
+
+  shouldComponentUpdate () {
+    return true
   }
 
   render () {

--- a/packages/haiku-creator/src/react/components/ProjectThumbnail.js
+++ b/packages/haiku-creator/src/react/components/ProjectThumbnail.js
@@ -35,7 +35,7 @@ class ProjectThumbnail extends React.Component {
             DASH_STYLES.thumb,
             (this.state.isMenuActive || this.state.isHovered) && DASH_STYLES.blurred
           ]}>
-          <ProjectPreview bytecodePath={this.bytecodePath} />
+          <ProjectPreview bytecodePath={this.bytecodePath} projectName={this.props.projectName} />
         </div>
         <div
           key='scrim'

--- a/packages/haiku-creator/src/react/components/ProjectThumbnail.js
+++ b/packages/haiku-creator/src/react/components/ProjectThumbnail.js
@@ -33,9 +33,13 @@ class ProjectThumbnail extends React.Component {
           key='thumb'
           style={[
             DASH_STYLES.thumb,
-            (this.state.isMenuActive || this.state.isHovered) && DASH_STYLES.blurred
+            this.state.isMenuActive && DASH_STYLES.blurred
           ]}>
-          <ProjectPreview bytecodePath={this.bytecodePath} projectName={this.props.projectName} />
+          <ProjectPreview
+            bytecodePath={this.bytecodePath}
+            projectName={this.props.projectName}
+            playing={this.state.isHovered && !this.state.isMenuActive}
+          />
         </div>
         <div
           key='scrim'

--- a/packages/haiku-creator/src/react/components/Tour/Steps/Congratulations.js
+++ b/packages/haiku-creator/src/react/components/Tour/Steps/Congratulations.js
@@ -1,12 +1,23 @@
 import React from 'react'
-import CheckTutorial from '@haiku/zack2-checktutorial/react'
 
-export default function ({ styles }) {
-  return (
-    <div>
-      <CheckTutorial haikuOptions={{loop: false}} />
-      <h2 style={styles.heading}>Congratulations!</h2>
-      <p style={styles.text}>You're now an animator.</p>
-    </div>
-  )
+import HaikuDOMAdapter from '@haiku/player/dom'
+
+import TourCheckTutorial from '../../../bytecode-fixtures/TourCheckTutorial'
+
+export default class Congratulations extends React.Component {
+  componentDidMount () {
+    if (this.mount) {
+      HaikuDOMAdapter(TourCheckTutorial)(this.mount)
+    }
+  }
+
+  render () {
+    return (
+      <div>
+        <div ref={(mount) => { this.mount = mount }} />
+        <h2 style={this.props.styles.heading}>Congratulations!</h2>
+        <p style={this.props.styles.text}>You're now an animator.</p>
+      </div>
+    )
+  }
 }

--- a/packages/haiku-creator/src/react/styles/dashShared.js
+++ b/packages/haiku-creator/src/react/styles/dashShared.js
@@ -118,7 +118,7 @@ export const DASH_STYLES = {
     height: 190,
     opacity: 0,
     color: Palette.SUNSTONE,
-    backgroundColor: Color(Palette.FATHER_COAL).fade(0.2),
+    backgroundColor: Color(Palette.FATHER_COAL).fade(0.4),
     borderTopLeftRadius: 5,
     borderTopRightRadius: 5
   },
@@ -150,7 +150,7 @@ export const DASH_STYLES = {
     transform: 'translateY(0px) translateX(-50%)'
   },
   gone2: {
-    transform: 'translateY(9px) translateX(-50%)',
+    transform: 'translateY(15px) translateX(-50%)',
     transition: 'none'
   },
   titleStrip: {


### PR DESCRIPTION
Medium-small PR, but feel free to ignore the copy/pasted bytecode.

After discussing with @zackbrown last night: since first touch is so important and we didn't want to treat the template projects **too** differently in dashboard 2, we can for now store preview bytecode for the template projects directly in the app so they're available as a fallback. This is extensible if needed, but not meant to be a permanent solution or anything—just for getting dashboard 2 out the door without corrupting the essential first touch with ugly, inconsistent, or missing previews.

I also opportunistically cleaned up the brittle @haiku/zack2-checktutorial dependency by using another fixture for that.