### PR TITLE
WIP: 250MB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.js
 source/*
 ~tmp
 .last-sync
+.last-compile

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,6 @@ node ./scripts/distro-configure.js --non-interactive # 0m
 node ./scripts/distro-download-secrets.js
 yarn relink
 node ./scripts/distro-prepare.js # 3m
-node ./scripts/distro-electron-rebuild.js # 5m
 node ./scripts/distro-uglify-sources.js # 1m
 node ./scripts/distro-build.js # 8m
 node ./scripts/distro-upload.js # 2m

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "mac": {
       "category": "public.app-category.developer-tools"
     },
-    "asar": true,
+    "asar": false,
     "asarUnpack": [
       "index.js",
       "config.js",
@@ -108,6 +108,18 @@
       "!source/**/{CHANGELOG.md,README.md,README,readme.md,readme,test,__tests__,tests,powered-test,example,examples,*.d.ts}",
       "!source/plumbing/node_modules/nodegit",
       "!source/plumbing/node_modules/electron",
+      "!source/plumbing/node_modules/@haiku/player/demo",
+      "!source/plumbing/node_modules/aws-sdk",
+      "!source/plumbing/node_modules/cli-table2",
+      "!source/plumbing/node_modules/eslint",
+      "!source/plumbing/node_modules/haiku-glass/node_modules/monaco-editor/dev",
+      "!source/plumbing/node_modules/monaco-editor/dev",
+      "!source/plumbing/node_modules/mout",
+      "!source/plumbing/node_modules/node-pre-gyp",
+      "!source/plumbing/node_modules/react-split-pane/demo",
+      "!source/plumbing/node_modules/rocambole-indent",
+      "!source/plumbing/node_modules/sinon",
+      "!source/plumbing/node_modules/table",
       "source/plumbing/node_modules/nodegit/package.json",
       "source/plumbing/node_modules/nodegit/dist/**",
       "source/plumbing/node_modules/nodegit/build/Release/nodegit.node",

--- a/scripts/git-subtree-push.js
+++ b/scripts/git-subtree-push.js
@@ -1,4 +1,3 @@
-const async = require('async')
 const cp = require('child_process')
 const path = require('path')
 const argv = require('yargs').argv

--- a/scripts/push.js
+++ b/scripts/push.js
@@ -3,7 +3,6 @@ const fse = require('fs-extra')
 const path = require('path')
 const argv = require('yargs').argv
 
-
 const getPackages = require('./helpers/allPackages')
 const depTypes = require('./helpers/depTypes')
 const nowVersion = require('./helpers/nowVersion')
@@ -71,7 +70,7 @@ if (!argv['no-remote']) {
 // Compile packages.
 cp.execSync('yarn sync', processOptions)
 openSourcePackages.forEach((pack) => {
-  const compileCommand = `node ./scripts/compile-package.js --package=${pack.name}`;
+  const compileCommand = `node ./scripts/compile-package.js --package=${pack.name}`
   if (openSourceProjects.has(pack.name)) {
     cp.execSync(compileCommand, processOptions)
   } else {


### PR DESCRIPTION
This is just the result of some Friday night hacking. The objective was to reduce the app footprint "somewhat". With these changes, Haiku.app is at ~250MB. (As opposed to 350 or 400 or 700 (!))

Although it seems to work fine (I've built the app locally and run it through some basic QA testing without any problem), it's pretty hacky, so it warrants review. (Note: If the verdict is "This is too hacky" or "I have a much better solution cooking that will land before New Years Day") then we can just simply toss this in the bin; this an after-hours project and didn't take a lot of time.)

Background: In Haiku.app, the entry point is `source/plumbing`. And plumbing holds all of the `haiku-*` subpackages. Previously, each `haiku-*` subpackage had its own node_modules folder.

What this PR does is move all dependencies up to source/plumbing, or, which has the effect of deduping them. So instead of multiple lodash copies across the app, we have just one. And then there are a a few hacks to work around some side-effects of this.

Risks:

- Suppose `haiku-foo` depends on `meow@1.2.3` and `haiku-bar` depends on `meow@4.5.6`. That's not accounted for at all by this. This may already be a problem when developing locally with mono, i.e. we may already "secretly" have this problem, so ¯\_(ツ)_/¯