### PR TITLE
Fix "return" inside event handler function breaks events UI

### DIFF
--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -1,14 +1,5 @@
 {
   "LottieExportInGlobalMenu": {
     "development": true
-  },
-  "LottieExportOnPublish": {
-    "development": true,
-    "production": true
-  },
-  "PreviewMode": {
-    "test": true,
-    "development": true,
-    "production": true
   }
 }

--- a/packages/haiku-common/src/experiments/index.ts
+++ b/packages/haiku-common/src/experiments/index.ts
@@ -9,8 +9,6 @@ import {getExperimentConfig} from './config';
  */
 export enum Experiment {
   LottieExportInGlobalMenu = 'LottieExportInGlobalMenu',
-  LottieExportOnPublish = 'LottieExportOnPublish',
-  PreviewMode = 'PreviewMode',
 }
 
 /**

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -21,7 +21,6 @@ import {
   DangerIconSVG,
   CliboardIconSVG
 } from './Icons'
-import { Experiment, experimentIsEnabled } from 'haiku-common/lib/experiments'
 import { ExporterFormat } from 'haiku-sdk-creator/lib/exporter'
 
 var mixpanel = require('haiku-serialization/src/utils/Mixpanel')
@@ -291,7 +290,7 @@ class StageTitleBar extends React.Component {
     return {
       commitMessage: 'Changes saved (via Haiku Desktop)',
       saveStrategy: SNAPSHOT_SAVE_RESOLUTION_STRATEGIES[this.state.snapshotSaveResolutionStrategyName],
-      exporterFormats: experimentIsEnabled(Experiment.LottieExportOnPublish) ? [ExporterFormat.Bodymovin] : []
+      exporterFormats: [ExporterFormat.Bodymovin]
     }
   }
 
@@ -443,14 +442,6 @@ class StageTitleBar extends React.Component {
     )
   }
 
-  hoverStyleForSaveButton () {
-    if (this.state.isSnapshotSaveInProgress) return null
-    if (this.state.snapshotSaveError) return null
-    if (this.state.snapshotMergeConflicts) return null
-    if (this.state.snapshotSaveConfirmed) return null
-    return BTN_STYLES.btnIconHover
-  }
-
   togglePreviewMode (checked) {
     const interaction = checked ? InteractionMode.EDIT : InteractionMode.LIVE
 
@@ -504,14 +495,11 @@ class StageTitleBar extends React.Component {
           </button>
         </Popover>
 
-        {
-          experimentIsEnabled(Experiment.PreviewMode) &&
-          <Toggle
-            onToggle={this.togglePreviewMode.bind(this)}
-            style={STYLES.previewToggle}
-            disabled={!this.props.isTimelineReady}
-          />
-        }
+        <Toggle
+          onToggle={(checked) => { this.togglePreviewMode(checked) }}
+          style={STYLES.previewToggle}
+          disabled={!this.props.isTimelineReady}
+        />
 
         {this.renderMergeConflictResolutionArea()}
         <button onClick={this.handleConnectionClick} style={[BTN_STYLES.btnIcon, BTN_STYLES.btnIconHover, STYLES.hide]} key='connect'>


### PR DESCRIPTION
Slightly complex review, but short.

I caught a bad bug in events UI due to how we prettify the handler code before showing it to the user. tl;dr, if we try to pass a function body through babylon intact, we'll get a compiler error if the function uses the keyword `return` anywhere—`return` and `return x` are not valid expressions outside of a function's scope.

Without fixing this, the UI loops on the syntax error it catches while trying to prettier the function body. Unfortunately, if we want to beautify the user's code using a formatter that depends on AST, we need to make it look like a complete function, not a list of expressions.

This PR provides a relatively painless solution: wrap the function body in `() => {` ... `}`, then format it, then return the resulting outdented function body.

Please see [User is allowed to save event handlers with syntax errors](https://app.asana.com/0/479779791675933/499273135535577/f) and [Monaco syntax errors don't display until additional keypress](https://app.asana.com/0/479779791675933/499273135535576/f) for related problems we should fix.