### PR TITLE
Force users to solve syntax errors in events ui

### DIFF
--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/Editor.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/Editor.js
@@ -72,7 +72,8 @@ class Editor extends React.Component {
     this.state = {
       contents: props.contents,
       isHovered: false,
-      isTrashHovered: false
+      isTrashHovered: false,
+      evaluator: null
     }
   }
 
@@ -151,7 +152,8 @@ class Editor extends React.Component {
         body: this.state.contents,
         type: 'FunctionExpression',
         name: null
-      }
+      },
+      evaluator: this.state.evaluator
     }
   }
 
@@ -168,6 +170,7 @@ class Editor extends React.Component {
         onMouseLeave={() => {
           this.setState({isHovered: false})
         }}
+        id={this.props.id}
       >
         <div style={STYLES.options}>
           {!this.props.hideEventSelector && (
@@ -224,6 +227,7 @@ class Editor extends React.Component {
         <div style={{...STYLES.amble, ...STYLES.postamble}}>
           {'}'}
           <SyntaxEvaluator
+            onChange={(evaluator) => { this.setState({evaluator}) }}
             evaluate={this.state.contents}
             style={STYLES.postamble.errors}
           />

--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/EditorActions.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/EditorActions.js
@@ -34,6 +34,7 @@ class EditorActions extends React.PureComponent {
         <button
           onClick={this.props.onSave}
           style={{...STYLES.button, ...STYLES.doneButton}}
+          title={this.props.title}
         >
           Done
         </button>

--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/HandlerManager.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/HandlerManager.js
@@ -67,9 +67,9 @@ class HandlerManager {
    * @param {Object} serializedEvent
    * @param {String} oldEventName
    */
-  replaceEvent ({id, event, handler}, oldEventName) {
+  replaceEvent ({id, event, handler, evaluator}, oldEventName) {
     this.appliedEventHandlers.delete(oldEventName)
-    this.appliedEventHandlers.set(event, {id, handler})
+    this.appliedEventHandlers.set(event, {id, handler, evaluator})
   }
 
   /**

--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/SyntaxEvaluator.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/SyntaxEvaluator.js
@@ -4,7 +4,7 @@ import {EVALUATOR_STATES} from './constants'
 import Palette from '../../Palette'
 import HaikuMode from '../../modes/haiku.js'
 
-class SyntaxEvaluator extends React.Component {
+class SyntaxEvaluator extends React.PureComponent {
   constructor (props) {
     super(props)
 
@@ -29,6 +29,10 @@ class SyntaxEvaluator extends React.Component {
     }
   }
 
+  shouldComponentUpdate (nextProps, nextState) {
+    return nextProps.evaluate !== this.props.evaluate
+  }
+
   componentWillUpdate () {
     const evaluator = this.getDefaultEvaluator()
     const wrapped = parseExpression.wrap(this.props.evaluate)
@@ -49,6 +53,7 @@ class SyntaxEvaluator extends React.Component {
     }
 
     this.evaluator = evaluator
+    this.props.onChange(evaluator)
   }
 
   render () {

--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
@@ -233,7 +233,7 @@ class EventHandlerEditor extends React.PureComponent {
           <div
             style={STYLES.editorsWrapper}
             className='haiku-scroll'
-            ref={(el) => (this.wrapper = el)}
+            ref={(el) => {this.wrapper = el}}
           >
             {this.renderEditors()}
           </div>

--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
@@ -6,7 +6,7 @@ import Editor from './Editor'
 import EditorActions from './EditorActions'
 import HandlerManager from './HandlerManager'
 import Palette from '../../Palette'
-import {EDITOR_WIDTH, EDITOR_HEIGHT} from './constants'
+import {EDITOR_WIDTH, EDITOR_HEIGHT, EVALUATOR_STATES} from './constants'
 
 const STYLES = {
   container: {
@@ -40,6 +40,10 @@ class EventHandlerEditor extends React.PureComponent {
     this.onEditorEventChange = this.onEditorEventChange.bind(this)
     this.onEditorRemoved = this.onEditorRemoved.bind(this)
     this.addAction = this.addAction.bind(this)
+
+    this.state = {
+      editorsWithErrors: []
+    }
   }
 
   /**
@@ -51,7 +55,7 @@ class EventHandlerEditor extends React.PureComponent {
    * 1- Triggering a re-render
    * 2- Instantiating a HandlerManager
    */
-  shouldComponentUpdate ({element, visible, options}, nextState) {
+  shouldComponentUpdate ({element, visible, options}, {editorsWithErrors}) {
     if (element && get(this.props, 'element.uid') !== get(element, 'uid')) {
       this.handlerManager = new HandlerManager(element)
       return true
@@ -59,7 +63,8 @@ class EventHandlerEditor extends React.PureComponent {
 
     if (
       (options && options.frame !== this.props.options.frame) ||
-      visible !== this.props.visible
+      visible !== this.props.visible ||
+      editorsWithErrors.length !== this.state.editorsWithErrors.length
     ) {
       return true
     }
@@ -73,9 +78,14 @@ class EventHandlerEditor extends React.PureComponent {
   }
 
   doSave () {
-    const serializedEventHandlers = this.handlerManager.serialize()
-    this.props.save(this.props.element, serializedEventHandlers)
-    this.props.close()
+    const result = this.handlerManager.serialize()
+
+    if (this.state.editorsWithErrors.length) {
+      this.scrollToEditor(this.state.editorsWithErrors[0])
+    } else {
+      this.props.save(this.props.element, result)
+      this.props.close()
+    }
   }
 
   doCancel () {
@@ -83,7 +93,22 @@ class EventHandlerEditor extends React.PureComponent {
   }
 
   onEditorContentChange (serializedEvent, oldEvent) {
-    this.handlerManager.replaceEvent(serializedEvent, oldEvent)
+    const {evaluator} = serializedEvent
+
+    if (evaluator && evaluator.state === EVALUATOR_STATES.ERROR) {
+      this.setState({
+        editorsWithErrors: this.state.editorsWithErrors.concat(
+          serializedEvent.id
+        )
+      })
+    } else {
+      this.handlerManager.replaceEvent(serializedEvent, oldEvent)
+      this.setState({
+        editorsWithErrors: this.state.editorsWithErrors.filter(
+          (editor) => editor !== serializedEvent.id
+        )
+      })
+    }
   }
 
   onEditorEventChange (serializedEvent, oldEvent) {
@@ -94,6 +119,11 @@ class EventHandlerEditor extends React.PureComponent {
   onEditorRemoved ({editor, event, handler}) {
     this.handlerManager.delete(event)
     this.forceUpdate()
+  }
+
+  scrollToEditor (editorId) {
+    const editor = this.wrapper.querySelector(`#${editorId}`)
+    this.wrapper.scrollTop = editor.offsetTop
   }
 
   renderFrameEditor (totalNumberOfHandlers, applicableEventHandlers) {
@@ -174,7 +204,7 @@ class EventHandlerEditor extends React.PureComponent {
     return (
       <div
         className='Absolute-Center'
-        onMouseDown={mouseEvent => {
+        onMouseDown={(mouseEvent) => {
           // Prevent outer view from closing us
           mouseEvent.stopPropagation()
         }}
@@ -200,7 +230,11 @@ class EventHandlerEditor extends React.PureComponent {
         />
 
         <div style={STYLES.outer}>
-          <div style={STYLES.editorsWrapper} className='haiku-scroll'>
+          <div
+            style={STYLES.editorsWrapper}
+            className='haiku-scroll'
+            ref={(el) => (this.wrapper = el)}
+          >
             {this.renderEditors()}
           </div>
         </div>
@@ -212,6 +246,11 @@ class EventHandlerEditor extends React.PureComponent {
           onSave={() => {
             this.doSave()
           }}
+          title={
+            this.state.editorsWithErrors.length
+              ? 'an event handler has a syntax error'
+              : ''
+          }
         />
       </div>
     )


### PR DESCRIPTION
This adds logic to avoid saving event handlers with syntax errors
by checking if there are editors with syntax errors and scrolling
to them if the user has pressed on 'save'

Asana task: https://app.asana.com/0/479779791675933/499273135535577

![2017-12-11 17_27_30](https://user-images.githubusercontent.com/4419992/33852295-b676a19e-de98-11e7-96be-ce4f4d026d1d.gif)
