### PR TITLE
Use the latest code to evaluate syntax in events ui

### DIFF
--- a/packages/haiku-glass/package.json
+++ b/packages/haiku-glass/package.json
@@ -24,6 +24,7 @@
     "capitalize": "^1.0.0",
     "color": "^2.0.0",
     "combokeys": "^2.4.6",
+    "cst": "^0.4.10",
     "haiku-bytecode": "HaikuTeam/bytecode.git",
     "haiku-common": "HaikuTeam/common.git",
     "haiku-fs-extra": "HaikuTeam/node-fs-extra.git#master-haiku",

--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
@@ -233,7 +233,7 @@ class EventHandlerEditor extends React.PureComponent {
           <div
             style={STYLES.editorsWrapper}
             className='haiku-scroll'
-            ref={(el) => {this.wrapper = el}}
+            ref={(el) => { this.wrapper = el }}
           >
             {this.renderEditors()}
           </div>


### PR DESCRIPTION
**Info**

- This should be an easy review.
- [Asana ticket](https://app.asana.com/0/479779791675933/499273135535576)

**What**

We are evaluating the syntax in the `componentWillUpdate` hook of the `SyntaxEvaluator` component, therefore, `this.props` doesn't point the latest updated value, making the evaluator go one step behind what the user has typed and from the monaco syntax evaluator.

**More**

We have discussed with @matthewtoast in the Asana ticket about "merging" syntax errors coming from monaco and from our own parser, but this turned out to be a sightly complex task mostly because monaco exposes [`getModelMarkers`](https://github.com/Microsoft/monaco-editor/blob/bad3c34056624dca34ac8be5028ae3454172125c/monaco.d.ts#L846) as a module-level function, and we have to query in order to filter errors from different editors.

While this is completely doable, I wanted to provide a quick solution, and prioritize the rest of the work accordingly.