### PR TITLE
Try/catch around user defined event handlers

### DIFF
--- a/packages/haiku-player/src/HaikuComponent.ts
+++ b/packages/haiku-player/src/HaikuComponent.ts
@@ -15,6 +15,7 @@ import manaFlattenTree from './helpers/manaFlattenTree';
 import scopifyElements from './helpers/scopifyElements';
 import SimpleEventEmitter from './helpers/SimpleEventEmitter';
 import upgradeBytecodeInPlace from './helpers/upgradeBytecodeInPlace';
+import consoleErrorOnce from './helpers/consoleErrorOnce';
 
 import Layout3D from './Layout3D';
 import ValueBuilder from './ValueBuilder';
@@ -735,7 +736,12 @@ function bindEventHandler(component, eventHandlerDescriptor, selector, eventName
       component._eventsFired[selector][eventName] =
         event || true;
 
-      eventHandlerDescriptor.original.call(component, event, ...args);
+      try {
+        eventHandlerDescriptor.original.call(component, event, ...args);
+      } catch (exception) {
+        consoleErrorOnce(exception);
+        return 1;
+      }
     }
   };
 }

--- a/packages/haiku-player/src/ValueBuilder.ts
+++ b/packages/haiku-player/src/ValueBuilder.ts
@@ -4,6 +4,7 @@
 
 import HaikuHelpers from './HaikuHelpers';
 import BasicUtils from './helpers/BasicUtils';
+import consoleErrorOnce from './helpers/consoleErrorOnce';
 import {isPreviewMode} from './helpers/interactionModes';
 import parsers from './properties/dom/parsers';
 import schema from './properties/dom/schema';
@@ -804,16 +805,6 @@ ValueBuilder.prototype._clearCachedClusters = function _clearCachedClusters(time
   }
   return this;
 };
-
-const CONSOLE_ERRORS = {};
-
-function consoleErrorOnce(err) {
-  const str = err && err.message.toString();
-  if (!CONSOLE_ERRORS[str]) {
-    CONSOLE_ERRORS[str] = true;
-    console.error(err);
-  }
-}
 
 /**
  * When evaluating expressions written by the user, don't crash everything.

--- a/packages/haiku-player/src/helpers/consoleErrorOnce.ts
+++ b/packages/haiku-player/src/helpers/consoleErrorOnce.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Haiku 2016-2017. All rights reserved.
+ */
+
+function generateLogger() {
+  const CONSOLE_ERRORS = {};
+
+  return function consoleErrorOnce(err) {
+    const str = err && err.message.toString();
+    if (!CONSOLE_ERRORS[str]) {
+      CONSOLE_ERRORS[str] = true;
+      console.error(err);
+    }
+  };
+}
+
+export default generateLogger();


### PR DESCRIPTION
This should be easy to review.

Asana ticket: https://app.asana.com/0/479779791675933/497685546814021

**Notes**

- The user still gets a toast error, I didn't tried to hide it because I think it's useful when haikuing
- I used a closure in `helpers/consoleErrorOnce` but if you think that there are performance implications I can switch into something better.