### PR TITLE
Fix tour positioning

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -27,6 +27,7 @@ import Palette from './components/Palette.js'
 import ActivityMonitor from '../utils/activityMonitor.js'
 import { linkExternalAssetsOnDrop, preventDefaultDrag } from 'haiku-serialization/src/utils/dndHelpers'
 import { HOMEDIR_LOGS_PATH, HOMEDIR_PATH } from 'haiku-serialization/src/utils/HaikuHomeDir'
+import requestElementCoordinates from 'haiku-serialization/src/utils/requestElementCoordinates'
 
 var pkg = require('./../../package.json')
 
@@ -411,19 +412,16 @@ export default class Creator extends React.Component {
   }
 
   handleFindElementCoordinates ({ selector, webview }) {
-    if (webview !== 'creator') { return }
-    console.info('[creator] handleRequestElementCoordinates', selector, webview)
-    try {
-      // TODO: find if there is a better solution to this scape hatch
-      let element = document.querySelector(selector)
-      let { top, left } = element.getBoundingClientRect()
-      if (this.tourChannel && this.envoy && !this.envoy.isInMockMode()) {
-        console.info('[creator] receive element coordinates', selector, top, left)
-        this.tourChannel.receiveElementCoordinates('creator', { top, left })
-      }
-    } catch (exception) {
-      console.error(`[creator] error fetching ${selector} in webview ${webview} (${exception})`)
-    }
+    requestElementCoordinates({
+      currentWebview: 'creator',
+      requestedWebview: webview,
+      selector,
+      shouldNotifyEnvoy:
+        this.tourChannel &&
+        this.envoy &&
+        !this.envoy.isInMockMode(),
+      tourClient: this.tourChannel
+    })
   }
 
   handleFindWebviewCoordinates () {

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -320,7 +320,7 @@ export default class Creator extends React.Component {
 
       window.addEventListener('resize', lodash.throttle(() => {
         // if (tourChannel.isTourActive()) {
-        tourChannel.notifyScreenResize()
+        tourChannel.updateLayout()
         // }
       }), 300)
     })

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -45,6 +45,16 @@ class ProjectBrowser extends React.Component {
     this.loadProjects()
     this.props.envoy.get('tour').then((tourChannel) => {
       this.tourChannel = tourChannel
+
+      // FIXME | HACK: since the project browser now supports scrolling, we
+      // must ensure the CheckTutorial project is in viewport when displaying
+      // the OpenProject step in the tour.
+      this.tourChannel.on('tour:requestShowStep', ({component, selector}) => {
+        if (component === 'OpenProject') {
+          const target = document.querySelector(selector)
+          target.parentNode.scrollTop = target.offsetTop - 350
+        }
+      })
     })
   }
 

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -170,7 +170,12 @@ class ProjectBrowser extends React.Component {
     }
 
     return (
-      <div style={DASH_STYLES.projectsWrapper}>
+      <div
+        style={DASH_STYLES.projectsWrapper}
+        onScroll={lodash.throttle(() => {
+          this.tourChannel.updateLayout()
+        }, 50)}
+      >
         {this.state.projectsList.map((projectObject, index) => (
           <ProjectThumbnail
             key={projectObject.projectName}

--- a/packages/haiku-creator/src/react/components/SideBar.js
+++ b/packages/haiku-creator/src/react/components/SideBar.js
@@ -100,7 +100,7 @@ class SideBar extends React.Component {
 
   render () {
     return (
-      <div style={STYLES.container} className='layout-box'>
+      <div style={STYLES.container} className='layout-box' id='sidebar'>
         <div style={[STYLES.bar, {zIndex: 1, paddingLeft: this.state.isFullscreen ? 15 : 82}]} className='frame'>
           <LogoMiniSVG />
           <button id='go-to-dashboard' key='dashboard' onClick={() => { this.goToDashboard() }}

--- a/packages/haiku-creator/src/react/components/Tooltip.js
+++ b/packages/haiku-creator/src/react/components/Tooltip.js
@@ -56,7 +56,7 @@ STYLES.TOP = {
     flexDirection: 'column-reverse'
   },
   children: {
-    bottom: 45
+    bottom: -35
   },
   spotlight: {
     top: -40

--- a/packages/haiku-creator/src/react/components/Tooltip.js
+++ b/packages/haiku-creator/src/react/components/Tooltip.js
@@ -99,8 +99,19 @@ STYLES.RIGHT = {
   }
 }
 
-export default function ({ coordinates, offset, spotlightRadius, display, children, next, finish, stepData, waitUserAction }) {
-  let { top, left } = coordinates
+function Tooltip (props) {
+  const {
+    coordinates,
+    offset,
+    spotlightRadius,
+    display,
+    children,
+    next,
+    finish,
+    stepData,
+    waitUserAction
+  } = props
+  let {top, left} = coordinates
   let circleDisplay = 'none'
   let positionStyles = STYLES[display.toUpperCase()] || {}
   let spotlightExtraStyles = {}
@@ -112,26 +123,31 @@ export default function ({ coordinates, offset, spotlightRadius, display, childr
   }
 
   if (display === 'left') {
-    top = top + 10
-    left = coordinates.left - STYLES.circle.width - 20
+    top = top + (coordinates.height / 2)
+    left = coordinates.left - STYLES.circle.width
+
+    if (left - 350 <= 10) {
+      return Tooltip({...props, display: 'top'})
+    }
   }
 
   if (display === 'right') {
-    top = top + 10
-    left = coordinates.left + 20
+    top = top + (coordinates.height / 2)
+    left = coordinates.left + STYLES.circle.width + coordinates.width
   }
 
   if (display === 'bottom') {
-    top = top + 10
+    top = top + coordinates.height + STYLES.circle.width
+    left = left + (coordinates.width / 2)
   }
 
   if (display === 'top') {
-    top = top - 10
-  }
+    top = coordinates.top - STYLES.circle.width
+    left = left + (coordinates.width / 2)
 
-  if (typeof top === 'number') {
-    top = top + offset.top
-    left = left + offset.left
+    if (top - 350 <= 10) {
+      return Tooltip({...props, display: 'bottom'})
+    }
   }
 
   if (spotlightRadius !== 'default') {
@@ -139,9 +155,20 @@ export default function ({ coordinates, offset, spotlightRadius, display, childr
     spotlightExtraStyles.height = spotlightRadius
   }
 
+  if (typeof top === 'number') {
+    top = top + offset.top
+    left = left + offset.left
+  }
+
   return (
     <div style={{top, left, ...STYLES.container, ...positionStyles.container}}>
-      <div style={{...STYLES.spotlight, ...positionStyles.spotlight, ...spotlightExtraStyles}} />
+      <div
+        style={{
+          ...STYLES.spotlight,
+          ...positionStyles.spotlight,
+          ...spotlightExtraStyles
+        }}
+      />
 
       <div style={{...STYLES.circle, display: circleDisplay}}>
         <div style={STYLES.circleInner} />
@@ -151,20 +178,38 @@ export default function ({ coordinates, offset, spotlightRadius, display, childr
           {children}
 
           {/* Don't show buttons on the first and last slides */}
-          {stepData.current > 0 && stepData.current < stepData.total &&
-            <div style={{display: 'flex', justifyContent: 'space-between', marginTop: 30}}>
-              <button style={TOUR_STYLES.btnSecondary} onClick={() => finish(true, true)}>Skip Tutorial</button>
-              <div>
-                <span style={{marginRight: 10}}>{stepData.current} of {stepData.total}</span>
-                {/* Show the next button if we aren't waiting for user interaction */}
-                {!waitUserAction &&
-                  <button style={TOUR_STYLES.btn} onClick={() => next()}>Next</button>
-                }
+          {stepData.current > 0 &&
+            stepData.current < stepData.total && (
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  marginTop: 30
+                }}
+              >
+                <button
+                  style={TOUR_STYLES.btnSecondary}
+                  onClick={() => finish(true, true)}
+                >
+                  Skip Tutorial
+                </button>
+                <div>
+                  <span style={{marginRight: 10}}>
+                    {stepData.current} of {stepData.total}
+                  </span>
+                  {/* Show the next button if we aren't waiting for user interaction */}
+                  {!waitUserAction && (
+                    <button style={TOUR_STYLES.btn} onClick={() => next()}>
+                      Next
+                    </button>
+                  )}
+                </div>
               </div>
-            </div>
-          }
+            )}
         </div>
       </div>
     </div>
   )
 }
+
+export default Tooltip

--- a/packages/haiku-creator/src/react/components/Tour/Steps/PublishedLink.js
+++ b/packages/haiku-creator/src/react/components/Tour/Steps/PublishedLink.js
@@ -9,7 +9,7 @@ export default function ({ styles, openLink }) {
       <h2 style={styles.heading}>Publishing</h2>
       <div style={styles.text}>
         <p>
-          Once the link generates (give it up to a minute,) share your work with teammates by giving them this link.
+          Once the link generates, share your work with teammates by giving them this link.
         </p>
         <p>
           That page includes not only your latest work, but instructions and code snippets for using your Haiku in any web codebase.

--- a/packages/haiku-creator/src/react/components/Tour/Steps/StatesStart.js
+++ b/packages/haiku-creator/src/react/components/Tour/Steps/StatesStart.js
@@ -9,7 +9,7 @@ export default function ({ styles }) {
       </video>
       <h2 style={styles.heading}>Sketch</h2>
       <div style={styles.text}>
-        <p>Alright, did you notice it change?  (Go ahead and drag the timeline ticker forward in time, otherwise your opacity changes in Step 1 made the check invisible.)</p>
+        <p>All right, did you notice it change?  (Go ahead and drag the timeline ticker forward in time, otherwise your opacity changes in Step 1 made the check invisible.)</p>
         <p>This is a central theme in Haiku—as a designer, you never lose your connection to your work.</p>
         <p>Let's move on to some of Haiku's features for building real apps.  Click on the icon to the left to toggle the State Inspector.</p>
       </div>

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -189,7 +189,7 @@ export class Glass extends React.Component {
       currentWebview: 'glass',
       requestedWebview: webview,
       selector,
-      isMockMode:
+      shouldNotifyEnvoy:
         this.tourClient &&
         this._component._envoyClient &&
         !this._component._envoyClient.isInMockMode(),
@@ -296,7 +296,6 @@ export class Glass extends React.Component {
         } else {
           this.forceUpdate()
         }
-
       } else if (what === 'showEventHandlersEditor') {
         const [{elementUID, options}] = args
         this.setLastSelectedElement(this._component.findElementByComponentId(elementUID))

--- a/packages/haiku-sdk-creator/src/tour/TourHandler.ts
+++ b/packages/haiku-sdk-creator/src/tour/TourHandler.ts
@@ -29,7 +29,7 @@ export class TourHandler implements Tour {
       webview: 'creator',
       component: 'OpenProject',
       display: 'left',
-      offset: {top: 100, left: 0},
+      offset: {top: 0, left: 0},
       spotlightRadius: 400,
       waitUserAction: true,
     },
@@ -38,7 +38,7 @@ export class TourHandler implements Tour {
       webview: 'timeline',
       component: 'OpacityIncrease',
       display: 'top',
-      offset: {top: 50, left: 20},
+      offset: {top: 0, left: 0},
       spotlightRadius: 8000,
       waitUserAction: true,
     },
@@ -47,7 +47,7 @@ export class TourHandler implements Tour {
       webview: 'timeline',
       component: 'OpacityReduce',
       display: 'top',
-      offset: {top: 50, left: 0},
+      offset: {top: 0, left: 0},
       spotlightRadius: 8000,
       waitUserAction: true,
     },
@@ -56,7 +56,7 @@ export class TourHandler implements Tour {
       webview: 'timeline',
       component: 'CreateTween',
       display: 'top',
-      offset: {top: 50, left: 100},
+      offset: {top: 0, left: 0},
       spotlightRadius: 8000,
       waitUserAction: true,
     },
@@ -65,35 +65,35 @@ export class TourHandler implements Tour {
       webview: 'timeline',
       component: 'Congratulations',
       display: 'top',
-      offset: {top: 50, left: 100},
+      offset: {top: 0, left: 0},
       spotlightRadius: 8000,
       waitUserAction: false,
     },
     {
-      selector: '#stage-mount',
+      selector: '#sidebar',
       webview: 'creator',
       component: 'LibraryStart',
       display: 'right',
-      offset: {top: 220, left: 0},
-      spotlightRadius: 'default',
+      offset: {top: 0, left: 0},
+      spotlightRadius: 1000,
       waitUserAction: true,
     },
     {
-      selector: '#state-inspector',
+      selector: '#sidebar',
       webview: 'creator',
       component: 'StatesStart',
       display: 'right',
-      offset: {top: 220, left: 50},
-      spotlightRadius: 800,
+      offset: {top: 0, left: 0},
+      spotlightRadius: 1000,
       waitUserAction: true,
     },
     {
-      selector: '#add-state-button',
+      selector: '#sidebar',
       webview: 'creator',
       component: 'AddState',
       display: 'right',
-      offset: {top: 220, left: 50},
-      spotlightRadius: 800,
+      offset: {top: 0, left: 0},
+      spotlightRadius: 1000,
       waitUserAction: true,
     },
     {
@@ -101,7 +101,7 @@ export class TourHandler implements Tour {
       webview: 'timeline',
       component: 'ReferenceState',
       display: 'right',
-      offset: {top: 0, left: 120},
+      offset: {top: 0, left: 0},
       spotlightRadius: 'default',
       waitUserAction: false,
     },
@@ -110,7 +110,7 @@ export class TourHandler implements Tour {
       webview: 'timeline',
       component: 'Summonables',
       display: 'right',
-      offset: {top: 0, left: 120},
+      offset: {top: 0, left: 0},
       spotlightRadius: 'default',
       waitUserAction: false,
     },
@@ -119,7 +119,7 @@ export class TourHandler implements Tour {
       webview: 'timeline',
       component: 'NoCodeRequired',
       display: 'right',
-      offset: {top: 0, left: 120},
+      offset: {top: 0, left: 0},
       spotlightRadius: 'default',
       waitUserAction: false,
     },
@@ -127,17 +127,17 @@ export class TourHandler implements Tour {
       selector: '#publish',
       webview: 'creator',
       component: 'Publish',
-      display: 'left',
-      offset: {top: 140, left: -50},
-      spotlightRadius: 'default',
+      display: 'bottom',
+      offset: {top: 0, left: -150},
+      spotlightRadius: 900,
       waitUserAction: true,
     },
     {
       selector: '.Popover',
       webview: 'creator',
       component: 'PublishedLink',
-      display: 'left',
-      offset: {top: 260, left: -150},
+      display: 'bottom',
+      offset: {top: 150, left: -150},
       spotlightRadius: 900,
       waitUserAction: false,
     },
@@ -146,7 +146,7 @@ export class TourHandler implements Tour {
       webview: 'creator',
       component: 'Finish',
       display: 'bottom',
-      offset: {top: 50, left: 0},
+      offset: {top: 0, left: 0},
       spotlightRadius: 'default',
       waitUserAction: true,
     },
@@ -219,8 +219,9 @@ export class TourHandler implements Tour {
     const origin = this.webviewData[webview] || fallbackPosition;
     const top = origin.top + position.top;
     const left =  origin.left + position.left;
+    const {width, height} = position;
 
-    this.requestShowStep(state, {top, left});
+    this.requestShowStep(state, {top, left, width, height});
   }
 
   receiveWebviewCoordinates(webview: string, coordinates: ClientBoundingRect) {
@@ -244,7 +245,7 @@ export class TourHandler implements Tour {
     if ((!didTakeTour() && !this.isActive) || force) {
       this.currentStep = 0;
       this.isActive = true;
-      this.requestShowStep({...this.states[this.currentStep]}, {top: '40%', left: '50%'});
+      this.requestShowStep({...this.states[this.currentStep]}, {top: '40%', left: '50%', width: 0, height: 0});
     }
   }
 

--- a/packages/haiku-sdk-creator/src/tour/TourHandler.ts
+++ b/packages/haiku-sdk-creator/src/tour/TourHandler.ts
@@ -228,7 +228,7 @@ export class TourHandler implements Tour {
     this.renderCurrentStepAgain();
   }
 
-  notifyScreenResize() {
+  updateLayout() {
     if (this.currentStep > 0) {
       this.shouldRenderAgain = true;
     }

--- a/packages/haiku-sdk-creator/src/tour/index.ts
+++ b/packages/haiku-sdk-creator/src/tour/index.ts
@@ -3,7 +3,7 @@ export interface Tour {
   hide(): MaybeAsync<void>;
   start(force?: boolean): MaybeAsync<void>;
   finish(createFile?: boolean): MaybeAsync<void>;
-  notifyScreenResize(): MaybeAsync<void>;
+  updateLayout(): MaybeAsync<void>;
   receiveElementCoordinates(webview: string, position: ClientBoundingRect): MaybeAsync<void>;
   receiveWebviewCoordinates(webview: string, coordinates: ClientBoundingRect): MaybeAsync<void>;
 }

--- a/packages/haiku-sdk-creator/src/tour/index.ts
+++ b/packages/haiku-sdk-creator/src/tour/index.ts
@@ -13,7 +13,7 @@ export interface TourState {
   webview: string;
   component: string;
   display: string;
-  offset: ClientBoundingRect;
+  offset: object;
   spotlightRadius: number|string;
   waitUserAction: boolean;
 }
@@ -21,6 +21,8 @@ export interface TourState {
 export interface ClientBoundingRect {
   top: number|string;
   left: number|string;
+  width: number|string;
+  height: number|string;
 }
 
 export type MaybeAsync<T> = T | Promise<T>;

--- a/packages/haiku-serialization/src/utils/requestElementCoordinates.js
+++ b/packages/haiku-serialization/src/utils/requestElementCoordinates.js
@@ -1,5 +1,5 @@
 module.exports = function requestElementCoordinates (
-  {currentWebview, requestedWebview, selector, isMockMode, tourClient},
+  {currentWebview, requestedWebview, selector, shouldNotifyEnvoy, tourClient},
   maxNumberOfTries = 15,
   currentNumberOfTries = 0
 ) {
@@ -14,15 +14,15 @@ module.exports = function requestElementCoordinates (
   let element = document.querySelector(selector)
 
   if (element) {
-    let {top, left} = element.getBoundingClientRect()
-    if (isMockMode) {
+    let {top, left, width, height} = element.getBoundingClientRect()
+    if (shouldNotifyEnvoy) {
       console.info(
         `[${currentWebview}] receive element coordinates`,
         selector,
         top,
         left
       )
-      tourClient.receiveElementCoordinates(currentWebview, {top, left})
+      tourClient.receiveElementCoordinates(currentWebview, {top, left, width, height})
     }
   } else {
     // If we didn't find an element, try again in 300ms

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -293,7 +293,7 @@ class Timeline extends React.Component {
       currentWebview: 'timeline',
       requestedWebview: webview,
       selector,
-      isMockMode:
+      shouldNotifyEnvoy:
         this.tourClient &&
         this.component._envoyClient &&
         !this.component._envoyClient.isInMockMode(),


### PR DESCRIPTION
**About**

This is a medium-sized pr, should take around 10 minutes to review

Asana ticket: https://app.asana.com/0/479779791675933/498466015939025

**What**

- Tooltip.js (needs a better name) accepts a prop that instructs the component where to place the tooltip (`top`, `bottom`, `left`, `right`), this adds logic to detect if the tooltip is going to be off of the screen and auto-position the tooltip accordingly. Ideally we should iterate over this and accept an array of preferred positions instead of determining by guessing.
- Add logic to re-render the tour on scroll
- Add logic to auto-scroll to CheckTutorial if the project is below the fold

![2017-12-14-12_27_45-compressor](https://user-images.githubusercontent.com/4419992/34000299-9c7fc8da-e0cb-11e7-8fd7-3988430eaf60.gif)
