### PR TITLE
hack: Disable timeline shift key behaviors behind a feature flag.

### DIFF
--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -1,5 +1,8 @@
 {
   "LottieExportInGlobalMenu": {
     "development": true
+  },
+  "TimelineShiftKeyBehaviors": {
+    "development": true
   }
 }

--- a/packages/haiku-common/src/experiments/index.ts
+++ b/packages/haiku-common/src/experiments/index.ts
@@ -9,6 +9,7 @@ import {getExperimentConfig} from './config';
  */
 export enum Experiment {
   LottieExportInGlobalMenu = 'LottieExportInGlobalMenu',
+  TimelineShiftKeyBehaviors = 'TimelineShiftKeyBehaviors',
 }
 
 /**

--- a/packages/haiku-timeline/package.json
+++ b/packages/haiku-timeline/package.json
@@ -34,6 +34,7 @@
     "color": "1.0.3",
     "decamelize": "1.2.0",
     "haiku-bytecode": "HaikuTeam/bytecode.git",
+    "haiku-common": "HaikuTeam/common.git",
     "haiku-fs-extra": "HaikuTeam/node-fs-extra.git#master-haiku",
     "haiku-serialization": "HaikuTeam/serialization.git",
     "lodash": "4.17.4",

--- a/packages/haiku-timeline/src/components/Globals.js
+++ b/packages/haiku-timeline/src/components/Globals.js
@@ -1,3 +1,5 @@
+import { experimentIsEnabled, Experiment } from 'haiku-common/lib/experiments';
+
 const globals = {
   mouse: { x: 0, y: 0 },
   // Control and shift keys are managed from Timeline.js
@@ -16,7 +18,9 @@ window.addEventListener('keyup', (keyupEvent) => {
 })
 
 window.addEventListener('keydown', (keydownEvent) => {
-  if (keydownEvent.which === 16) globals.isShiftKeyDown = true
+  if (keydownEvent.which === 16 && experimentIsEnabled(Experiment.TimelineShiftKeyBehaviors)) {
+    globals.isShiftKeyDown = true
+  }
   if (keydownEvent.which === 17) globals.isControlKeyDown = true
 })
 

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -3,6 +3,7 @@ import Color from 'color'
 import lodash from 'lodash'
 import { DraggableCore } from 'react-draggable'
 
+import { experimentIsEnabled, Experiment } from 'haiku-common/lib/experiments';
 import ActiveComponent from 'haiku-serialization/src/bll/ActiveComponent'
 import TimelineModel from 'haiku-serialization/src/bll/Timeline'
 import Row from 'haiku-serialization/src/bll/Row'
@@ -321,7 +322,7 @@ class Timeline extends React.Component {
       // case 32: //space
       case 37: // left
         if (this.state.isCommandKeyDown) {
-          if (this.state.isShiftKeyDown) {
+          if (this.state.isShiftKeyDown && experimentIsEnabled(Experiment.TimelineShiftKeyBehaviors)) {
             this.component.getCurrentTimeline().setVisibleFrameRange(0, this.component.getCurrentTimeline().getRightFrameEndpoint())
             return this.component.getCurrentTimeline().updateCurrentFrame(0)
           } else {

--- a/packages/haiku-timeline/yarn.lock
+++ b/packages/haiku-timeline/yarn.lock
@@ -2509,6 +2509,10 @@ haiku-bytecode@HaikuTeam/bytecode.git:
     svg-parser "1.0.5"
     to-style "1.3.3"
 
+haiku-common@HaikuTeam/common.git:
+  version "2.3.10"
+  resolved "git+ssh://git@github.com/HaikuTeam/common.git#285698df9e792c242e953414f7cecb454b86af1d"
+
 haiku-fs-extra@HaikuTeam/node-fs-extra.git#master-haiku:
   version "1.0.0"
   resolved "https://codeload.github.com/HaikuTeam/node-fs-extra/tar.gz/3a90fa18a472d45071c3dce3b28785fe0ddfa12a"


### PR DESCRIPTION
This change is a fast hack to disable *all* shift-key timeline behaviors (yes, even shift-click to deselect). It's the fastest known working way to get out a build that doesn't have major multiselect bugs. Since the feature flag is easy enough to flip, I'm going to propose rolling a release with this now (i.e. checking it in) so @zackbrown and @taylorpoe can QA a build with this stuff disabled. It should be straightforward to kick off a new build if we find the fix. Meanwhile, I left shift key enabled on dev for attempted fixin'.