### PR TITLE
Fix constant body issues w/multiselect

### DIFF
--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -1344,7 +1344,7 @@ class ActiveComponent extends BaseModel {
     keyframes.forEach((keyframe) => {
       // Only keyframes that have a next keyframe should get the curve assigned,
       // otherwise you'll see a "surprise curve" if you add a next keyframe
-      if (keyframe.next() && keyframe.next()._selected) {
+      if (keyframe.isNextKeyframeSelected()) {
         keyframe.changeCurve(curveName, metadata)
       }
     })

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -92,7 +92,7 @@ class Keyframe extends BaseModel {
     // Since we are dealing with a tween, we can't just check if the keyframe
     // is selected or not, we must peek at the next keyframe, if the next one is
     // selected, we must _potentially_ deselect both (we are in toggle mode)
-    if (this.isSelected() && this.isTransitionSegment() && this.isNextKeyframeSelected()) {
+    if (this.isSelected() && this.isNextKeyframeSelected()) {
       const next = this.next()
       const prev = this.prev()
 

--- a/packages/haiku-timeline/src/components/ConstantBody.js
+++ b/packages/haiku-timeline/src/components/ConstantBody.js
@@ -63,17 +63,23 @@ export default class ConstantBody extends React.Component {
         }}
         onMouseDown={(mouseEvent) => {
           mouseEvent.stopPropagation()
-          const hasMultipleSelectedKeyframes =
-            this.props.timeline.hasMultipleSelectedKeyframes()
-          const skipDeselect =
-            Globals.isShiftKeyDown ||
-            ((Globals.isControlKeyDown || mouseEvent.nativeEvent.which === 3) &&
-              hasMultipleSelectedKeyframes)
 
-          this.props.keyframe.toggleSelect({
-            skipDeselect,
-            selectConstBody: true
-          }, Globals.isShiftKeyDown)
+          const isTriggeringContextMenu =
+            Globals.isControlKeyDown || mouseEvent.nativeEvent.which === 3
+          const skipDeselect = Globals.isShiftKeyDown || isTriggeringContextMenu
+
+          if (isTriggeringContextMenu) {
+            this.props.keyframe.selectSelfAndSurrounds({
+              skipDeselect,
+              selectConstBody: true
+            })
+          } else {
+            this.props.keyframe.toggleSelectSelfAndSurrounds({
+              skipDeselect,
+              selectConstBody: true
+            })
+          }
+
         }}
         style={{
           position: 'absolute',


### PR DESCRIPTION
Should fix the follwing tidkets:

- [Timeline bug: After multi-drag, keyframes didn't get deselected (and got stuck that way)](https://app.asana.com/0/479779791675933/488080510412728)
- [Multi select selecting transitions and applying tweens inconstently](https://app.asana.com/0/479779791675933/501102857337894)

And a couple of extra issues related with ConstantBody.