### PR TITLE
Separate the concepts of `selected` from `active`

### DIFF
--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -1320,9 +1320,19 @@ class ActiveComponent extends BaseModel {
     return this
   }
 
-  deleteSelectedKeyframes (metadata) {
-    const keyframes = this.getSelectedKeyframes()
-    keyframes.forEach((keyframe) => keyframe.delete(metadata))
+  deleteActiveKeyframes (metadata) {
+    const keyframes = this.getActiveKeyframes()
+    keyframes.forEach((keyframe) => {
+      if (!keyframe.isTransitionSegment()) {
+        const prev = keyframe.prev()
+
+        if (prev && prev.isTransitionSegment()) {
+          prev.removeCurve(metadata)
+        }
+      }
+
+      keyframe.delete(metadata)
+    })
     this.deselectAndDeactivateAllKeyframes()
     return this
   }
@@ -1344,27 +1354,27 @@ class ActiveComponent extends BaseModel {
     keyframes.forEach((keyframe) => {
       // Only keyframes that have a next keyframe should get the curve assigned,
       // otherwise you'll see a "surprise curve" if you add a next keyframe
-      if (keyframe.isNextKeyframeSelected()) {
+      if (keyframe.isNextKeyframeActive()) {
         keyframe.changeCurve(curveName, metadata)
       }
     })
     return this
   }
 
-  dragStartSelectedKeyframes (dragData) {
-    const keyframes = this.getSelectedKeyframes()
+  dragStartActiveKeyframes (dragData) {
+    const keyframes = this.getActiveKeyframes()
     keyframes.forEach((keyframe) => keyframe.dragStart(dragData))
     return this
   }
 
-  dragStopSelectedKeyframes (dragData) {
-    const keyframes = this.getSelectedKeyframes()
+  dragStopActiveKeyframes (dragData) {
+    const keyframes = this.getActiveKeyframes()
     keyframes.forEach((keyframe) => keyframe.dragStart(dragData))
     return this
   }
 
-  dragSelectedKeyframes (pxpf, mspf, dragData, metadata) {
-    const keyframes = this.getSelectedKeyframes()
+  dragActiveKeyframes (pxpf, mspf, dragData, metadata) {
+    const keyframes = this.getActiveKeyframes()
     keyframes.forEach((keyframe) => keyframe.drag(pxpf, mspf, dragData, metadata))
     return this
   }
@@ -1912,6 +1922,10 @@ class ActiveComponent extends BaseModel {
 
   getSelectedKeyframes () {
     return Keyframe.where({ component: this, _selected: true })
+  }
+
+  getActiveKeyframes () {
+    return Keyframe.where({ component: this, _activated: true })
   }
 
   getCurrentKeyframes (criteria) {

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -427,6 +427,12 @@ class Timeline extends BaseModel {
     })
   }
 
+  getActiveKeyframes () {
+    return Keyframe.filter((keyframe) => {
+      return keyframe.isActive()
+    })
+  }
+
   hasMultipleSelectedKeyframes () {
     const found = this.getSelectedKeyframes()
     return found.length > 1

--- a/packages/haiku-timeline/src/components/ConstantBody.js
+++ b/packages/haiku-timeline/src/components/ConstantBody.js
@@ -79,7 +79,6 @@ export default class ConstantBody extends React.Component {
               selectConstBody: true
             })
           }
-
         }}
         style={{
           position: 'absolute',

--- a/packages/haiku-timeline/src/components/Globals.js
+++ b/packages/haiku-timeline/src/components/Globals.js
@@ -1,4 +1,4 @@
-import { experimentIsEnabled, Experiment } from 'haiku-common/lib/experiments';
+import { experimentIsEnabled, Experiment } from 'haiku-common/lib/experiments'
 
 const globals = {
   mouse: { x: 0, y: 0 },

--- a/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
+++ b/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
@@ -46,40 +46,39 @@ export default class InvisibleKeyframeDragger extends React.Component {
         onMouseDown={() => {
           // This logic is here to allow keyframes to be dragged without having
           // to select them first.
-          if (this.props.timeline.getSelectedKeyframes().length <= 1 && !Globals.isShiftKeyDown) {
-            this.props.keyframe.select(
-              {skipDeselect: false, directlySelected: true}
+          if (!this.props.keyframe.isActive() && !Globals.isShiftKeyDown) {
+            this.props.keyframe.activate(
+              {skipDeselect: false}
             )
 
             this.performedSelection = true
           }
         }}
         onStart={(dragEvent, dragData) => {
-          this.props.component.dragStartSelectedKeyframes(dragData)
+          this.props.component.dragStartActiveKeyframes(dragData)
         }}
         onStop={(dragEvent, dragData, wasDrag, lastMouseButtonPressed) => {
-          if (wasDrag) {
-            this.props.component.dragStopSelectedKeyframes(dragData)
-          } else if (!this.performedSelection) {
+          if (!wasDrag && !this.performedSelection) {
             const skipDeselect =
               Globals.isShiftKeyDown ||
               (Globals.isControlKeyDown || lastMouseButtonPressed === 3)
 
-            this.props.keyframe.toggleSelect(
+            this.props.keyframe.toggleActive(
               {skipDeselect, directlySelected: true}
             )
           }
 
+          this.props.component.dragStopActiveKeyframes(dragData)
           this.performedSelection = false
         }}
         onDrag={lodash.throttle((dragEvent, dragData) => {
-          this.props.component.dragSelectedKeyframes(frameInfo.pxpf, frameInfo.mspf, dragData, { alias: 'timeline' })
+          this.props.component.dragActiveKeyframes(frameInfo.pxpf, frameInfo.mspf, dragData, { alias: 'timeline' })
         }, THROTTLE_TIME)}>
         <span
           onContextMenu={(ctxMenuEvent) => {
             ctxMenuEvent.stopPropagation()
 
-            this.props.keyframe.select(
+            this.props.keyframe.activate(
               {skipDeselect: this.props.keyframe.isSelected(), directlySelected: true}
             )
 

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -3,7 +3,7 @@ import Color from 'color'
 import lodash from 'lodash'
 import { DraggableCore } from 'react-draggable'
 
-import { experimentIsEnabled, Experiment } from 'haiku-common/lib/experiments';
+import { experimentIsEnabled, Experiment } from 'haiku-common/lib/experiments'
 import ActiveComponent from 'haiku-serialization/src/bll/ActiveComponent'
 import TimelineModel from 'haiku-serialization/src/bll/Timeline'
 import Row from 'haiku-serialization/src/bll/Row'
@@ -232,7 +232,7 @@ class Timeline extends React.Component {
     })
 
     this.addEmitterListener(this.ctxmenu, 'deleteKeyframe', () => {
-      this.component.deleteSelectedKeyframes({ from: 'timeline' })
+      this.component.deleteActiveKeyframes({ from: 'timeline' })
     })
 
     this.addEmitterListener(this.ctxmenu, 'joinKeyframes', (curveName) => {
@@ -344,7 +344,7 @@ class Timeline extends React.Component {
       // case 46: //delete
       // case 13: //enter
       // delete
-      case 8: return this.component.deleteSelectedKeyframes({ from: 'timeline' }) // Only if there are any
+      case 8: return this.component.deleteActiveKeyframes({ from: 'timeline' }) // Only if there are any
       case 16: return this.updateKeyboardState({ isShiftKeyDown: true })
       case 17: return this.updateKeyboardState({ isControlKeyDown: true })
       case 18: return this.updateKeyboardState({ isAltKeyDown: true })

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -127,7 +127,8 @@ export default class TransitionBody extends React.Component {
           // This logic is here to allow transitions to be dragged without having
           // to select them first.
           if (!this.props.preventDragging) {
-            if (this.props.timeline.getSelectedKeyframes().length <= 2 && !Globals.isShiftKeyDown) {
+            // console.log(!(this.props.keyframe.isSelected() && this.props.keyframe.isActive()) && !Globals.isShiftKeyDown)
+            if (!(this.props.keyframe.isSelected() && this.props.keyframe.isActive()) && !Globals.isShiftKeyDown) {
               this.props.keyframe.selectSelfAndSurrounds(
                 {skipDeselect: false, directlySelected: true}
               )

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -127,7 +127,6 @@ export default class TransitionBody extends React.Component {
           // This logic is here to allow transitions to be dragged without having
           // to select them first.
           if (!this.props.preventDragging) {
-            // console.log(!(this.props.keyframe.isSelected() && this.props.keyframe.isActive()) && !Globals.isShiftKeyDown)
             if (!(this.props.keyframe.isSelected() && this.props.keyframe.isActive()) && !Globals.isShiftKeyDown) {
               this.props.keyframe.selectSelfAndSurrounds(
                 {skipDeselect: false, directlySelected: true}
@@ -139,14 +138,12 @@ export default class TransitionBody extends React.Component {
         }}
         onStart={(dragEvent, dragData) => {
           if (!this.props.preventDragging) {
-            this.props.component.dragStartSelectedKeyframes(dragData)
+            this.props.component.dragStartActiveKeyframes(dragData)
           }
         }}
         onStop={(dragEvent, dragData, wasDrag, lastMouseButtonPressed) => {
           if (!this.props.preventDragging) {
-            if (wasDrag) {
-              this.props.component.dragStopSelectedKeyframes(dragData)
-            } else if (!this.performedSelection) {
+            if (!wasDrag && !this.performedSelection) {
               const skipDeselect =
                 Globals.isShiftKeyDown ||
                 (Globals.isControlKeyDown || lastMouseButtonPressed === 3)
@@ -155,11 +152,12 @@ export default class TransitionBody extends React.Component {
             }
           }
 
+          this.props.component.dragStopActiveKeyframes(dragData)
           this.performedSelection = false
         }}
         onDrag={lodash.throttle((dragEvent, dragData) => {
           if (!this.props.preventDragging) {
-            this.props.component.dragSelectedKeyframes(frameInfo.pxpf, frameInfo.mspf, dragData, { alias: 'timeline' })
+            this.props.component.dragActiveKeyframes(frameInfo.pxpf, frameInfo.mspf, dragData, { alias: 'timeline' })
           }
         }, THROTTLE_TIME)}
         onContextMenu>


### PR DESCRIPTION
Most of our problems come from the mix of those two used everywhere,
after this, we are using `selected` only to deal with curves.

It surely needs better naming, but this is a start.

Rules:

- If a keyframe has a curve, and it's selected, the curve is
highlighted
- If a keyframe has a curve and it's active, only the keyframe
is highlighted

I used `selected` because of legacy compatibility with drag&drop,
but we must change that