### PR TITLE
Enable the "Next" button in all tutorial steps

### DIFF
--- a/packages/haiku-creator/src/react/components/ProjectThumbnail.js
+++ b/packages/haiku-creator/src/react/components/ProjectThumbnail.js
@@ -43,6 +43,7 @@ class ProjectThumbnail extends React.Component {
         </div>
         <div
           key='scrim'
+          className='js-utility-project-launcher'
           style={[
             DASH_STYLES.scrim,
             (this.state.isMenuActive || this.state.isHovered) && {opacity: 1}

--- a/packages/haiku-creator/src/react/components/Tour/Tour.js
+++ b/packages/haiku-creator/src/react/components/Tour/Tour.js
@@ -74,7 +74,16 @@ class Tour extends React.Component {
   }
 
   next () {
-    this.tourChannel.next()
+    if (this.state.stepData.current === 1) {
+      const tutorialOpener =
+        document.querySelector(`${this.state.selector} .js-utility-project-launcher`)
+
+      if (tutorialOpener) {
+        tutorialOpener.click()
+      }
+    } else {
+      this.tourChannel.next()
+    }
   }
 
   finish (createFile, skipped) {

--- a/packages/haiku-sdk-creator/src/tour/TourHandler.ts
+++ b/packages/haiku-sdk-creator/src/tour/TourHandler.ts
@@ -31,7 +31,7 @@ export class TourHandler implements Tour {
       display: 'left',
       offset: {top: 0, left: 0},
       spotlightRadius: 400,
-      waitUserAction: true,
+      waitUserAction: false,
     },
     {
       selector: '.gauge-time-readout',
@@ -40,7 +40,7 @@ export class TourHandler implements Tour {
       display: 'top',
       offset: {top: 80, left: 50},
       spotlightRadius: 8000,
-      waitUserAction: true,
+      waitUserAction: false,
     },
     {
       selector: '.gauge-time-readout',
@@ -49,7 +49,7 @@ export class TourHandler implements Tour {
       display: 'top',
       offset: {top: 80, left: 50},
       spotlightRadius: 8000,
-      waitUserAction: true,
+      waitUserAction: false,
     },
     {
       selector: '.gauge-time-readout',
@@ -58,7 +58,7 @@ export class TourHandler implements Tour {
       display: 'top',
       offset: {top: 80, left: 50},
       spotlightRadius: 8000,
-      waitUserAction: true,
+      waitUserAction: false,
     },
     {
       selector: '.gauge-time-readout',
@@ -76,7 +76,7 @@ export class TourHandler implements Tour {
       display: 'right',
       offset: {top: 0, left: 0},
       spotlightRadius: 1000,
-      waitUserAction: true,
+      waitUserAction: false,
     },
     {
       selector: '#sidebar',
@@ -85,7 +85,7 @@ export class TourHandler implements Tour {
       display: 'right',
       offset: {top: 0, left: 0},
       spotlightRadius: 1000,
-      waitUserAction: true,
+      waitUserAction: false,
     },
     {
       selector: '#sidebar',
@@ -94,7 +94,7 @@ export class TourHandler implements Tour {
       display: 'right',
       offset: {top: 0, left: 0},
       spotlightRadius: 1000,
-      waitUserAction: true,
+      waitUserAction: false,
     },
     {
       selector: '.property-input-field',
@@ -148,7 +148,7 @@ export class TourHandler implements Tour {
       display: 'bottom',
       offset: {top: 0, left: 0},
       spotlightRadius: 'default',
-      waitUserAction: true,
+      waitUserAction: false,
     },
   ];
 


### PR DESCRIPTION
As the title says, there are only two "special" steps:

- When the user is asked to open a project, here I included a bit
of extra logic to open the project programatically (hack)
- When the user is asked to publish the project, here I kept the
"Next" button hidden, because the step that follows depends on the
popup modal, if we think we absolutely need the "Next" button here
we can do it, but with a extra bit of logic (we need to talk to
envoy)

This should be easy to review.

Asana ticket: https://app.asana.com/0/479779791675933/504610834323577