### PR TITLE
Fix layout issues with mana-ification of raster data

### DIFF
--- a/packages/haiku-player/src/HaikuComponent.ts
+++ b/packages/haiku-player/src/HaikuComponent.ts
@@ -3,11 +3,12 @@
  */
 
 import Config from './Config';
-import HaikuTimeline from './HaikuTimeline';
 import HaikuGlobal from './HaikuGlobal';
+import HaikuTimeline from './HaikuTimeline';
 import addElementToHashTable from './helpers/addElementToHashTable';
 import applyPropertyToElement from './helpers/applyPropertyToElement';
 import clone from './helpers/clone';
+import consoleErrorOnce from './helpers/consoleErrorOnce';
 import cssQueryList from './helpers/cssQueryList';
 import {isPreviewMode} from './helpers/interactionModes';
 import isMutableProperty from './helpers/isMutableProperty';
@@ -15,7 +16,6 @@ import manaFlattenTree from './helpers/manaFlattenTree';
 import scopifyElements from './helpers/scopifyElements';
 import SimpleEventEmitter from './helpers/SimpleEventEmitter';
 import upgradeBytecodeInPlace from './helpers/upgradeBytecodeInPlace';
-import consoleErrorOnce from './helpers/consoleErrorOnce';
 
 import Layout3D from './Layout3D';
 import ValueBuilder from './ValueBuilder';
@@ -25,7 +25,6 @@ const pkg = require('./../package.json');
 const PLAYER_VERSION = pkg.version;
 const STRING_TYPE = 'string';
 const OBJECT_TYPE = 'object';
-const IDENTITY_MATRIX = Layout3D.createMatrix();
 const HAIKU_ID_ATTRIBUTE = 'haiku-id';
 const DEFAULT_TIMELINE_NAME = 'Default';
 
@@ -1350,18 +1349,8 @@ function computeAndApplyNodeLayout(element, parent) {
   if (parent) {
     const parentSize = parent.layout.computed.size;
 
-    const computedLayout = Layout3D.computeLayout(element.layout, element.layout.matrix, IDENTITY_MATRIX, parentSize);
-
-    if (computedLayout === false) {
-      // False indicates 'don't show
-      element.layout.computed = {
-        invisible: true,
-        size: parentSize || {x: 0, y: 0, z: 0},
-      };
-    } else {
-      // Need to pass some size to children, so if this element doesn't have one, use the parent's.
-      element.layout.computed = computedLayout || {size: parentSize};
-    }
+    element.layout.computed =
+      Layout3D.computeLayout(element.layout, element.layout.matrix, parentSize);
   }
 }
 

--- a/packages/haiku-player/src/Layout3D.ts
+++ b/packages/haiku-player/src/Layout3D.ts
@@ -145,7 +145,7 @@ function multiplyArrayOfMatrices(arrayOfMatrices: number[][]): number[] {
   return product;
 }
 
-function computeLayout(layoutSpec, currentMatrix, parentMatrix, parentsizeAbsoluteIn) {
+function computeLayout(layoutSpec, currentMatrix, parentsizeAbsoluteIn) {
   const parentsizeAbsolute = parentsizeAbsoluteIn || {x: 0, y: 0, z: 0};
 
   if (parentsizeAbsolute.z === undefined || parentsizeAbsolute.z === null) {
@@ -153,16 +153,11 @@ function computeLayout(layoutSpec, currentMatrix, parentMatrix, parentsizeAbsolu
   }
 
   const size = computeSize(layoutSpec, layoutSpec.sizeMode, parentsizeAbsolute);
-
-  const outputNodepad = {} as any;
-  const matrix = computeMatrix(outputNodepad, layoutSpec, currentMatrix, size, parentMatrix, parentsizeAbsolute);
-
-  outputNodepad.size = size;
-  outputNodepad.matrix = matrix;
-  outputNodepad.shown = layoutSpec.shown;
-  outputNodepad.opacity = layoutSpec.opacity;
-
-  return outputNodepad;
+  return {
+    ...layoutSpec,
+    size,
+    matrix: computeMatrix(layoutSpec, currentMatrix, size, parentsizeAbsolute),
+  };
 }
 
 export default {

--- a/packages/haiku-player/src/helpers/isMatrixableTransformArray.ts
+++ b/packages/haiku-player/src/helpers/isMatrixableTransformArray.ts
@@ -1,0 +1,14 @@
+import {transformValueIsEssentiallyInt} from './transformValueIsEssentiallyInt';
+
+export const isMatrixableTransformArray = (transform) => {
+  return transformValueIsEssentiallyInt(transform[2], 0) &&
+    transformValueIsEssentiallyInt(transform[3], 0) &&
+    transformValueIsEssentiallyInt(transform[6], 0) &&
+    transformValueIsEssentiallyInt(transform[7], 0) &&
+    transformValueIsEssentiallyInt(transform[8], 0) &&
+    transformValueIsEssentiallyInt(transform[9], 0) &&
+    transformValueIsEssentiallyInt(transform[10], 1) &&
+    transformValueIsEssentiallyInt(transform[11], 0) &&
+    transformValueIsEssentiallyInt(transform[14], 0) &&
+    transformValueIsEssentiallyInt(transform[15], 1);
+};

--- a/packages/haiku-player/src/helpers/parseCssTransformString.ts
+++ b/packages/haiku-player/src/helpers/parseCssTransformString.ts
@@ -4,7 +4,7 @@
 
 import Layout3D from './../Layout3D';
 import cssMat4 from './../vendor/css-mat4';
-import mat4Decompose from './../vendor/mat4-decompose';
+import mat4Decompose, {DecomposedMat4} from './../vendor/mat4-decompose';
 import math3d from './../vendor/math3d';
 import MathUtils from './MathUtils';
 import parseCssValueString from './parseCssValueString';
@@ -21,7 +21,7 @@ function separate(str) {
 export default function parseCssTransformString(inStr) {
   const out = {};
 
-  if (!inStr || inStr === '') {
+  if (!inStr) {
     return out;
   }
 
@@ -76,12 +76,8 @@ export default function parseCssTransformString(inStr) {
 
       // 2D
       case 'rotate':
-        if (spec.values[0].unit === 'deg') {
-          const converted = MathUtils.degreesToRadians(spec.values[0].value);
-          layout.rotate[2] = converted;
-        } else {
-          layout.rotate[2] = spec.values[0].value;
-        }
+        layout.rotate[2] =
+          spec.values[0].unit === 'deg' ? MathUtils.degreesToRadians(spec.values[0].value) : spec.values[0].value;
         break;
       case 'scale':
         layout.scale[0] = spec.values[0].value;
@@ -128,77 +124,49 @@ export default function parseCssTransformString(inStr) {
     }
 
     // Transfer the layout specification into a full matrix so we can multiply it later
-    const matrix = cssMat4([], layout);
-
-    return matrix;
+    return cssMat4([], layout);
   });
 
   // Note the array reversal - to combine matrices we go in the opposite of the transform sequence
   // I.e. if we transform A->B->C, the multiplication order should be CxBxA
-  const product = Layout3D.multiplyArrayOfMatrices(matrices.reverse());
-
-  // We'll decompose the matrix and make the changes in-place to the vectors in this object
-  const components = {
-    translation: [0, 0, 0],
-    scale: [0, 0, 0],
-    skew: [0, 0, 0],
-    perspective: [0, 0, 0, 1],
-    quaternion: [0, 0, 0, 1],
-    rotation: [0, 0, 0],
-  };
-  mat4Decompose(
-    product,
-    components.translation,
-    components.scale,
-    components.skew,
-    components.perspective,
-    components.quaternion,
-  );
-
-  components.rotation = math3d.getEulerAngles(
-    components.quaternion[0],
-    components.quaternion[1],
-    components.quaternion[2],
-    components.quaternion[3],
-  );
-  components.rotation[0] = MathUtils.degreesToRadians(components.rotation[0]);
-  components.rotation[1] = MathUtils.degreesToRadians(components.rotation[1]);
-  components.rotation[2] = MathUtils.degreesToRadians(components.rotation[2]);
-
-  for (const subkey in components) {
-    for (const idx in components[subkey]) {
-      components[subkey][idx] = parseFloat(components[subkey][idx].toFixed(2));
-    }
+  const decomposed = mat4Decompose(Layout3D.multiplyArrayOfMatrices(matrices.reverse()));
+  if (decomposed === false) {
+    return out;
   }
+
+  const {translation, scale, quaternion} = decomposed as DecomposedMat4;
+
+  const rotation = math3d.getEulerAngles.apply(undefined, quaternion)
+    .map((degrees) => Number(MathUtils.degreesToRadians(degrees).toFixed(2)));
 
   // The reason for the conditional test is we don't want to bother assigning the attribute if it's the default/fallback
   // (keeps the bytecode less noisy if we only include what is really an override)
-  if (components.translation[0] !== 0) {
-    out['translation.x'] = components.translation[0];
+  if (translation[0] !== 0) {
+    out['translation.x'] = translation[0];
   }
-  if (components.translation[1] !== 0) {
-    out['translation.y'] = components.translation[1];
+  if (translation[1] !== 0) {
+    out['translation.y'] = translation[1];
   }
-  if (components.translation[2] !== 0) {
-    out['translation.z'] = components.translation[2];
+  if (translation[2] !== 0) {
+    out['translation.z'] = translation[2];
   }
-  if (components.rotation[0] !== 0) {
-    out['rotation.x'] = components.rotation[0];
+  if (rotation[0] !== 0) {
+    out['rotation.x'] = rotation[0];
   }
-  if (components.rotation[1] !== 0) {
-    out['rotation.y'] = components.rotation[1];
+  if (rotation[1] !== 0) {
+    out['rotation.y'] = rotation[1];
   }
-  if (components.rotation[2] !== 0) {
-    out['rotation.z'] = components.rotation[2];
+  if (rotation[2] !== 0) {
+    out['rotation.z'] = rotation[2];
   }
-  if (components.scale[0] !== 1) {
-    out['scale.x'] = components.scale[0];
+  if (scale[0] !== 1) {
+    out['scale.x'] = scale[0];
   }
-  if (components.scale[1] !== 1) {
-    out['scale.y'] = components.scale[1];
+  if (scale[1] !== 1) {
+    out['scale.y'] = scale[1];
   }
-  if (components.scale[2] !== 1) {
-    out['scale.z'] = components.scale[2];
+  if (scale[2] !== 1) {
+    out['scale.z'] = scale[2];
   }
 
   return out;

--- a/packages/haiku-player/src/helpers/parseCssTransformString.ts
+++ b/packages/haiku-player/src/helpers/parseCssTransformString.ts
@@ -135,6 +135,13 @@ export default function parseCssTransformString(inStr) {
   }
 
   const {translation, scale, quaternion} = decomposed as DecomposedMat4;
+  if (scale.indexOf(0) !== -1) {
+    // In any dimension and axis of rotation, a single scale factor of 0 vanishes to the horizon. We can pick an
+    // arbitrary axis to scale to 0 and use this to describe the layout without loss of effect.
+    return {
+      'scale.x': 0,
+    };
+  }
 
   const rotation = math3d.getEulerAngles.apply(undefined, quaternion)
     .map((degrees) => Number(MathUtils.degreesToRadians(degrees).toFixed(2)));

--- a/packages/haiku-player/src/helpers/parseCssTransformString.ts
+++ b/packages/haiku-player/src/helpers/parseCssTransformString.ts
@@ -96,9 +96,20 @@ export default function parseCssTransformString(inStr) {
 
       // 3D
       case 'rotate3d':
-        layout.rotate[0] = spec.values[0].value;
-        layout.rotate[1] = spec.values[1].value;
-        layout.rotate[2] = spec.values[2].value;
+        if (spec.values.length !== 3) {
+          break;
+        }
+        layout.rotate = spec.values.map((axisSpec) => {
+          if (axisSpec.value === 0) {
+            return 0;
+          }
+
+          if (axisSpec.unit === 'deg') {
+            return MathUtils.degreesToRadians(axisSpec.value);
+          }
+
+          return axisSpec.value;
+        });
         break;
       case 'scale3d':
         layout.scale[0] = spec.values[0].value;

--- a/packages/haiku-player/src/helpers/transformValueIsEssentiallyInt.ts
+++ b/packages/haiku-player/src/helpers/transformValueIsEssentiallyInt.ts
@@ -1,0 +1,5 @@
+/**
+ * Returns true iff a transform value is "essentially" a specified basis int.
+ */
+export const transformValueIsEssentiallyInt =
+  (transformValue: number, basis: number): boolean => Math.abs(transformValue - basis) < 1e-6;

--- a/packages/haiku-player/src/layout/computeMatrix.ts
+++ b/packages/haiku-player/src/layout/computeMatrix.ts
@@ -26,26 +26,9 @@
  * THE SOFTWARE.
  */
 
-export default function computeMatrix(
-  outputNodepad,
-  layoutSpec,
-  currentMatrix,
-  currentsizeAbsolute,
-  parentMatrix,
-  parentsizeAbsolute,
-) {
-  const translationX = layoutSpec.translation.x;
-  const translationY = layoutSpec.translation.y;
-  const translationZ = layoutSpec.translation.z;
-  const orientationX = layoutSpec.orientation.x;
-  const orientationY = layoutSpec.orientation.y;
-  const orientationZ = layoutSpec.orientation.z;
-  const orientationW = layoutSpec.orientation.w;
-  const scaleX = layoutSpec.scale.x;
-  const scaleY = layoutSpec.scale.y;
-  const scaleZ = layoutSpec.scale.z;
-  const alignX = layoutSpec.align.x * parentsizeAbsolute.x;
+export default function computeMatrix(layoutSpec, currentMatrix, currentsizeAbsolute, parentsizeAbsolute) {
   const alignY = layoutSpec.align.y * parentsizeAbsolute.y;
+  const alignX = layoutSpec.align.x * parentsizeAbsolute.x;
   const alignZ = layoutSpec.align.z * parentsizeAbsolute.z;
   const mountPointX = layoutSpec.mount.x * currentsizeAbsolute.x;
   const mountPointY = layoutSpec.mount.y * currentsizeAbsolute.y;
@@ -54,66 +37,44 @@ export default function computeMatrix(
   const originY = layoutSpec.origin.y * currentsizeAbsolute.y;
   const originZ = layoutSpec.origin.z * currentsizeAbsolute.z;
 
-  const wx = orientationW * orientationX;
-  const wy = orientationW * orientationY;
-  const wz = orientationW * orientationZ;
-  const xx = orientationX * orientationX;
-  const yy = orientationY * orientationY;
-  const zz = orientationZ * orientationZ;
-  const xy = orientationX * orientationY;
-  const xz = orientationX * orientationZ;
-  const yz = orientationY * orientationZ;
+  const wx = layoutSpec.orientation.w * layoutSpec.orientation.x;
+  const wy = layoutSpec.orientation.w * layoutSpec.orientation.y;
+  const wz = layoutSpec.orientation.w * layoutSpec.orientation.z;
+  const xx = layoutSpec.orientation.x * layoutSpec.orientation.x;
+  const yy = layoutSpec.orientation.y * layoutSpec.orientation.y;
+  const zz = layoutSpec.orientation.z * layoutSpec.orientation.z;
+  const xy = layoutSpec.orientation.x * layoutSpec.orientation.y;
+  const xz = layoutSpec.orientation.x * layoutSpec.orientation.z;
+  const yz = layoutSpec.orientation.y * layoutSpec.orientation.z;
 
-  const rs0 = (1 - 2 * (yy + zz)) * scaleX;
-  const rs1 = 2 * (xy + wz) * scaleX;
-  const rs2 = 2 * (xz - wy) * scaleX;
-  const rs3 = 2 * (xy - wz) * scaleY;
-  const rs4 = (1 - 2 * (xx + zz)) * scaleY;
-  const rs5 = 2 * (yz + wx) * scaleY;
-  const rs6 = 2 * (xz + wy) * scaleZ;
-  const rs7 = 2 * (yz - wx) * scaleZ;
-  const rs8 = (1 - 2 * (xx + yy)) * scaleZ;
+  const rs0 = (1 - 2 * (yy + zz)) * layoutSpec.scale.x;
+  const rs1 = 2 * (xy + wz) * layoutSpec.scale.x;
+  const rs2 = 2 * (xz - wy) * layoutSpec.scale.x;
+  const rs3 = 2 * (xy - wz) * layoutSpec.scale.y;
+  const rs4 = (1 - 2 * (xx + zz)) * layoutSpec.scale.y;
+  const rs5 = 2 * (yz + wx) * layoutSpec.scale.y;
+  const rs6 = 2 * (xz + wy) * layoutSpec.scale.z;
+  const rs7 = 2 * (yz - wx) * layoutSpec.scale.z;
+  const rs8 = (1 - 2 * (xx + yy)) * layoutSpec.scale.z;
 
   const tx =
     alignX +
-    translationX -
+    layoutSpec.translation.x -
     mountPointX +
     originX -
     (rs0 * originX + rs3 * originY + rs6 * originZ);
   const ty =
     alignY +
-    translationY -
+    layoutSpec.translation.y -
     mountPointY +
     originY -
     (rs1 * originX + rs4 * originY + rs7 * originZ);
   const tz =
     alignZ +
-    translationZ -
+    layoutSpec.translation.z -
     mountPointZ +
     originZ -
     (rs2 * originX + rs5 * originY + rs8 * originZ);
 
-  outputNodepad.align = {x: alignX, y: alignY, z: alignZ};
-  outputNodepad.mount = {x: mountPointX, y: mountPointY, z: mountPointZ};
-  outputNodepad.origin = {x: originX, y: originY, z: originZ};
-  outputNodepad.offset = {x: tx, y: ty, z: tz};
-
-  return [
-    parentMatrix[0] * rs0 + parentMatrix[4] * rs1 + parentMatrix[8] * rs2,
-    parentMatrix[1] * rs0 + parentMatrix[5] * rs1 + parentMatrix[9] * rs2,
-    parentMatrix[2] * rs0 + parentMatrix[6] * rs1 + parentMatrix[10] * rs2,
-    0,
-    parentMatrix[0] * rs3 + parentMatrix[4] * rs4 + parentMatrix[8] * rs5,
-    parentMatrix[1] * rs3 + parentMatrix[5] * rs4 + parentMatrix[9] * rs5,
-    parentMatrix[2] * rs3 + parentMatrix[6] * rs4 + parentMatrix[10] * rs5,
-    0,
-    parentMatrix[0] * rs6 + parentMatrix[4] * rs7 + parentMatrix[8] * rs8,
-    parentMatrix[1] * rs6 + parentMatrix[5] * rs7 + parentMatrix[9] * rs8,
-    parentMatrix[2] * rs6 + parentMatrix[6] * rs7 + parentMatrix[10] * rs8,
-    0,
-    parentMatrix[0] * tx + parentMatrix[4] * ty + parentMatrix[8] * tz,
-    parentMatrix[1] * tx + parentMatrix[5] * ty + parentMatrix[9] * tz,
-    parentMatrix[2] * tx + parentMatrix[6] * ty + parentMatrix[10] * tz,
-    1,
-  ];
+  return [rs0, rs1, rs2, 0, rs3, rs4, rs5, 0, rs6, rs7, rs8, 0, tx, ty, tz, 1];
 }

--- a/packages/haiku-player/src/layout/convertManaLayout.ts
+++ b/packages/haiku-player/src/layout/convertManaLayout.ts
@@ -158,9 +158,13 @@ export default function convertManaLayout(mana) {
       // Strip off the old value which is no longer needed
       delete attributes.transform;
 
-      // If the x/y attributes are present, they can interfere with the transform, so we strip them off
-      delete attributes.x;
-      delete attributes.y;
+      // If the x/y attributes are present, they can interfere with the transform, so we strip them off except in
+      // the case of <image>. <image> has the special behavior that x and y position the image relative to the
+      // origin *before* any transformations are applied.
+      if (node.elementName !== 'image') {
+        delete attributes.x;
+        delete attributes.y;
+      }
     }
   }, null, null);
 

--- a/packages/haiku-player/src/layout/formatTransform.ts
+++ b/packages/haiku-player/src/layout/formatTransform.ts
@@ -25,13 +25,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+import {isMatrixableTransformArray} from '../helpers/isMatrixableTransformArray';
+import {transformValueIsEssentiallyInt} from '../helpers/transformValueIsEssentiallyInt';
+import Layout3D from '../Layout3D';
 
 const TRANSFORM_SUFFIX = ')';
 const TRANSFORM_ZERO = '0';
 const TRANSFORM_COMMA = ',';
 const TRANSFORM_ZILCH = TRANSFORM_ZERO + TRANSFORM_COMMA;
-const TWO = 2;
-const THREE = 3;
 
 export default function formatTransform(transform, format, devicePixelRatio) {
   transform[12] =
@@ -41,11 +42,14 @@ export default function formatTransform(transform, format, devicePixelRatio) {
 
   let prefix;
   let last;
-  if (format === TWO) {
+  if (format === Layout3D.FORMATS.TWO) {
     // Example: matrix(1,0,0,0,0,1)
     // 2d matrix is: matrix(scaleX(),skewY(),skewX(),scaleY(),translateX(),translateY())
     // Modify via: matrix(a,b,c,d,tx,ty) <= matrix3d(a,b,0,0,c,d,0,0,0,0,1,0,tx,ty,0,1)
-    const two = [
+
+    // Note how we set the transform far to two here!
+    // tslint:disable-next-line:no-parameter-reassignment
+    transform = [
       transform[0],
       transform[1],
       transform[4],
@@ -54,44 +58,16 @@ export default function formatTransform(transform, format, devicePixelRatio) {
       transform[13],
     ];
 
-    // Note how we set the transform far to two here!
-    // tslint:disable-next-line:no-param-reassign
-    transform = two;
-
     prefix = 'matrix(';
     last = 5;
-  } else if (format === THREE) {
+  } else {
     // Example: matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,716,243,0,1)
     prefix = 'matrix3d(';
     last = 15;
   }
 
-  prefix += (transform[0] < 0.000001 && transform[0] > -0.000001) ? TRANSFORM_ZILCH : transform[0] + TRANSFORM_COMMA;
-  prefix += (transform[1] < 0.000001 && transform[1] > -0.000001) ? TRANSFORM_ZILCH : transform[1] + TRANSFORM_COMMA;
-  prefix += (transform[2] < 0.000001 && transform[2] > -0.000001) ? TRANSFORM_ZILCH : transform[2] + TRANSFORM_COMMA;
-  prefix += (transform[3] < 0.000001 && transform[3] > -0.000001) ? TRANSFORM_ZILCH : transform[3] + TRANSFORM_COMMA;
-  prefix += (transform[4] < 0.000001 && transform[4] > -0.000001) ? TRANSFORM_ZILCH : transform[4] + TRANSFORM_COMMA;
-  if (last > 5) {
-    prefix += (transform[5] < 0.000001 && transform[5] > -0.000001)
-      ? TRANSFORM_ZILCH : transform[5] + TRANSFORM_COMMA;
-    prefix += (transform[6] < 0.000001 && transform[6] > -0.000001)
-      ? TRANSFORM_ZILCH : transform[6] + TRANSFORM_COMMA;
-    prefix += (transform[7] < 0.000001 && transform[7] > -0.000001)
-      ? TRANSFORM_ZILCH : transform[7] + TRANSFORM_COMMA;
-    prefix += (transform[8] < 0.000001 && transform[8] > -0.000001)
-      ? TRANSFORM_ZILCH : transform[8] + TRANSFORM_COMMA;
-    prefix += (transform[9] < 0.000001 && transform[9] > -0.000001)
-      ? TRANSFORM_ZILCH : transform[9] + TRANSFORM_COMMA;
-    prefix += (transform[10] < 0.000001 && transform[10] > -0.000001)
-      ? TRANSFORM_ZILCH : transform[10] + TRANSFORM_COMMA;
-    prefix += (transform[11] < 0.000001 && transform[11] > -0.000001)
-      ? TRANSFORM_ZILCH : transform[11] + TRANSFORM_COMMA;
-    prefix += (transform[12] < 0.000001 && transform[12] > -0.000001)
-      ? TRANSFORM_ZILCH : transform[12] + TRANSFORM_COMMA;
-    prefix += (transform[13] < 0.000001 && transform[13] > -0.000001)
-      ? TRANSFORM_ZILCH : transform[13] + TRANSFORM_COMMA;
-    prefix += (transform[14] < 0.000001 && transform[14] > -0.000001)
-      ? TRANSFORM_ZILCH : transform[14] + TRANSFORM_COMMA;
+  for (let i = 0; i < last; i += 1) {
+    prefix += transformValueIsEssentiallyInt(transform[i], 0) ? TRANSFORM_ZILCH : transform[i] + TRANSFORM_COMMA;
   }
 
   prefix += transform[last] + TRANSFORM_SUFFIX;

--- a/packages/haiku-player/src/vendor/mat4-decompose/index.ts
+++ b/packages/haiku-player/src/vendor/mat4-decompose/index.ts
@@ -14,11 +14,11 @@ https://github.com/ChromiumWebApps/chromium/blob/master/ui/gfx/transform_util.cc
 http://www.w3.org/TR/css3-transforms/#decomposing-a-3d-matrix
 */
 
-import create from './../gl-mat4/create';
-import glv3cross from './../gl-vec3/cross';
-import glv3dot from './../gl-vec3/dot';
-import glv3length from './../gl-vec3/length';
-import glv3normalize from './../gl-vec3/normalize';
+import create from '../gl-mat4/create';
+import glv3cross from '../gl-vec3/cross';
+import glv3dot from '../gl-vec3/dot';
+import glv3length from '../gl-vec3/length';
+import glv3normalize from '../gl-vec3/normalize';
 import normalize from './normalize';
 
 const vec3 = {
@@ -32,6 +32,7 @@ const tmp = create();
 const row = [[0, 0, 0], [0, 0, 0], [0, 0, 0]];
 const pdum3 = [0, 0, 0];
 
+export const roundVector = (vector: number[]): number[] => vector.map((value) => Number(value.toFixed(2)));
 export type ThreeTuple = [number, number, number];
 export type FourTuple = [number, number, number, number];
 export interface DecomposedMat4 {
@@ -46,18 +47,26 @@ export default function decomposeMat4(matrix): boolean|DecomposedMat4 {
     return false;
   }
 
-  // Next take care of translation
-  const translation = [tmp[12], tmp[13], tmp[14]].map((value) => Number(value.toFixed(2))) as ThreeTuple;
+  const translation = roundVector([tmp[12], tmp[13], tmp[14]]) as ThreeTuple;
 
-  // Now get scale and shear. 'row' is a 3 element array of 3 component vectors
+  // Now get scale. 'row' is a 3 element array of 3 component vectors
   mat3from4(row, tmp);
 
   // Compute scale factor and normalize rows.
-  const scale = [
+  const scale = roundVector([
     vec3.length(row[0]),
     vec3.length(row[1]),
     vec3.length(row[2]),
-  ].map((value) => Number(value.toFixed(2))) as ThreeTuple;
+  ]) as ThreeTuple;
+  // Return early if we have any 0 scale factors.
+  if (scale.indexOf(0) !== -1) {
+    return {
+      translation: [0, 0, 0],
+      scale: [0, 0, 0],
+      quaternion: [0, 0, 0, 0],
+    };
+  }
+
   vec3.normalize(row[0], row[0]);
   vec3.normalize(row[1], row[1]);
   vec3.normalize(row[2], row[2]);

--- a/packages/haiku-player/src/vendor/mat4-decompose/index.ts
+++ b/packages/haiku-player/src/vendor/mat4-decompose/index.ts
@@ -14,16 +14,12 @@ https://github.com/ChromiumWebApps/chromium/blob/master/ui/gfx/transform_util.cc
 http://www.w3.org/TR/css3-transforms/#decomposing-a-3d-matrix
 */
 
-import normalize from './normalize';
 import create from './../gl-mat4/create';
-import clone from './../gl-mat4/clone';
-import determinant from './../gl-mat4/determinant';
-import invert from './../gl-mat4/invert';
-import transpose from './../gl-mat4/transpose';
+import glv3cross from './../gl-vec3/cross';
+import glv3dot from './../gl-vec3/dot';
 import glv3length from './../gl-vec3/length';
 import glv3normalize from './../gl-vec3/normalize';
-import glv3dot from './../gl-vec3/dot';
-import glv3cross from './../gl-vec3/cross';
+import normalize from './normalize';
 
 const vec3 = {
   length: glv3length,
@@ -33,119 +29,38 @@ const vec3 = {
 };
 
 const tmp = create();
-const perspectiveMatrix = create();
-const tmpVec4 = [0, 0, 0, 0];
 const row = [[0, 0, 0], [0, 0, 0], [0, 0, 0]];
 const pdum3 = [0, 0, 0];
 
-export default function decomposeMat4(
-  matrix,
-  translation,
-  scale,
-  skew,
-  perspective,
-  quaternion,
-) {
-  if (!translation) {
-    translation = [0, 0, 0];
-  }
-  if (!scale) {
-    scale = [0, 0, 0];
-  }
-  if (!skew) {
-    skew = [0, 0, 0];
-  }
-  if (!perspective) {
-    perspective = [0, 0, 0, 1];
-  }
-  if (!quaternion) {
-    quaternion = [0, 0, 0, 1];
-  }
+export type ThreeTuple = [number, number, number];
+export type FourTuple = [number, number, number, number];
+export interface DecomposedMat4 {
+  translation: ThreeTuple;
+  scale: ThreeTuple;
+  quaternion: FourTuple;
+}
 
+export default function decomposeMat4(matrix): boolean|DecomposedMat4 {
   // normalize, if not possible then bail out early
   if (!normalize(tmp, matrix)) {
     return false;
   }
 
-  // perspectiveMatrix is used to solve for perspective, but it also provides
-  // an easy way to test for singularity of the upper 3x3 component.
-  clone(perspectiveMatrix);
-
-  perspectiveMatrix[3] = 0;
-  perspectiveMatrix[7] = 0;
-  perspectiveMatrix[11] = 0;
-  perspectiveMatrix[15] = 1;
-
-  // If the perspectiveMatrix is not invertible, we are also unable to
-  // decompose, so we'll bail early. Constant taken from SkMatrix44::invert.
-  if (Math.abs(Number(determinant(perspectiveMatrix) < 1e-8))) {
-    return false;
-  }
-
-  const a03 = tmp[3];
-  const a13 = tmp[7];
-  const a23 = tmp[11];
-  const a30 = tmp[12];
-  const a31 = tmp[13];
-  const a32 = tmp[14];
-  const a33 = tmp[15];
-
-  // First, isolate perspective.
-  if (a03 !== 0 || a13 !== 0 || a23 !== 0) {
-    tmpVec4[0] = a03;
-    tmpVec4[1] = a13;
-    tmpVec4[2] = a23;
-    tmpVec4[3] = a33;
-
-    // Solve the equation by inverting perspectiveMatrix and multiplying
-    // rightHandSide by the inverse.
-    // resuing the perspectiveMatrix here since it's no longer needed
-    const ret = invert(perspectiveMatrix, perspectiveMatrix);
-    if (!ret) {
-      return false;
-    }
-    transpose(perspectiveMatrix, perspectiveMatrix);
-
-    // multiply by transposed inverse perspective matrix, into perspective vec4
-    vec4multMat4(perspective, tmpVec4, perspectiveMatrix);
-  } else {
-    // no perspective
-    perspective[0] = perspective[1] = perspective[2] = 0;
-    perspective[3] = 1;
-  }
-
   // Next take care of translation
-  translation[0] = a30;
-  translation[1] = a31;
-  translation[2] = a32;
+  const translation = [tmp[12], tmp[13], tmp[14]].map((value) => Number(value.toFixed(2))) as ThreeTuple;
 
   // Now get scale and shear. 'row' is a 3 element array of 3 component vectors
   mat3from4(row, tmp);
 
-  // Compute X scale factor and normalize first row.
-  scale[0] = vec3.length(row[0]);
+  // Compute scale factor and normalize rows.
+  const scale = [
+    vec3.length(row[0]),
+    vec3.length(row[1]),
+    vec3.length(row[2]),
+  ].map((value) => Number(value.toFixed(2))) as ThreeTuple;
   vec3.normalize(row[0], row[0]);
-
-  // Compute XY shear factor and make 2nd row orthogonal to 1st.
-  skew[0] = vec3.dot(row[0], row[1]);
-  combine(row[1], row[1], row[0], 1.0, -skew[0]);
-
-  // Now, compute Y scale and normalize 2nd row.
-  scale[1] = vec3.length(row[1]);
   vec3.normalize(row[1], row[1]);
-  skew[0] /= scale[1];
-
-  // Compute XZ and YZ shears, orthogonalize 3rd row
-  skew[1] = vec3.dot(row[0], row[2]);
-  combine(row[2], row[2], row[0], 1.0, -skew[1]);
-  skew[2] = vec3.dot(row[1], row[2]);
-  combine(row[2], row[2], row[1], 1.0, -skew[2]);
-
-  // Next, get Z scale and normalize 3rd row.
-  scale[2] = vec3.length(row[2]);
   vec3.normalize(row[2], row[2]);
-  skew[1] /= scale[2];
-  skew[2] /= scale[2];
 
   // At this point, the matrix (in rows) is orthonormal.
   // Check for a coordinate system flip.  If the determinant
@@ -161,14 +76,12 @@ export default function decomposeMat4(
   }
 
   // Now, get the rotations out
-  quaternion[0] =
-    0.5 * Math.sqrt(Math.max(1 + row[0][0] - row[1][1] - row[2][2], 0));
-  quaternion[1] =
-    0.5 * Math.sqrt(Math.max(1 - row[0][0] + row[1][1] - row[2][2], 0));
-  quaternion[2] =
-    0.5 * Math.sqrt(Math.max(1 - row[0][0] - row[1][1] + row[2][2], 0));
-  quaternion[3] =
-    0.5 * Math.sqrt(Math.max(1 + row[0][0] + row[1][1] + row[2][2], 0));
+  const quaternion: FourTuple = [
+    0.5 * Math.sqrt(Math.max(1 + row[0][0] - row[1][1] - row[2][2], 0)),
+    0.5 * Math.sqrt(Math.max(1 - row[0][0] + row[1][1] - row[2][2], 0)),
+    0.5 * Math.sqrt(Math.max(1 - row[0][0] - row[1][1] + row[2][2], 0)),
+    0.5 * Math.sqrt(Math.max(1 + row[0][0] + row[1][1] + row[2][2], 0)),
+  ];
 
   if (row[2][1] > row[1][2]) {
     quaternion[0] = -quaternion[0];
@@ -179,20 +92,8 @@ export default function decomposeMat4(
   if (row[1][0] > row[0][1]) {
     quaternion[2] = -quaternion[2];
   }
-  return true;
-}
 
-// will be replaced by gl-vec4 eventually
-function vec4multMat4(out, a, m) {
-  const x = a[0];
-  const y = a[1];
-  const z = a[2];
-  const w = a[3];
-  out[0] = m[0] * x + m[4] * y + m[8] * z + m[12] * w;
-  out[1] = m[1] * x + m[5] * y + m[9] * z + m[13] * w;
-  out[2] = m[2] * x + m[6] * y + m[10] * z + m[14] * w;
-  out[3] = m[3] * x + m[7] * y + m[11] * z + m[15] * w;
-  return out;
+  return {translation, scale, quaternion};
 }
 
 // gets upper-left of a 4x4 matrix into a 3x3 of vectors
@@ -208,10 +109,4 @@ function mat3from4(out, mat4x4) {
   out[2][0] = mat4x4[8];
   out[2][1] = mat4x4[9];
   out[2][2] = mat4x4[10];
-}
-
-function combine(out, a, b, scale1, scale2) {
-  out[0] = a[0] * scale1 + b[0] * scale2;
-  out[1] = a[1] * scale1 + b[1] * scale2;
-  out[2] = a[2] * scale1 + b[2] * scale2;
 }

--- a/packages/haiku-player/test/unit/Layout3D.computeLayout.test.js
+++ b/packages/haiku-player/test/unit/Layout3D.computeLayout.test.js
@@ -2,8 +2,6 @@ var test = require('tape');
 var Layout3D = require('./../../lib/Layout3D').default;
 
 test('Layout3D.computeLayout', function (t) {
-  t.plan(1);
-
   const args1 = [
     {
       shown: true,
@@ -21,21 +19,17 @@ test('Layout3D.computeLayout', function (t) {
       sizeAbsolute: {x: 0, y: 0, z: 0}
     },
     [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
-    [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
     {x: 852, y: 839, z: 0}
   ];
 
-  t.deepEqual(
-    Layout3D.computeLayout(...args1),
-    {
-      align: {x: 0, y: 0, z: 0},
-      matrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 33, 0, 0, 1],
-      mount: {x: 0, y: 0, z: 0},
-      offset: {x: 33, y: 0, z: 0},
-      opacity: 1,
-      origin: {x: 0, y: 0, z: 0},
-      shown: true,
-      size: {x: 426, y: 839, z: 0},
-    }
-  );
+  const {align, matrix, mount, opacity, origin, shown, size} = Layout3D.computeLayout(...args1);
+
+  t.deepEqual(align, {x: 0, y: 0, z: 0});
+  t.deepEqual(matrix, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 33, 0, 0, 1]);
+  t.deepEqual(mount, {x: 0, y: 0, z: 0});
+  t.equal(opacity, 1);
+  t.deepEqual(origin, {x: 0, y: 0, z: 0});
+  t.true(shown);
+  t.deepEqual(size, {x: 426, y: 839, z: 0});
+  t.end();
 });

--- a/packages/haiku-player/test/unit/layout.convertManaLayout.test.js
+++ b/packages/haiku-player/test/unit/layout.convertManaLayout.test.js
@@ -558,14 +558,44 @@ test('layout.convertManaLayout', function (t) {
           }
         ]
       }
+    ],
+    // Generic elements should see their x and y attributes stripped off.
+    [
+      {
+        elementName: 'svg',
+        attributes: { x: '10', y: '20', transform: 'translate(10)' },
+        children: []
+      },
+      {
+        elementName: 'svg',
+        attributes: {
+          'translation.x': 10,
+        },
+        children: []
+      }
+    ],
+    // Image elements should preserve their x and y attributes.
+    [
+      {
+        elementName: 'image',
+        attributes: { x: '10', y: '20', transform: 'translate(10)' },
+        children: []
+      },
+      {
+        elementName: 'image',
+        attributes: {
+          'x': '10',
+          'y': '20',
+          'translation.x': 10,
+        },
+        children: []
+      }
     ]
   ]
 
   t.plan(data.length)
 
-  data.forEach(datum => {
-    var a = JSON.stringify(convertManaLayout(datum[0]))
-    var b = JSON.stringify(datum[1])
-    t.equal(a, b)
+  data.forEach(([input, output]) => {
+    t.deepEqual(convertManaLayout(input), output)
   })
 })

--- a/packages/haiku-player/test/unit/layout.parseCssTransformString.test.js
+++ b/packages/haiku-player/test/unit/layout.parseCssTransformString.test.js
@@ -38,14 +38,7 @@ test('layout.parseCssTransformString', function (t) {
     [
       'matrix3d(1,0,0,.1,-0.2,-.22,30000,1,0,0,0,1,0.2,0,0,1) translate3d(10px,20,20) matrix(0,6,4,3,2.2,0) scale3d(0,0,0) rotate3d(0,0.5,0,0) rotateZ(1.2);',
       {
-        'translation.x': 0.2,
-        'translation.y': -0.1,
-        'translation.z': 14211.27,
-        'rotation.y': 1.57,
-        'rotation.z': 1.57,
-        'scale.x': 0,
-        'scale.y': 0,
-        'scale.z': 0
+        "scale.x": 0
       }
     ],
     [

--- a/packages/haiku-player/test/unit/layout.parseCssTransformString.test.js
+++ b/packages/haiku-player/test/unit/layout.parseCssTransformString.test.js
@@ -36,6 +36,49 @@ test('layout.parseCssTransformString', function (t) {
     ],
     ['rotate(217) rotate(-32) rotate(56)', { 'rotation.z': 4.21 }],
     [
+      'matrix3d(1.5,0,0,0,0,1.5,0,0,0,0,1.5,0,1,1,1,1);',
+      {
+        "scale.x": 1.5,
+        "scale.y": 1.5,
+        "scale.z": 1.5,
+        "translation.x": 1,
+        "translation.y": 1,
+        "translation.z": 1
+      }
+    ],
+    [
+      'matrix(1.5,0,0,1.5,1,1);',
+      {
+        "scale.x": 1.5,
+        "scale.y": 1.5,
+        "translation.x": 1,
+        "translation.y": 1
+      }
+    ],
+    [
+      'translate3d(1,2,3);',
+      {
+        "translation.x": 1,
+        "translation.y": 2,
+        "translation.z": 3
+      }
+    ],
+    [
+      'scale3d(1,2,3);',
+      {
+        "scale.y": 2,
+        "scale.z": 3
+      }
+    ],
+    [
+      'rotate3d(0,90deg,120deg);',
+      {
+        "rotation.x": 6.28,
+        "rotation.y": 1.57, // = Math.PI / 4
+        "rotation.z": 2.09  // = 2 * Math.PI / 3
+      }
+    ],
+    [
       'matrix3d(1,0,0,.1,-0.2,-.22,30000,1,0,0,0,1,0.2,0,0,1) translate3d(10px,20,20) matrix(0,6,4,3,2.2,0) scale3d(0,0,0) rotate3d(0,0.5,0,0) rotateZ(1.2);',
       {
         "scale.x": 0

--- a/packages/haiku-player/test/unit/layout.parseCssTransformString.test.js
+++ b/packages/haiku-player/test/unit/layout.parseCssTransformString.test.js
@@ -64,8 +64,8 @@ test('layout.parseCssTransformString', function (t) {
         "rotation.y": 3.14,
         "rotation.z": 2.97,
         "scale.x": -1,
-        "scale.y": 1,
-        "scale.z": 1
+        "scale.y": -1,
+        "scale.z": -1
       }
     ],
     [
@@ -80,7 +80,7 @@ test('layout.parseCssTransformString', function (t) {
         "scale.x": 2.72,
         "scale.y": 2.72,
       }
-    ],
+    ]
   ]
 
   t.plan(data.length)


### PR DESCRIPTION
This PR requires ~~a reviewer who deeply groks affine transformations and careful testing of Player demos~~ careful testing of object instantiation on stage.

 * [Asana ticket](https://app.asana.com/0/479779791675933/488080510412729/f)
 * [Asana ticket](https://app.asana.com/0/479779791675933/488686568445425/f)

**Background:**

After a pretty deeply false start (see below—tl;dr my understanding of the issue turned out to be deeply flawed), it turned out all our raster layouts were broken due to one small oversight in the the process of converting mana layout when instantiating an object on stage. Specifically, we blindly strip out the `<x, y>` node attributes during this process, which is a good idea to do on everything _except_ `<image>` nodes. The unique behavior of `<image>` nodes is that `<x, y>` _defines a coordinate system_ about which all transforms are applied.

~~The vendor library we use for decomposing a sequence of SVG transformations into `scale.x`-type properties uses [a specific ordering](https://github.com/mattdesl/mat4-decompose) for its decomposition. The ordering as it applies to work we do (since we don't support computations based on skew or perspective [yet]) is: 1. Translation, 2. Scale, 3. Rotation. This happens to be incompatible with the ordering we use to compute layout matrices, which is: 1. Rotation, 2. Scale, 3. Translation.~~

~~This doesn't really matter *unless* we have a case of where an origin-repositioning transform (scale or rotation) is composed with any other transform, at which point wacky things start to happen because origin-repositioning transforms are generally not commutative with other transforms. Put more simply, `translate(10, 20) rotate(30)` is not isomorphic to `rotate(30) translate(10, 20)`, and we parse complex transforms into the former but actually implement the latter.~~ Note from the future: these operations actually *do* commute as long as there is no transform-origin set.

**Implementation:**

~~To avoid backward-incompatible changes to how the Player calcs layout and any other side effects, this PR instead parses transform sequences into an order actually compatible with the rest of our code.~~ In the process, I refactored out all the dead/useless code dealing with skew and perspective, since it doesn't factor into our computed layout at this time.

~~Player demos should be tested, as well as the documented broken cases in Asana:~~
The following should be carefully tested:
 - Rotate raster slice in Sketch, then instantiate on stage. Confirm bounding box perfectly contains the rotated element.
 - Flip raster slice in Sketch, then instantiate on stage. Confirm orientation on Glass matches what you see in Sketch.