### PR TITLE
feat: Add a new player config option for strictSizing.

### DIFF
--- a/packages/haiku-creator/src/react/components/ProjectPreview.js
+++ b/packages/haiku-creator/src/react/components/ProjectPreview.js
@@ -39,6 +39,7 @@ class ProjectPreview extends React.Component {
           this.mount,
           {
             sizing: 'cover',
+            strictSizing: false,
             loop: true,
             interactionMode: InteractionMode.EDIT,
             autoplay: false

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -3,6 +3,7 @@ import lodash from 'lodash'
 import Radium from 'radium'
 import HaikuDOMRenderer from '@haiku/player/lib/renderers/dom'
 import HaikuContext from '@haiku/player/lib/HaikuContext'
+import Config from '@haiku/player/lib/Config'
 import ActiveComponent from 'haiku-serialization/src/bll/ActiveComponent'
 import Element from 'haiku-serialization/src/bll/Element'
 import react2haiku from 'haiku-serialization/src/utils/react2haiku'
@@ -119,8 +120,20 @@ export class Glass extends React.Component {
     this.drawLoop = this.drawLoop.bind(this)
     this.draw = this.draw.bind(this)
 
-    this._haikuRenderer = new HaikuDOMRenderer()
-    this._haikuContext = new HaikuContext(null, this._haikuRenderer, {}, { timelines: {}, template: { elementName: 'div', attributes: {}, children: [] } }, { options: { cache: {}, seed: 'abcde' } })
+    const haikuConfig = Config.build({
+      options: {
+        seed: Config.seed(),
+        cache: {}
+      }
+    })
+    this._haikuRenderer = new HaikuDOMRenderer(haikuConfig)
+    this._haikuContext = new HaikuContext(
+      null,
+      this._haikuRenderer,
+      {},
+      { timelines: {}, template: { elementName: 'div', attributes: {}, children: [] } },
+      haikuConfig
+    )
 
     this.handleRequestElementCoordinates = this.handleRequestElementCoordinates.bind(this)
     this.handleBoltMousedown = this.handleBoltMousedown.bind(this)

--- a/packages/haiku-player/src/Config.ts
+++ b/packages/haiku-player/src/Config.ts
@@ -60,6 +60,11 @@ const DEFAULTS = {
     // HaikuComponent.js for info.
     sizing: null,
 
+    // strictSizing: Boolean|null
+    // Whether we should listen for resizing events on anything other than window.resize. Here, "strictness" refers to
+    // our comfort with assuming the component might be resized by a non-window resize event.
+    strictSizing: true,
+
     // preserve3d: String
     // Placeholder for an option to control whether to enable preserve-3d mode in DOM environments. [UNUSED]
     preserve3d: 'auto',

--- a/packages/haiku-player/src/Config.ts
+++ b/packages/haiku-player/src/Config.ts
@@ -60,10 +60,12 @@ const DEFAULTS = {
     // HaikuComponent.js for info.
     sizing: null,
 
-    // strictSizing: Boolean|null
-    // Whether we should listen for resizing events on anything other than window.resize. Here, "strictness" refers to
-    // our comfort with assuming the component might be resized by a non-window resize event.
-    strictSizing: true,
+    // alwaysComputeSizing: Boolean|null
+    // Whether we should always assume the size of the mount will change on every tick. There is a significant
+    // performance boost for all non-'normal' sizing modes if we *don't* always assume this, but the size of the
+    // mount might change underneath for reasons other than changes in media queries. To be safe, we leave this on
+    // by default.
+    alwaysComputeSizing: true,
 
     // preserve3d: String
     // Placeholder for an option to control whether to enable preserve-3d mode in DOM environments. [UNUSED]

--- a/packages/haiku-player/src/HaikuContext.ts
+++ b/packages/haiku-player/src/HaikuContext.ts
@@ -234,7 +234,7 @@ HaikuContext.prototype.performPatchRender = function performPatchRender() {
     return void (0);
   }
 
-  const container = this.config.options.sizing && this.config.options.sizing !== 'normal'
+  const container = this._renderer.shouldCreateContainer
     ? this._renderer.createContainer(this._mount)
     : this._renderer.getLastContainer();
   const patches = this.component.patch(container, this.config.options);
@@ -399,7 +399,7 @@ HaikuContext['createComponentFactory'] = function createComponentFactory(
 
     // Previously these were initialized in the scope above, but I moved them here which seemed to resolve
     // an initialization/mounting issue when running in React.
-    const renderer = new rendererClass();
+    const renderer = new rendererClass(haikuConfigMerged);
     const context = new HaikuContext(mount, renderer, platform, bytecode, haikuConfigMerged);
     const component = context.getRootComponent();
 

--- a/packages/haiku-player/src/layout/formatTransform.ts
+++ b/packages/haiku-player/src/layout/formatTransform.ts
@@ -48,7 +48,7 @@ export default function formatTransform(transform, format, devicePixelRatio) {
     // Modify via: matrix(a,b,c,d,tx,ty) <= matrix3d(a,b,0,0,c,d,0,0,0,0,1,0,tx,ty,0,1)
 
     // Note how we set the transform far to two here!
-    // tslint:disable-next-line:no-parameter-reassignment
+    // tslint:disable-next-line:no-param-reassign
     transform = [
       transform[0],
       transform[1],

--- a/packages/haiku-player/src/renderers/dom/HaikuDOMRenderer.ts
+++ b/packages/haiku-player/src/renderers/dom/HaikuDOMRenderer.ts
@@ -45,6 +45,10 @@ HaikuDOMRenderer.prototype.mixpanel = function mixpanel(domElement, mixpanelToke
   return createMixpanel(domElement, mixpanelToken, component);
 };
 
+HaikuDOMRenderer.prototype.hasSizing = function hasSizing() {
+  return this.config && this.config.options.sizing && this.config.options.sizing !== 'normal';
+};
+
 HaikuDOMRenderer.prototype.createContainer = function createContainer(domElement) {
   this._lastContainer = {
     isContainer: true,
@@ -55,12 +59,7 @@ HaikuDOMRenderer.prototype.createContainer = function createContainer(domElement
     },
   };
 
-  if (
-    !this.config ||
-    !this.config.options.sizing ||
-    this.config.options.sizing === 'normal' ||
-    !this.config.options.strictSizing
-  ) {
+  if (!this.hasSizing() || !this.config.options.alwaysComputeSizing) {
     this.shouldCreateContainer = false;
   }
 
@@ -194,8 +193,15 @@ HaikuDOMRenderer.prototype.initialize = function initialize(domMountElement) {
   });
 
   // WINDOW
-  if (this.config.options.sizing && this.config.options.sizing !== 'normal' && !this.config.options.strictSizing) {
+
+  // If there's any sizing mode that requires computation of container size and alwaysComputeSizing is *disabled*, make
+  // an "overiding" assumption that we probably want to recompute the container when media queries change.
+  if (this.hasSizing() && !this.config.options.alwaysComputeSizing) {
     win.addEventListener('resize', () => {
+      this.shouldCreateContainer = true;
+    });
+
+    win.addEventListener('orientationchange', () => {
       this.shouldCreateContainer = true;
     });
   }

--- a/packages/haiku-player/src/renderers/dom/HaikuDOMRenderer.ts
+++ b/packages/haiku-player/src/renderers/dom/HaikuDOMRenderer.ts
@@ -10,7 +10,7 @@ import patch from './patch';
 import render from './render';
 
 // tslint:disable-next-line:function-name
-export default function HaikuDOMRenderer() {
+export default function HaikuDOMRenderer(config) {
   this._user = {
     mouse: {
       x: 0,
@@ -24,6 +24,9 @@ export default function HaikuDOMRenderer() {
   };
 
   this._lastContainer = undefined;
+
+  this.config = config;
+  this.shouldCreateContainer = true;
 }
 
 HaikuDOMRenderer.prototype.render = function renderWrap(domElement, virtualContainer, virtualTree, component) {
@@ -43,7 +46,7 @@ HaikuDOMRenderer.prototype.mixpanel = function mixpanel(domElement, mixpanelToke
 };
 
 HaikuDOMRenderer.prototype.createContainer = function createContainer(domElement) {
-  return this._lastContainer = {
+  this._lastContainer = {
     isContainer: true,
     layout: {
       computed: {
@@ -51,6 +54,17 @@ HaikuDOMRenderer.prototype.createContainer = function createContainer(domElement
       },
     },
   };
+
+  if (
+    !this.config ||
+    !this.config.options.sizing ||
+    this.config.options.sizing === 'normal' ||
+    !this.config.options.strictSizing
+  ) {
+    this.shouldCreateContainer = false;
+  }
+
+  return this._lastContainer;
 };
 
 HaikuDOMRenderer.prototype.getLastContainer = function getLastContainer() {
@@ -180,6 +194,11 @@ HaikuDOMRenderer.prototype.initialize = function initialize(domMountElement) {
   });
 
   // WINDOW
+  if (this.config.options.sizing && this.config.options.sizing !== 'normal' && !this.config.options.strictSizing) {
+    win.addEventListener('resize', () => {
+      this.shouldCreateContainer = true;
+    });
+  }
 
   win.addEventListener('blur', (blurEvent) => {
     clearKey();

--- a/packages/haiku-player/test/TestHelpers.js
+++ b/packages/haiku-player/test/TestHelpers.js
@@ -1,9 +1,10 @@
 var jsdom = require('jsdom')
 var async = require('async')
-var HaikuDOMAdapter = require('./../lib/adapters/dom').default
-var HaikuDOMRenderer = require('./../lib/renderers/dom').default
-var HaikuContext = require('./../lib/HaikuContext').default
-var HaikuGlobal = require('./../lib/HaikuGlobal').default
+var Config = require('../lib/Config').default
+var HaikuDOMAdapter = require('../lib/adapters/dom').default
+var HaikuDOMRenderer = require('../lib/renderers/dom').default
+var HaikuContext = require('../lib/HaikuContext').default
+var HaikuGlobal = require('../lib/HaikuGlobal').default
 
 var TestHelpers = {}
 
@@ -28,8 +29,9 @@ function createDOM (cb) {
 function createRenderTest (template, cb) {
   return createDOM(function _createDOM (err, window, mount) {
     if (err) throw err
-    var renderer = new HaikuDOMRenderer()
-    var context = new HaikuContext(null, renderer, {}, { timelines: {}, template: template }, { options: { cache: {}, seed: 'abcde' + Math.random() } })
+    var config = Config.build({ options: { cache: {}, seed: Config.seed() } })
+    var renderer = new HaikuDOMRenderer(config)
+    var context = new HaikuContext(null, renderer, {}, { timelines: {}, template: template }, config)
     var component = context.component
     var container = renderer.createContainer(mount)
     var tree = component.render(container, context.config.options)

--- a/packages/haiku-player/test/render/dom/alwaysComputeSizing.test.js
+++ b/packages/haiku-player/test/render/dom/alwaysComputeSizing.test.js
@@ -1,0 +1,83 @@
+var test = require('tape')
+var TestHelpers = require('./../../TestHelpers')
+
+test('render.dom.alwaysComputeSizing.on', function (t) {
+  const template = {
+    elementName: 'div',
+    attributes: { 'haiku-id': 'abcde' },
+    children: []
+  }
+
+  const timelines = {
+    Default: {
+      'haiku:abcde': {
+        'sizeAbsolute.x': { 0: { value: 1600 } },
+        'sizeAbsolute.y': { 0: { value: 1200 } }
+      }
+    }
+  }
+
+  const config = { sizing: 'cover', alwaysComputeSizing: true }
+
+  TestHelpers.createRenderTest(
+    template,
+    timelines,
+    config,
+    function (err, mount, renderer, context, component, teardown) {
+      if (err) throw err
+      let scale = mount.firstChild.haiku.virtual.layout.scale
+      t.equal(scale.x, 0.5, 'cover sizing scales x down by 1/2 to fit container')
+      t.equal(scale.y, 0.5, 'cover sizing scales y down by 1/2 to fit container')
+      mount.width /= 2
+      mount.height /= 2
+      context.tick()
+      scale = mount.firstChild.haiku.virtual.layout.scale
+      t.equal(scale.x, 0.25, 'cover sizing scales x down by 1/4 to fit new container')
+      t.equal(scale.y, 0.25, 'cover sizing scales y down by 1/4 to fit new container')
+      teardown()
+    }
+  )
+
+  t.end()
+})
+
+test('render.dom.alwaysComputeSizing.off', function (t) {
+  const template = {
+    elementName: 'div',
+    attributes: { 'haiku-id': 'abcde' },
+    children: []
+  }
+
+  const timelines = {
+    Default: {
+      'haiku:abcde': {
+        'sizeAbsolute.x': { 0: { value: 1600 } },
+        'sizeAbsolute.y': { 0: { value: 1200 } }
+      }
+    }
+  }
+
+  const config = { sizing: 'cover', alwaysComputeSizing: false }
+
+  TestHelpers.createRenderTest(
+    template,
+    timelines,
+    config,
+    function (err, mount, renderer, context, component, teardown) {
+      if (err) throw err
+      let scale = mount.firstChild.haiku.virtual.layout.scale
+      context.tick()
+      t.equal(scale.x, 0.5, 'cover sizing scales x down by 1/2 to fit container')
+      t.equal(scale.y, 0.5, 'cover sizing scales y down by 1/2 to fit container')
+      mount.width /= 2
+      mount.height /= 2
+      context.tick()
+      scale = mount.firstChild.haiku.virtual.layout.scale
+      t.equal(scale.x, 0.5, 'cover sizing.x does not scale although the size of the mount changed')
+      t.equal(scale.y, 0.5, 'cover sizing.y does not scale although the size of the mount changed')
+      teardown()
+    }
+  )
+
+  t.end()
+})

--- a/packages/haiku-player/test/render/dom/appendChild.test.js
+++ b/packages/haiku-player/test/render/dom/appendChild.test.js
@@ -10,10 +10,10 @@ test('render.dom.appendChild', function (t) {
     children: []
   }
 
-  TestHelpers.createRenderTest(template, function (err, mount, renderer, context, component, teardown) {
+  TestHelpers.createRenderTest(template, {}, {}, function (err, mount, renderer, context, component, teardown) {
     if (err) throw err
-    t.equal(mount.outerHTML, '<div style="width: 800px; height: 600px;"><div haiku-id="abcde" style="display: block;' +
-      ' visibility: visible; opacity: 1; width: 0px; height: 0px;"></div></div>', 'base html render ok')
+    t.equal(mount.outerHTML, '<div><div haiku-id="abcde" style="display: block; visibility: visible; opacity: 1;' +
+      ' width: 800px; height: 600px;"></div></div>', 'base html render ok')
     teardown()
   })
 })


### PR DESCRIPTION
Should be really quick review for @matthewtoast 😄 

Background: the last Player perf pass introduced the concept of caching the internal representation of the mount's bounding box between full flush renders if there isn't a sizing mode enabled, i.e. if we don't actually care about the size of the mount's bounding box for our rendering logic. This resulted in a huge performance improvement for patch rendering when there is no sizing mode, but did nothing for cases where there is. (Calculating a bounding box on every RAF is pretty expensive.)

This PR introduces a default-on config-based option (`strictSizing`) which, if disabled, tells the DOM renderer to recalculate the bounding box only on `window.resize`. It feels safer to go with defaults tracking current behavior and experiment with this selectively, but plan would be to disable `strictSizing` on Dashboard 2, share page, and haiku.ai, all of which use sizing modes to achieve the desired effect.

Note: since component-initialized window event listeners are the domain of `HaikuDOMRenderer`, it  felt wisest to refactor the DOM renderer to accept config.