### PR TITLE
List touch events as available event listeners

### DIFF
--- a/packages/haiku-player/src/renderers/dom/Events.ts
+++ b/packages/haiku-player/src/renderers/dom/Events.ts
@@ -45,6 +45,24 @@ export default {
       human: 'Scroll',
     },
   },
+  touch: {
+    touchstart: {
+      menuable: true,
+      human: 'Touch Start'
+    },
+    touchend: {
+      menuable: true,
+      human: 'Touch End'
+    },
+    touchmove: {
+      menuable: true,
+      human: 'Touch Move'
+    },
+    touchcancel: {
+      menuable: true,
+      human: 'Touch Cancel'
+    }
+  },
   keyboard: {
     keyup: {
       menuable: true,


### PR DESCRIPTION
The player already handles all the logic to attach event handlers,
this only lists touch events as available, making them appear on
the events ui.

This should be a straightforward review

[Asana ticket](https://app.asana.com/0/482906470227387/505957877019449)