### PR TITLE
Add simple window dragging for the tour

### DIFF
--- a/packages/haiku-creator/package.json
+++ b/packages/haiku-creator/package.json
@@ -49,6 +49,7 @@
     "react-copy-to-clipboard": "^5.0.0",
     "react-dom": "15.4.2",
     "react-drag-and-drop": "2.4.0",
+    "react-draggable": "2.2.3",
     "react-height": "2.2.0",
     "react-motion": "0.4.7",
     "react-onclickoutside": "^6.4.0",

--- a/packages/haiku-creator/public/stylesheets/global.css
+++ b/packages/haiku-creator/public/stylesheets/global.css
@@ -474,3 +474,11 @@ input::-webkit-input-placeholder {
 .Droppable {
     height: 100%;
 }
+
+.react-draggable-dragged {
+  cursor: -webkit-grab;
+}
+
+.react-draggable-dragging {
+  cursor: -webkit-grabbing;
+}

--- a/packages/haiku-creator/src/react/components/Tooltip.js
+++ b/packages/haiku-creator/src/react/components/Tooltip.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Palette from './Palette'
 import { TOUR_STYLES } from '../styles/tourShared'
+import Draggable from 'react-draggable'
 
 const STYLES = {
   container: {
@@ -173,41 +174,43 @@ function Tooltip (props) {
       <div style={{...STYLES.circle, display: circleDisplay}}>
         <div style={STYLES.circleInner} />
       </div>
-      <div style={{...STYLES.childrenWrapper, ...positionStyles.children}}>
-        <div style={STYLES.children}>
-          {children}
+      <Draggable key={stepData.current}>
+        <div style={{...STYLES.childrenWrapper, ...positionStyles.children}}>
+          <div style={STYLES.children}>
+            {children}
 
-          {/* Don't show buttons on the first and last slides */}
-          {stepData.current > 0 &&
-            stepData.current < stepData.total && (
-              <div
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  marginTop: 30
-                }}
-              >
-                <button
-                  style={TOUR_STYLES.btnSecondary}
-                  onClick={() => finish(true, true)}
+            {/* Don't show buttons on the first and last slides */}
+            {stepData.current > 0 &&
+              stepData.current < stepData.total && (
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    marginTop: 30
+                  }}
                 >
-                  Skip Tutorial
-                </button>
-                <div>
-                  <span style={{marginRight: 10}}>
-                    {stepData.current} of {stepData.total}
-                  </span>
-                  {/* Show the next button if we aren't waiting for user interaction */}
-                  {!waitUserAction && (
-                    <button style={TOUR_STYLES.btn} onClick={() => next()}>
-                      Next
-                    </button>
-                  )}
+                  <button
+                    style={TOUR_STYLES.btnSecondary}
+                    onClick={() => finish(true, true)}
+                  >
+                    Skip Tutorial
+                  </button>
+                  <div>
+                    <span style={{marginRight: 10}}>
+                      {stepData.current} of {stepData.total}
+                    </span>
+                    {/* Show the next button if we aren't waiting for user interaction */}
+                    {!waitUserAction && (
+                      <button style={TOUR_STYLES.btn} onClick={() => next()}>
+                        Next
+                      </button>
+                    )}
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
+          </div>
         </div>
-      </div>
+      </Draggable>
     </div>
   )
 }


### PR DESCRIPTION
As the title says, it is using the same react library as the
timeline for the dragging (`react-draggable`) for consistency
purposes, but we may consider other, more robust options.

Sasha suggested `react-dnd` which has an awesome API, maybe we
can go with that as our standard when doing the refactor of the
timeline multiselect.

This should be easy to review.

[Asana task](https://app.asana.com/0/482906470227387/504284557602347)