### PR TITLE
Use frames by default in timeline API.

### DIFF
--- a/packages/haiku-player/src/HaikuTimeline.ts
+++ b/packages/haiku-player/src/HaikuTimeline.ts
@@ -292,10 +292,7 @@ HaikuTimeline.prototype._shout = function _shout(key) {
   return this;
 };
 
-HaikuTimeline.prototype.start = function start(
-  maybeGlobalClockTime,
-  descriptor,
-) {
+HaikuTimeline.prototype.start = function start(maybeGlobalClockTime, descriptor) {
   this._localElapsedTime = 0;
   this._isActive = true;
   this._isPlaying = true;
@@ -354,7 +351,11 @@ HaikuTimeline.prototype.play = function play(requestedOptions) {
   return this;
 };
 
-HaikuTimeline.prototype.seek = function seek(ms) {
+HaikuTimeline.prototype.frameToMs = function frameToMs(frame) {
+  return ~~(this._component.getClock().getFrameDuration() * frame);
+};
+
+HaikuTimeline.prototype.seekMs = function seekMs(ms) {
   this._ensureClockIsRunning();
   const clockTime = this._component.getClock().getTime();
   this._controlTime(ms, clockTime);
@@ -367,17 +368,29 @@ HaikuTimeline.prototype.seek = function seek(ms) {
   return this;
 };
 
-HaikuTimeline.prototype.gotoAndPlay = function gotoAndPlay(ms) {
+HaikuTimeline.prototype.seek = function seek(frame) {
+  return this.seekMs(this.frameToMs(frame));
+};
+
+HaikuTimeline.prototype.gotoAndPlayMs = function gotoAndPlayMs(ms) {
   this._ensureClockIsRunning();
   this.seek(ms);
   this.play();
   return this;
 };
 
-HaikuTimeline.prototype.gotoAndStop = function gotoAndStop(ms) {
+HaikuTimeline.prototype.gotoAndPlay = function gotoAndPlay(frame) {
+  return this.gotoAndPlayMs(this.frameToMs(frame));
+};
+
+HaikuTimeline.prototype.gotoAndStopMs = function gotoAndStopMs(ms) {
   this._ensureClockIsRunning();
   this.seek(ms);
   return this;
+};
+
+HaikuTimeline.prototype.gotoAndStop = function gotoAndStop(frame) {
+  return this.gotoAndStopMs(this.frameToMs(frame));
 };
 
 /**

--- a/packages/haiku-player/src/helpers/compareSemver.ts
+++ b/packages/haiku-player/src/helpers/compareSemver.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Haiku 2016-2017. All rights reserved.
+ */
+
+/**
+ * Simple semver comparitor function for semvers.
+ *
+ * Used for determining if a semver a = x.y.z is less than, greater than, or equal to a semver b = x'.y'.z'. Returns 1
+ * if a > b, -1 if a < b, or 0 if they are equal.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+const compareSemver = (a: string, b: string): number => {
+  const semverA = a.split('.');
+  const semverB = b.split('.');
+
+  if (semverA.length !== 3 || semverB.length !== 3) {
+    throw new Error(`Invalid semver comparison: ${a}, ${b}`);
+  }
+
+  for (let i = 0; i < 3; ++i) {
+    if (semverA[i] < semverB[i]) {
+      return -1;
+    }
+    if (semverA[i] > semverB[i]) {
+      return 1;
+    }
+  }
+
+  return 0;
+};
+
+export default compareSemver;

--- a/packages/haiku-player/src/renderers/dom/Events.ts
+++ b/packages/haiku-player/src/renderers/dom/Events.ts
@@ -48,20 +48,20 @@ export default {
   touch: {
     touchstart: {
       menuable: true,
-      human: 'Touch Start'
+      human: 'Touch Start',
     },
     touchend: {
       menuable: true,
-      human: 'Touch End'
+      human: 'Touch End',
     },
     touchmove: {
       menuable: true,
-      human: 'Touch Move'
+      human: 'Touch Move',
     },
     touchcancel: {
       menuable: true,
-      human: 'Touch Cancel'
-    }
+      human: 'Touch Cancel',
+    },
   },
   keyboard: {
     keyup: {


### PR DESCRIPTION
WIP, please don't merge! Don't even look!

Pending:
 - After `mc` is merged, teach plumbing to upgradeBytecodeInPlace and persist the result to disk on project start. (Note: at this point we can remove all the places we call it manually in the app.)
 - Update first semver this is supported in from 2.3.62 to whatever the actual version is right before merge, and probably make a compatibility config to store this sort of thing in.