### PR TITLE
Upgrade electron to the latest (stable) version, 1.7.10

### DIFF
--- a/packages/haiku-creator/package.json
+++ b/packages/haiku-creator/package.json
@@ -61,7 +61,7 @@
     "babel-cli": "6.18.0",
     "babel-preset-react-app": "2.2.0",
     "babel-register": "6.24.0",
-    "electron": "1.7.0",
+    "electron": "1.7.10",
     "snazzy": "6.0.0",
     "standard": "8.6.0",
     "tap-spec": "^4.1.1",

--- a/packages/haiku-creator/yarn.lock
+++ b/packages/haiku-creator/yarn.lock
@@ -9,6 +9,10 @@
     lodash "^4.17.4"
     react "15.4.2"
 
+"@types/node@^7.0.18":
+  version "7.0.51"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.51.tgz#1fb9bd2c7d28b1e8b1fe438f01494d0da8e451af"
+
 JSONStream@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -1718,10 +1722,11 @@ electron-to-chromium@^1.1.0, electron-to-chromium@^1.2.7:
   version "1.3.21"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz#a967ebdcfe8ed0083fc244d1894022a8e8113ea2"
 
-electron@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.0.tgz#307a5a00a521e679c2cd829706bffdb6d34da186"
+electron@1.7.10:
+  version "1.7.10"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.10.tgz#3a3e83d965fd7fafe473be8ddf8f472561b6253d"
   dependencies:
+    "@types/node" "^7.0.18"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 

--- a/packages/haiku-glass/package.json
+++ b/packages/haiku-glass/package.json
@@ -46,7 +46,7 @@
     "async": "^2.5.0",
     "babel-cli": "^6.24.0",
     "babel-preset-react-app": "^2.2.0",
-    "electron": "1.7.0",
+    "electron": "1.7.10",
     "jsdom": "^11.1.0",
     "prop-types": "^15.6.0",
     "snazzy": "^6.0.0",

--- a/packages/haiku-glass/yarn.lock
+++ b/packages/haiku-glass/yarn.lock
@@ -13,6 +13,10 @@
   version "6.0.88"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.88.tgz#f618f11a944f6a18d92b5c472028728a3e3d4b66"
 
+"@types/node@^7.0.18":
+  version "7.0.51"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.51.tgz#1fb9bd2c7d28b1e8b1fe438f01494d0da8e451af"
+
 JSONStream@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -1691,10 +1695,11 @@ electron-to-chromium@^1.1.0, electron-to-chromium@^1.2.7:
   version "1.3.21"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz#a967ebdcfe8ed0083fc244d1894022a8e8113ea2"
 
-electron@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.0.tgz#307a5a00a521e679c2cd829706bffdb6d34da186"
+electron@1.7.10:
+  version "1.7.10"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.10.tgz#3a3e83d965fd7fafe473be8ddf8f472561b6253d"
   dependencies:
+    "@types/node" "^7.0.18"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 

--- a/packages/haiku-plumbing/package.json
+++ b/packages/haiku-plumbing/package.json
@@ -90,7 +90,7 @@
   "devDependencies": {
     "babel-cli": "6.18.0",
     "babel-preset-es2015": "6.18.0",
-    "electron": "1.7.0",
+    "electron": "1.7.10",
     "electron-rebuild": "1.5.7",
     "gulp": "3.9.1",
     "gulp-cli": "1.2.2",

--- a/packages/haiku-plumbing/yarn.lock
+++ b/packages/haiku-plumbing/yarn.lock
@@ -75,6 +75,10 @@
   dependencies:
     "@haiku/player" "2.3.6"
 
+"@types/node@^7.0.18":
+  version "7.0.51"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.51.tgz#1fb9bd2c7d28b1e8b1fe438f01494d0da8e451af"
+
 JSONStream@^1.0.3, JSONStream@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -2165,10 +2169,11 @@ electron-rebuild@1.5.7:
     spawn-rx "^2.0.7"
     yargs "^3.31.0"
 
-electron@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.0.tgz#307a5a00a521e679c2cd829706bffdb6d34da186"
+electron@1.7.10:
+  version "1.7.10"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.10.tgz#3a3e83d965fd7fafe473be8ddf8f472561b6253d"
   dependencies:
+    "@types/node" "^7.0.18"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 

--- a/packages/haiku-timeline/package.json
+++ b/packages/haiku-timeline/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-react-app": "2.2.0",
-    "electron": "1.7.0",
+    "electron": "1.7.10",
     "snazzy": "^7.0.0",
     "standard": "^10.0.2",
     "tap-spec": "4.1.1",

--- a/packages/haiku-timeline/yarn.lock
+++ b/packages/haiku-timeline/yarn.lock
@@ -13,6 +13,10 @@
   version "8.0.57"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.57.tgz#e5d8b4dc112763e35cfc51988f4f38da3c486d99"
 
+"@types/node@^7.0.18":
+  version "7.0.51"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.51.tgz#1fb9bd2c7d28b1e8b1fe438f01494d0da8e451af"
+
 JSONStream@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -1714,10 +1718,11 @@ electron-to-chromium@^1.1.0, electron-to-chromium@^1.2.7:
   version "1.3.21"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.21.tgz#a967ebdcfe8ed0083fc244d1894022a8e8113ea2"
 
-electron@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.0.tgz#307a5a00a521e679c2cd829706bffdb6d34da186"
+electron@1.7.10:
+  version "1.7.10"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.10.tgz#3a3e83d965fd7fafe473be8ddf8f472561b6253d"
   dependencies:
+    "@types/node" "^7.0.18"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 


### PR DESCRIPTION
Ready to merge -- if this doesn't step on anything @stristr is doing.

**What:** Upgrades electron to `1.7.10` in all dependent modules. https://electronjs.org/releases#1.7.10

**Motivation:**

* Good idea to keep up to date with framework improvements and fixes
* Get needed Typescript definitions missing from earlier Electron version

**Review:**

* Should be quick to review
* Maybe take for a spin locally (it seems to work fine)