### PR TITLE
fix: always write out dom-embed.js.

### DIFF
--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -795,9 +795,7 @@ class Project extends BaseModel {
       fse.outputFileSync(path.join(this.getFolder(), `code/${scenename}/dom.js`), DOM_JS)
     }
 
-    if (!fse.existsSync(path.join(this.getFolder(), `code/${scenename}/dom-embed.js`))) {
-      fse.outputFileSync(path.join(this.getFolder(), `code/${scenename}/dom-embed.js`), DOM_EMBED_JS)
-    }
+    fse.outputFileSync(path.join(this.getFolder(), `code/${scenename}/dom-embed.js`), DOM_EMBED_JS)
 
     if (!fse.existsSync(path.join(this.getFolder(), `code/${scenename}/dom-standalone.js`))) {
       fse.outputFileSync(path.join(this.getFolder(), `code/${scenename}/dom-standalone.js`), DOM_STANDALONE_JS)


### PR DESCRIPTION
Teensy review. Noticed this significant regression when testing embed code—we need to always write out `dom-embed.js` in the project folder for the embed code to be checking for the right version of `@haiku/player`.

[Asana ticket](https://app.asana.com/0/480796620059175/511466430513270/f)