### PR TITLE
Fix legacy of short-lived strictSizing API

### DIFF
--- a/packages/@haiku/player/src/renderers/dom/HaikuDOMRenderer.ts
+++ b/packages/@haiku/player/src/renderers/dom/HaikuDOMRenderer.ts
@@ -199,11 +199,6 @@ HaikuDOMRenderer.prototype.initialize = function initialize(domMountElement) {
   });
 
   // WINDOW
-  if (this.config.options.sizing && this.config.options.sizing !== 'normal' && !this.config.options.strictSizing) {
-    win.addEventListener('resize', () => {
-      this.shouldCreateContainer = true;
-    });
-  }
 
   // If there's any sizing mode that requires computation of container size and alwaysComputeSizing is *disabled*, make
   // an "overiding" assumption that we probably want to recompute the container when media queries change.

--- a/packages/haiku-creator/src/react/components/ProjectPreview.js
+++ b/packages/haiku-creator/src/react/components/ProjectPreview.js
@@ -39,7 +39,7 @@ class ProjectPreview extends React.Component {
           this.mount,
           {
             sizing: 'cover',
-            strictSizing: false,
+            alwaysComputeSizing: false,
             loop: true,
             interactionMode: InteractionMode.EDIT,
             autoplay: false


### PR DESCRIPTION
Tiny fix: after renaming the `strictSizing` API to `alwaysComputeSizing`, some stuff got lost in the shuffle. This should restore expected behavior.