### PR TITLE
Go back to original playhead when existing preview

### DIFF
--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -309,8 +309,9 @@ class Timeline extends BaseModel {
           timelineInstance.gotoAndPlay(0)
           timelineInstance.options.loop = true
         } else {
+          this.seek(this.getCurrentFrame())
           timelineInstance.freeze()
-          timelineInstance.seek(0)
+          timelineInstance.seek(this.getCurrentMs())
           timelineInstance.options.loop = false
         }
       })

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -298,13 +298,7 @@ class Timeline extends React.Component {
   }
 
   handleInteractionModeChange (relpath, interactionMode) {
-    const isPreviewModeActive = isPreviewMode(interactionMode)
-
-    if (!isPreviewModeActive) {
-      this.playbackSkipBack()
-    }
-
-    this.setState({isPreviewModeActive})
+    this.setState({isPreviewModeActive: isPreviewMode(interactionMode)})
   }
 
   getPopoverMenuItems ({ event, type, model, offset, curve }) {


### PR DESCRIPTION
**Info**

- This PR should only take a couple of minutes to review
- [Asana Task](https://app.asana.com/0/482906470227387/505957877019447)

**Summary**

Since the internal playhead state of the `Timeline` model doesn't change when switching to preview mode, we can reset the playhead using `Timeline#getCurrentFrame` and `Timeline#getCurrentMs`