### PR TITLE
Primitives Instantiation (incomplete but worth merging)

### DIFF
--- a/packages/haiku-serialization/package.json
+++ b/packages/haiku-serialization/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "yarn test:unit && yarn test:bll",
-    "test:unit": "tape \"test/unit/**/*.test.js\" | tap-spec || true",
-    "test:bll": "tape \"test/bll/**/*.test.js\" | tap-spec || true",
+    "test:unit": "NODE_ENV=test tape \"test/unit/**/*.test.js\" | tap-spec || true",
+    "test:bll": "NODE_ENV=test tape \"test/bll/**/*.test.js\" | tap-spec || true",
     "lint": "standard \"src/**/*.js\" --fix --verbose | snazzy || true"
   },
   "author": "Matthew Trost <matthew@haiku.ai>",

--- a/packages/haiku-serialization/src/bll/Bytecode.js
+++ b/packages/haiku-serialization/src/bll/Bytecode.js
@@ -304,6 +304,33 @@ Bytecode.pasteBytecode = (destination, pasted, translation) => {
   return destination
 }
 
+Bytecode.applyOverrides = (overrides, timelinesObject, timelineName, timelineSelector, timelineTime) => {
+  if (overrides && Object.keys(overrides).length > 0) {
+    if (!timelinesObject[timelineName]) timelinesObject[timelineName] = {}
+    if (!timelinesObject[timelineName][timelineSelector]) timelinesObject[timelineName][timelineSelector] = {}
+
+    for (const propertyName in overrides) {
+      if (!timelinesObject[timelineName][timelineSelector][propertyName]) timelinesObject[timelineName][timelineSelector][propertyName] = {}
+      if (!timelinesObject[timelineName][timelineSelector][propertyName][timelineTime]) timelinesObject[timelineName][timelineSelector][propertyName][timelineTime] = {}
+      if (!timelinesObject[timelineName][timelineSelector][propertyName][timelineTime].edited) {
+        timelinesObject[timelineName][timelineSelector][propertyName][timelineTime].value = overrides[propertyName]
+      }
+    }
+  }
+}
+
+Bytecode.extractOverrides = (bytecode) => {
+  const overrides = {}
+
+  if (bytecode.states) {
+    for (const stateName in bytecode.states) {
+      overrides[stateName] = bytecode.states[stateName].value
+    }
+  }
+
+  return overrides
+}
+
 Bytecode.clone = (bytecode) => {
   // Eventually we may lean on a more custom-tailored clone method instead of lodash
   return lodash.cloneDeep(bytecode)

--- a/packages/haiku-serialization/src/bll/Design.js
+++ b/packages/haiku-serialization/src/bll/Design.js
@@ -38,15 +38,20 @@ Design.designSourceToCodeSource = (relpath) => {
  * @param relpath {String} Path to the design element
  * @param cb {Function}
  */
-Design.designAsCode = (folder, relpath, cb) => {
+Design.designAsCode = (folder, relpath, options = {}, cb) => {
+  // Note that readMana runs the contents through svgo
   return File.readMana(folder, relpath, (err, mana) => {
     if (err) return cb(err)
-    const identifier = Design.designSourceToIdentifierName(relpath)
-    const modpath = ModuleWrapper.identifierToLocalModpath(identifier)
-    Template.fixManaSourceAttribute(mana, relpath) // Adds source="relpath_to_file_from_project_root"
-    const bytecode = Template.manaToDynamicBytecode(mana, identifier, modpath)
-    return cb(null, identifier, modpath, bytecode)
+    return Design.manaAsCode(relpath, mana, options, cb)
   })
+}
+
+Design.manaAsCode = (relpath, mana, options = {}, cb) => {
+  const identifier = Design.designSourceToIdentifierName(relpath)
+  const modpath = ModuleWrapper.identifierToLocalModpath(identifier)
+  Template.fixManaSourceAttribute(mana, relpath) // Adds source="relpath_to_file_from_project_root"
+  const bytecode = Template.manaToDynamicBytecode(mana, identifier, modpath, options)
+  return cb(null, identifier, modpath, bytecode)
 }
 
 module.exports = Design

--- a/packages/haiku-serialization/src/bll/Primitive.js
+++ b/packages/haiku-serialization/src/bll/Primitive.js
@@ -1,24 +1,33 @@
 const BaseModel = require('./BaseModel')
 
-const PRIMITIVES = {
-  circle: require('@haiku/player/components/Circle/code/main/code'),
-  ellipse: require('@haiku/player/components/Ellipse/code/main/code'),
-  line: require('@haiku/player/components/Line/code/main/code'),
-  path: require('@haiku/player/components/Path/code/main/code'),
-  polygon: require('@haiku/player/components/Polygon/code/main/code'),
-  polyline: require('@haiku/player/components/Polyline/code/main/code'),
-  rect: require('@haiku/player/components/Rect/code/main/code')
-}
+// const HaikuPlayerBuiltinComponents = require('@haiku/player/components')
+const HaikuPlayerBuiltinComponents = {}
 
 /**
  * @class Primitive
  * @description
- *.  Collection of static class methods for "primitive" components (Line, Rect, etc).
+ *.  Collection of methods for "primitive" components (Line, Rectangle, etc).
  */
-class Primitive extends BaseModel {}
+class Primitive extends BaseModel {
+  getClassName () {
+    return this.classname
+  }
+
+  getRequirePath () {
+    return this.requirePath
+  }
+
+  getStates () {
+    return this.bytecode.states
+  }
+}
 
 Primitive.DEFAULT_OPTIONS = {
-  required: {}
+  required: {
+    requirePath: true,
+    bytecode: true,
+    classname: true
+  }
 }
 
 BaseModel.extend(Primitive)
@@ -28,21 +37,25 @@ BaseModel.extend(Primitive)
  * @description Give an arbitrary bytecode object, determine whether it represents
  * a known 'primitive' component (Line, Rect, Path, etc)
  * @param bytecode {Object} The bytecode object
- * @returns {Object} The bytecode of the respective primitive component
+ * @returns {Object} The Primitive instance
  */
-Primitive.inferPrimitiveFromBytecode = (bytecode) => {
-  for (const elementName in PRIMITIVES) {
-    const primitive = PRIMITIVES[elementName]
-    const areIsomorphic = Bytecode.areBytecodesIsomorphic(bytecode, primitive)
-    if (areIsomorphic) return primitive
-  }
-}
+Primitive.inferPrimitiveFromBytecode = (theirBytecode) => {
+  for (const classname in HaikuPlayerBuiltinComponents) {
+    const {
+      requirePath,
+      bytecode
+    } = HaikuPlayerBuiltinComponents[classname]
 
-Primitive.inferPrimitiveFromMana = (mana) => {
-  for (const elementName in PRIMITIVES) {
-    const primitive = PRIMITIVES[elementName]
-    const areEquivalent = Template.areTemplatesEquivalent(mana, primitive.template)
-    if (areEquivalent) return primitive
+    const areIsomorphic = Bytecode.areBytecodesIsomorphic(theirBytecode, bytecode)
+
+    if (areIsomorphic) {
+      return Primitive.upsert({
+        uid: requirePath,
+        requirePath,
+        classname,
+        bytecode
+      })
+    }
   }
 }
 
@@ -50,4 +63,3 @@ module.exports = Primitive
 
 // Down here to avoid Node circular dependency stub objects. #FIXME
 const Bytecode = require('./Bytecode')
-const Template = require('./Template')

--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -667,7 +667,7 @@ class Project extends BaseModel {
    * @param cb {Function}
    */
   componentizeDesign (relpath, options, cb) {
-    return Design.designAsCode(this.getFolder(), relpath, (err, identifier, modpath, bytecode) => {
+    return Design.designAsCode(this.getFolder(), relpath, {}, (err, identifier, modpath, bytecode) => {
       if (err) return cb(err)
 
       return this.upsertComponentBytecodeToModule(modpath, bytecode, options, (err, component) => {

--- a/packages/haiku-serialization/src/bll/Row.js
+++ b/packages/haiku-serialization/src/bll/Row.js
@@ -634,7 +634,7 @@ class Row extends BaseModel {
    * @description When debugging, use this to log a concise shorthand of this entity.
    */
   dump () {
-    let str = `${this.getType()}.${this.place}|${this.depth}.${this.seq}.${this.index}`
+    let str = `${this.getType()}.${this.element.getComponentId()}.${this.place}|${this.depth}.${this.seq}.${this.index}`
     if (this.isCluster()) str += `.${this.cluster.prefix}[]`
     if (this.isProperty()) str += `.${this.getPropertyName()}`
     if (this.isSelected()) str += ' {s}'

--- a/packages/haiku-serialization/test/bll/02_ActiveComponent.test.js
+++ b/packages/haiku-serialization/test/bll/02_ActiveComponent.test.js
@@ -1,6 +1,7 @@
 const tape = require('tape')
 const path = require('path')
 const fse = require('haiku-fs-extra')
+
 const Project = require('./../../src/bll/Project')
 const File = require('./../../src/bll/File')
 const Element = require('./../../src/bll/Element')
@@ -158,7 +159,7 @@ tape('ActiveComponent.prototype.instantiateComponent[2](component)', (t) => {
         return File.read(folder, modpath, (err, contents) => {
           if (err) throw err
           t.ok(contents.length,15402,'content checksum ok')
-          return ac0.instantiateComponent(modpath, {}, { from: 'test' }, (err, info, mana) => {
+          return ac0.instantiateComponent(`./${modpath}`, {}, { from: 'test' }, (err, info, mana) => {
             t.error(err, 'no err upon instantiation')
             t.equal(info.center.x, 0, 'info center is returned')
             t.equal(mana.attributes.source, '../designs_path_svg/code.js', 'rel source is in mana attribute')
@@ -176,10 +177,10 @@ tape('ActiveComponent.prototype.instantiateComponent[2](component)', (t) => {
             }, 'timeline is ok')
             const subtemplate = ac0.getReifiedBytecode().template.children[0]
             t.equal(subtemplate.elementName.metadata.relpath, 'code/designs_path_svg/code.js', 'el name is bytecode')
-            t.deepEqual(subtemplate.attributes, { 'haiku-id': '76fc778dc382', 'haiku-title': 'designs_path_svg', source: '../designs_path_svg/code.js' }, 'el attrs ok')
+            t.deepEqual(subtemplate.attributes, { source: '../designs_path_svg/code.js', identifier: 'designs_path_svg', 'haiku-title': 'designs_path_svg', 'haiku-id': '76fc778dc382' }, 'el attrs ok')
             return File.read(folder, ac0.fetchActiveBytecodeFile().relpath, (err, contents) => {
               if (err) throw err
-              t.equal(contents.length, 1676, 'checksum ok')
+              t.equal(contents.length, 1718, 'checksum ok')
               var lines = contents.split('\n')
               t.equal(lines[0], 'var Haiku = require("@haiku/player");', 'first line is haiku require')
               t.equal(lines[1], 'var designs_path_svg = require("../designs_path_svg/code.js");', 'first line is component require')
@@ -212,7 +213,7 @@ tape('ActiveComponent.prototype.deleteComponent[2](component)', (t) => {
         return File.read(folder, modpath, (err, contents) => {
           if (err) throw err
           t.equal(ac0.getReifiedBytecode().template.children.length,0)
-          return ac0.instantiateComponent(modpath, {}, { from: 'test' }, (err, info, mana) => {
+          return ac0.instantiateComponent(`./${modpath}`, {}, { from: 'test' }, (err, info, mana) => {
             if (err) throw err
             return ac0.deleteComponent(mana.attributes['haiku-id'], { from: 'test' }, (err) => {
               if (err) throw err
@@ -280,6 +281,7 @@ tape('ActiveComponent.prototype.batchUpsertEventHandlers[1]', (t) => {
       return ac0.batchUpsertEventHandlers(selectorName, SERIALIZED_EVENTS, { from: 'test' }, (err) => {
         if (err) throw err
         t.equal(typeof ac0.getReifiedBytecode().eventHandlers[selectorName].click.handler, 'function', 'handler is fn')
+        fse.removeSync(folder)
       })
     })
   })
@@ -327,6 +329,50 @@ const PATH_SVG_2 = `
       <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
           <g foobar="url(#abc123)" id="Artboard" transform="translate(-200.000000, -500.000000)" stroke="#AAAAAA">
               <path d="M300.000001,260.753906 C282.404105,283.559532 310.725273,290.63691 326.835937,295.734375 C331.617305,297.247215 342.059558,301.595875 338.316406,309.21875 C337.259516,311.371092 335.344104,313.379399 333.070312,314.140625 C316.687518,319.6253 318.607648,314.107756 316.175781,298.535156 C314.073483,285.072967 341.353724,262.381072 307.847656,273.160156 C302.953426,274.734657 299.363413,279.037222 295.621094,282.5625 C294.703984,283.426421 289.762583,289.749326 292.835937,292.191406 C310.800174,306.465746 310.629063,293.466831 327.605469,293.117188 C340.400227,292.853669 361.733615,282.532042 364.140625,298.585938 C364.591437,301.592694 366.227007,305.49551 364.140625,307.707031 C356.643614,315.653704 320.800977,318.428842 316.511719,304 C313.310899,293.23261 309.646651,279.191944 316.511719,270.300781 L317.605469,266.996094 C318.70025,265.578208 319.962133,263.856288 321.726562,263.546875 C348.187608,258.906626 333.406544,260.284286 342.546875,271.855469 C345.091836,275.077257 351.639186,275.674796 351.988281,279.765625 L354.464844,283.632812 C357.416932,318.226499 296.30014,340.100228 293.25,300.105469 C292.638094,292.081893 291.431499,283.803546 293.25,275.964844 C294.715721,269.646813 297.246721,262.379048 302.785156,259.003906 C320.414927,248.260262 322.400502,263.451084 330.808594,271.378906 C333.565871,273.978688 339.302903,273.7221 340.503906,277.316406 C343.115394,285.131945 334.783267,296.681412 341.050781,302.03125 C348.504241,308.39339 366.513246,311.846671 370.4375,302.867188 L372.515625,301.476562 C387.936662,266.190128 352.052706,234.955091 328.25,269.800781 C322.336272,278.458113 340.249653,294.392337 330.753906,301.621094 C326.91332,304.544788 294.058884,308.199097 286.269531,307.359375 C284.995803,307.222062 284.102217,305.584758 283.921875,304.316406 C282.389249,293.537418 285.731973,295.96395 292.257812,288.046875 C311.385715,264.841117 307.46635,267.289874 346.21875,270.695312 C348.526208,270.898085 351.084913,271.703414 352.59375,273.460938 C354.971579,276.230679 354.398541,281.016656 357.144531,283.421875 C361.463282,287.20468 369.172641,295.592094 372.613281,290.996094 C396.717804,258.797319 361.228307,257.906354 349.429687,268.339844 C338.784302,277.753531 347.977468,308.238322 342.097656,310.683594 C334.379679,313.893313 325.61253,313.607482 317.28125,314.285156 C310.815625,314.811077 304.233838,315.258597 297.820312,314.285156 C296.449037,314.077025 295.446155,312.335074 295.328125,310.953125 C294.594926,302.368493 293.381654,293.498605 295.328125,285.105469 C302.241349,255.29581 326.590452,265.047417 334.488281,291.011719 C336.03704,296.103302 335.56021,306.996168 340.308594,312.417969 C354.750775,328.908343 356.425475,297.576804 356.195312,291.328125" id="Path-4"></path>
+          </g>
+      </g>
+  </svg>
+`
+
+const PATH_SVG_3 = `
+  <?xml version="1.0" encoding="UTF-8"?>
+  <svg width="68px" height="89px" viewBox="0 0 68 89" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <!-- Generator: sketchtool 47.1 (45422) - http://www.bohemiancoding.com/sketch -->
+      <title>Path 4</title>
+      <desc>Created with sketchtool.</desc>
+      <defs></defs>
+      <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <path d="M17.5653834,3.24972415 C8.78389065,8.63238435 1.15496876,16.867694 20.7239544,24.5300652 C26.9448788,26.965911 36.76719,18.3562061 40.7500129,23.7200077 L44.6500477,25.5459034 C45.3309428,26.4628877 45.2634552,28.0088797 44.6500477,28.972316 C40.283801,35.8300754 36.7692766,43.9422339 30.0363492,48.4986212 C3.94577219,66.1549492 0.849351892,3.9426716 3.58535894,68.9917693 C3.62002238,69.8158993 4.34989854,70.8001994 5.16954396,70.8927913 C10.2187973,71.4631845 15.5113964,72.2300336 20.4136501,70.8927913 C28.6541842,68.6449293 37.6053859,66.2696073 43.774663,60.3620439 C45.8662922,58.3591461 40.9520483,55.2350407 38.9698462,53.1237882 C33.5723273,47.3748662 29.5781845,37.84985 21.7495917,36.9030402 L17.5817152,35.2600606 C14.4654507,34.8831717 11.1402095,36.2600956 8.16479687,35.2600606 C-9.62704708,29.2802293 10.6327249,17.7007378 18.3329782,16.553612 C31.2729233,14.6259162 44.4263319,12.9706265 57.4835796,13.7870043 C60.0375498,13.9466861 61.6631672,17.0364793 62.791416,19.3332851 C71.3885276,36.8346515 68.6320193,65.946643 43.7550649,67.2671308 C36.7209402,67.6405075 28.1558195,61.13799 22.6903036,65.5816886 C17.5802963,69.7363434 20.9179086,78.7534312 21.5666755,85.3072418 C21.698505,86.6389764 23.5484756,87.3731718 24.8689663,87.5904281 C58.1282882,93.0624832 24.1319409,61.5570061 21.4196893,47.600372 C19.9891261,40.2390173 19.2998726,32.5854165 20.1752058,25.1376083 C23.1677916,-0.324932459 33.2960952,10.7898797 20.3548556,0.502714662 L17.5653834,3.24972415 Z" id="Path-4" stroke="#979797" fill="#FF0000"></path>
+      </g>
+  </svg>
+`
+
+const PATH_SVG_4 = `
+  <?xml version="1.0" encoding="UTF-8"?>
+  <svg width="48px" height="49px" viewBox="0 0 58 59" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <!-- Generator: sketchtool 47.1 (45422) - http://www.bohemiancoding.com/sketch -->
+      <title>Path 4</title>
+      <desc>Created with sketchtool.</desc>
+      <defs></defs>
+      <g id="Page-1" stroke="none" stroke-width="2" fill="none" fill-rule="evenodd">
+          <path d="M17.5653834,3.24972415 C8.78389065,8.63238435 22.2222,16.867694 20.7239544,24.5300652 C26.9448788,26.965911 36.76719,18.3562061 40.7500129,23.7200077 L44.6500477,25.5459034 C45.3309428,26.4628877 45.2634552,28.0088797 44.6500477,28.972316 C40.283801,35.8300754 36.7692766,43.9422339 30.0363492,48.4986212 C3.94577219,66.1549492 0.849351892,3.9426716 3.58535894,68.9917693 C3.62002238,69.8158993 4.34989854,70.8001994 5.16954396,70.8927913 C10.2187973,71.4631845 15.5113964,72.2300336 20.4136501,70.8927913 C28.6541842,68.6449293 37.6053859,66.2696073 43.774663,60.3620439 C45.8662922,58.3591461 40.9520483,55.2350407 38.9698462,53.1237882 C33.5723273,47.3748662 29.5781845,37.84985 21.7495917,36.9030402 L17.5817152,35.2600606 C14.4654507,34.8831717 11.1402095,36.2600956 8.16479687,35.2600606 C-9.62704708,29.2802293 10.6327249,17.7007378 18.3329782,16.553612 C31.2729233,14.6259162 44.4263319,12.9706265 57.4835796,13.7870043 C60.0375498,13.9466861 61.6631672,17.0364793 62.791416,19.3332851 C71.3885276,36.8346515 68.6320193,65.946643 43.7550649,67.2671308 C36.7209402,67.6405075 28.1558195,61.13799 22.6903036,65.5816886 C17.5802963,69.7363434 20.9179086,78.7534312 21.5666755,85.3072418 C21.698505,86.6389764 23.5484756,87.3731718 24.8689663,87.5904281 C58.1282882,93.0624832 24.1319409,61.5570061 21.4196893,47.600372 C19.9891261,40.2390173 19.2998726,32.5854165 20.1752058,25.1376083 C23.1677916,-0.324932459 33.2960952,10.7898797 20.3548556,0.502714662 L17.5653834,3.24972415 Z" id="Path-4" stroke="#ABABAB" fill="#DDEEEE"></path>
+      </g>
+  </svg>
+`
+
+const RECT_SVG_1 = `
+  <?xml version="1.0" encoding="UTF-8"?>
+  <svg width="79px" height="79px" viewBox="0 0 79 79" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <!-- Generator: sketchtool 47.1 (45422) - http://www.bohemiancoding.com/sketch -->
+      <title>Rectangle</title>
+      <desc>Created with sketchtool.</desc>
+      <defs>
+          <rect id="path-1" x="0" y="0" width="79" height="79"></rect>
+      </defs>
+      <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+          <g id="Rectangle">
+              <use fill="#420000" fill-rule="evenodd" xlink:href="#path-1"></use>
+              <rect stroke="#9200FF" stroke-width="16" x="8" y="8" width="63" height="63"></rect>
           </g>
       </g>
   </svg>

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -85,7 +85,19 @@ function toValueDescriptor ({ bookendValue, computedValue }) {
   return {
     kind: EXPR_KINDS.VALUE,
     params: [],
-    body: computedValue + ''
+    body: safeDisplayableStringValue(computedValue)
+  }
+}
+
+function safeDisplayableStringValue (val) {
+  if (typeof val === 'string') {
+    return val
+  }
+
+  try {
+    return JSON.stringify(val)
+  } catch (exception) {
+    return ''
   }
 }
 
@@ -216,7 +228,13 @@ export default class ExpressionInput extends React.Component {
       // Assume that we already stored warnings about this function in the evaluator state from a change action
       return false
     } else {
-      let observedType = typeof committable
+      let observedType
+      if (Array.isArray(committable)) {
+        observedType = 'array'
+      } else {
+        observedType = typeof committable
+      }
+
       let expectedType = original.valueType
 
       if (!ANY_TYPES[expectedType]) {

--- a/packages/haiku-timeline/src/components/PropertyInputField.js
+++ b/packages/haiku-timeline/src/components/PropertyInputField.js
@@ -3,6 +3,8 @@ import lodash from 'lodash'
 import Color from 'color'
 import Palette from 'haiku-ui-common/lib/Palette'
 
+const CELL_WIDTH = 83
+
 export default class PropertyInputField extends React.Component {
   constructor (props) {
     super(props)
@@ -46,7 +48,7 @@ export default class PropertyInputField extends React.Component {
         className='property-input-field-box'
         style={{
           height: this.props.rowHeight - 1,
-          width: this.props.inputCellWidth,
+          width: CELL_WIDTH,
           position: 'relative',
           outline: 'none'
         }}
@@ -68,7 +70,7 @@ export default class PropertyInputField extends React.Component {
             outline: 'none',
             color: 'transparent',
             textShadow: '0 0 0 ' + Color(Palette.ROCK).fade(0.3), // darkmagic
-            minWidth: 83,
+            width: CELL_WIDTH,
             height: this.props.rowHeight + 1,
             paddingLeft: 7,
             paddingTop: 3,
@@ -94,11 +96,23 @@ export default class PropertyInputField extends React.Component {
   }
 }
 
+function safeText (textOrObj) {
+  if (typeof textOrObj === 'string') {
+    return textOrObj
+  }
+
+  try {
+    return JSON.stringify(textOrObj)
+  } catch (exception) {
+    return '?'
+  }
+}
+
 function remapPrettyValue (prettyValue) {
   if (prettyValue && prettyValue.render === 'react') {
-    return <span style={prettyValue.style}>{prettyValue.text}</span>
+    return <span style={prettyValue.style}>{safeText(prettyValue.text)}</span>
   }
-  return prettyValue
+  return safeText(prettyValue)
 }
 
 PropertyInputField.propTypes = {

--- a/packages/haiku-timeline/test/projects/complex/code/main/code.js
+++ b/packages/haiku-timeline/test/projects/complex/code/main/code.js
@@ -18,6 +18,24 @@ module.exports = {
   eventHandlers: {},
   timelines: {
     Default: {
+      "haiku:bubtonkillingsworth": {
+        opacity: {
+          "0": {
+            value: 0
+          }
+        },
+
+        bazzzleDeeBoopla: {
+          "0": {
+            value: [{ x: 0.5, y: 0.5, moveTo: true }, { x: 71.5, y: 58.5 }]
+          },
+
+          "100": {
+            value: [{ x: 0.5, y: 0.5, moveTo: true }, { x: 71.5, y: 58.5 }]
+          }
+        }
+      },
+
       "haiku:f203a65f49c0": {
         shown: {
           "0": { value: false, curve: "linear" },
@@ -30,6 +48,10 @@ module.exports = {
         },
 
         opacity: {
+          "0": {
+            value: [{ x: 0.5, y: 0.5, moveTo: true }, { x: 71.5, y: 58.5 }]
+          },
+
           "200": { value: 0.0 },
           "300": { value: 0.5, curve: "linear" },
           "1500": { value: 1.0 },
@@ -63,11 +85,17 @@ module.exports = {
         "translation.y": { "0": { value: 55 }, "3000": { value: 300 } },
         "style.outline": { "0": { value: "1px solid gray" } },
         "scale.x": {
-          "0": { value: 0 },
+          "0": {
+            value: 0
+          },
+
           "10": { value: 0 },
           "20": { value: 0 },
           "166": { value: 0 },
-          "200": { value: 0 },
+          "200": {
+            value: [{ x: 0.5, y: 0.5, moveTo: true }, { x: 71.5, y: 58.5 }]
+          },
+
           "300": { value: 0 },
           "400": { value: 0 },
           "500": { value: 0 },
@@ -92,6 +120,12 @@ module.exports = {
       },
 
       "haiku:e5e416e36283": {
+        pathInstructions: {
+          "0": {
+            value: [{ x: 0.5, y: 0.5, moveTo: true }, { x: 71.5, y: 58.5 }]
+          }
+        },
+
         "translation.x": { "0": { value: -5.5, edited: true } },
         "translation.y": { "0": { value: 67.5, edited: true } },
         "sizeAbsolute.x": { "0": { value: 172 } },


### PR DESCRIPTION
OK to merge.

**What:**

- Adds (experiment-hidden) logic for instantiating primitive designs as primitive components
- Various fixes to supporting, tangential, and ancillary logic for this feature

**To the reviewer:**

- Should be a medium review.
- The primitive instantiation behavior is working "in essence," but it is both _unfinished_ and _hidden behind an experiment flag_. (But don't expect it to work right if you enable the experiment flag.) There were some tricky problems surfaced through this work that need to be resolved before I can finish the feature, but...
- I want to merge these changes now, since they will be required in the near future, and will end up fixing some edge cases to the feature and some behavior that we will depend on for multi-component as well.