### PR TITLE
Lottie fixes

### DIFF
--- a/packages/haiku-formats/src/exporters/bodymovin/bodymovinExporter.ts
+++ b/packages/haiku-formats/src/exporters/bodymovin/bodymovinExporter.ts
@@ -882,6 +882,9 @@ export class BodymovinExporter implements Exporter {
   private visitAllTimelines(callback: (timeline: any) => void) {
     for (const timelineId in this.bytecode.timelines) {
       for (const haikuId in this.bytecode.timelines[timelineId]) {
+        if (/^__/.test(haikuId)) {
+          continue;
+        }
         callback(this.bytecode.timelines[timelineId][haikuId]);
       }
     }

--- a/packages/haiku-formats/src/exporters/bodymovin/bodymovinExporter.ts
+++ b/packages/haiku-formats/src/exporters/bodymovin/bodymovinExporter.ts
@@ -465,7 +465,6 @@ export class BodymovinExporter implements Exporter {
         [TransformKey.Color]: getFixedPropertyValue([0, 0, 0, 0]),
         [TransformKey.StrokeLinecap]: StrokeLinecap.Square,
         [TransformKey.StrokeLinejoin]: StrokeLinejoin.Miter,
-        [TransformKey.StrokeDasharray]: [],
       };
     }
 
@@ -476,8 +475,12 @@ export class BodymovinExporter implements Exporter {
       [TransformKey.Color]: this.getValue(timeline.stroke, colorTransformer),
       [TransformKey.StrokeLinecap]: linecapTransformer(initialValueOrNull(timeline, 'stroke-linecap')),
       [TransformKey.StrokeLinejoin]: linejoinTransformer(initialValueOrNull(timeline, 'stroke-linejoin')),
-      [TransformKey.StrokeDasharray]: dasharrayTransformer(initialValueOrNull(timeline, 'stroke-dasharray')),
     };
+
+    const dasharray = initialValueOrNull(timeline, 'stroke-dasharray');
+    if (dasharray) {
+      stroke[TransformKey.StrokeDasharray] = dasharrayTransformer(dasharray);
+    }
 
     return stroke;
   }

--- a/packages/haiku-formats/test/exporters/baseBytecode.ts
+++ b/packages/haiku-formats/test/exporters/baseBytecode.ts
@@ -46,7 +46,8 @@ export default {
             "value": "#00FF00"
           }
         }
-      }
+      },
+      "__max": 1000
     }
   },
   "template": {

--- a/packages/haiku-formats/test/exporters/bodymovin.test.ts
+++ b/packages/haiku-formats/test/exporters/bodymovin.test.ts
@@ -271,7 +271,7 @@ tape('BodymovinExporter', (test: tape.Test) => {
       test.deepEqual(c, {a: 0, k: [1, 0, 0, 1]}, 'parses stroke color');
       test.equal(lc, 3, 'uses stroke-linecap="square" by default');
       test.equal(lj, 1, 'uses stroke-linejoin="miter" by default');
-      test.deepEqual(d, [], 'uses no stroke-dasharray by default');
+      test.is(d, undefined, 'uses no stroke-dasharray by default');
     }
 
     {


### PR DESCRIPTION
Some very minor Lottie fixes I noticed while working on different issues. Just a few minutes to review.

1. lottie-web 5.x doesn't like stroke-dasharray represented as an empty array (`[]`). This changes behavior to only put in a dash array if a nontrivial one exists.
2. Something in `mc` made the virtual timeline property `__max` show up during iteration, which essentially breaks all export. I worked around this by making all __-prefixed timeline IDs get skipped, in case we want to add more "concrete virtual properties" later.