### PR TITLE
Fix: avoid issues with stage zooming and events ui

### DIFF
--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -1845,6 +1845,18 @@ export class Glass extends React.Component {
             </div>
           : ''}
 
+        {!this.isPreviewMode() &&
+          <EventHandlerEditor
+            element={this.state.targetElement}
+            save={(targetElement, serializedEvent) => {
+              this.saveEventHandlers(targetElement, serializedEvent)
+            }}
+            close={() => { this.hideEventHandlersEditor() }}
+            visible={this.state.isEventHandlerEditorOpen}
+            options={this.state.eventHandlerEditorOptions}
+          />
+        }
+
         <div
           ref='container'
           id='haiku-glass-stage-container'
@@ -2036,18 +2048,6 @@ export class Glass extends React.Component {
               })}
             </div>
             : ''}
-
-          {!this.isPreviewMode() &&
-            <EventHandlerEditor
-              element={this.state.targetElement}
-              save={(targetElement, serializedEvent) => {
-                this.saveEventHandlers(targetElement, serializedEvent)
-              }}
-              close={() => { this.hideEventHandlersEditor() }}
-              visible={this.state.isEventHandlerEditorOpen}
-              options={this.state.eventHandlerEditorOptions}
-            />
-          }
 
           {(!this.isPreviewMode())
             ? <div


### PR DESCRIPTION
**Info**

- This should be really easy to review
- It is completely safe to ignore the "Aside" section of this PR, I wrote
it as a way to put my findings somewhere.
- Asana tickets:
  - [Actions dropdown unselectable](https://app.asana.com/0/482906470227387/504797284679451)
  - [Zooming out in the stage makes the Actions panel tiny](https://app.asana.com/0/482906470227387/504560696663895)

**What**

This moves the events UI interface out of the stage wrapper,
therefore all matrix transformations don't affect the modal.

**Aside**

I spent some time playing with the idea of moving the whole UI
into creator, as I think this will be good for us in the future,
mainly because the events UI is going to grow in complexity
(planned, check the spec) and we may be forced to move the
logic into a separate webview down the road. Moving the logic
into creator was a good first step in decoupling everything from
Glass.

I failed because there's a significant amount of effort related
to syncing `ActiveComponent` between the two webviews. At the
current state of things, all instantiation logic is only present
in the `ActiveComponent` instance of Glass.