### PR TITLE
Fix: set preview mode background to root element

### DIFF
--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -1792,7 +1792,8 @@ export class Glass extends React.Component {
           width: '100%',
           height: '100%',
           visibility: (this.getActiveComponent()) ? 'visible' : 'hidden',
-          cursor: this.getCursorCssRule()
+          cursor: this.getCursorCssRule(),
+          backgroundColor: (this.isPreviewMode()) ? 'white' : 'inherit'
         }}
 
         onMouseDown={(mouseDown) => {
@@ -1856,7 +1857,7 @@ export class Glass extends React.Component {
             top: 0,
             left: 0,
             transform: this.getCSSTransform(zoom, pan),
-            backgroundColor: (this.isPreviewMode()) ? 'white' : 'inherit'
+            backgroundColor: 'inherit'
           }}>
 
           {(!this.isPreviewMode())


### PR DESCRIPTION
> Difficulty: easy review
> [Asana ticket](https://app.asana.com/0/482906470227387/505957877019445)

When preview mode is activated, we are setting a white background
(vs the default gray) to reinforce the idea that something is
happening.

This sets the background to the root component of glass, avoiding
the illusion at certain stage sizes that there's a strange border
around the stage.