### PR TITLE
Fix leaky player

### DIFF
--- a/packages/@haiku/player/src/Layout3D.ts
+++ b/packages/@haiku/player/src/Layout3D.ts
@@ -146,6 +146,8 @@ function multiplyArrayOfMatrices(arrayOfMatrices: number[][]): number[] {
 }
 
 function computeLayout(layoutSpec, currentMatrix, parentsizeAbsoluteIn) {
+  // Clean out the existing computed layout from the layout spec, if it exists.
+  delete layoutSpec.computed;
   const parentsizeAbsolute = parentsizeAbsoluteIn || {x: 0, y: 0, z: 0};
 
   if (parentsizeAbsolute.z === undefined || parentsizeAbsolute.z === null) {

--- a/packages/@haiku/player/test/unit/Layout3D.computeLayout.test.js
+++ b/packages/@haiku/player/test/unit/Layout3D.computeLayout.test.js
@@ -16,13 +16,14 @@ test('Layout3D.computeLayout', function (t) {
       sizeProportional: {x: 0.5, y: 1, z: 1},
       sizeMode: {x: 0, y: 0, z: 0},
       sizeDifferential: {x: 0, y: 0, z: 0},
-      sizeAbsolute: {x: 0, y: 0, z: 0}
+      sizeAbsolute: {x: 0, y: 0, z: 0},
+      computed: {}  // Should be removed
     },
     [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
     {x: 852, y: 839, z: 0}
   ];
 
-  const {align, matrix, mount, opacity, origin, shown, size} = Layout3D.computeLayout(...args1);
+  const {align, matrix, mount, opacity, origin, shown, size, computed} = Layout3D.computeLayout(...args1);
 
   t.deepEqual(align, {x: 0, y: 0, z: 0});
   t.deepEqual(matrix, [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 33, 0, 0, 1]);
@@ -31,5 +32,6 @@ test('Layout3D.computeLayout', function (t) {
   t.deepEqual(origin, {x: 0, y: 0, z: 0});
   t.true(shown);
   t.deepEqual(size, {x: 426, y: 839, z: 0});
+  t.is(undefined, computed);
   t.end();
 });


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/480796620059175/515552372320152/f)

Turned out to be a one-liner to fix a major memory leak.

783ac163 introduced a perf regression with [this overzealous use of the object spread notation](https://github.com/HaikuTeam/mono/commit/783ac163f331e79ea3e2d2c8b6402aeaf54b45c1#diff-821c3c0323b1418629401b82f32760d9R157) in a super-obscure way. From tick to tick, layout is patched from the cached `_flatManaTree` if it changed. (The relatively new trick where we cache the flat mana tree vs. recalculating it on every tick, which gives a net perf boost, is actually what made this leak possible!) The problem is that by patching `cachedNode.layout` through vanities, we end up holding on to `catchedNode.layout.computed` from the previous tick. So the `{...layoutSpec}` added in 783ac163 is actually creating an object that looks like this on first tick:

```{layout: {computed: {...}, ...}}```

and this on second tick:

```{layout: {computed: {computed: {...}, ...}, ...}}```

and this on third tick:

```{layout: {computed: {computed: {computed: {...}, ...}, ...}, ...}}```

Which turns out to be a 2GB memory leak in ~20 minutes on a project with a bajillion nodes on loop—just a cascading vortex of `Float32Array`s holding 16-element vectors representing affine transformation matrices from previous ticks.

[timeline slows down over time](https://app.asana.com/0/480796620059175/511844918286659/f) is likely to be a side effect of this too.