### PR TITLE
fix: grandfather in support for plain "backgroundColor" style setter.

### DIFF
--- a/packages/@haiku/player/src/properties/dom/vanities.ts
+++ b/packages/@haiku/player/src/properties/dom/vanities.ts
@@ -179,6 +179,7 @@ function styleSetter(prop) {
 }
 
 const STYLE_VANITIES = {
+  backgroundColor: styleSetter('backgroundColor'),
   'style.alignContent': styleSetter('alignContent'),
   'style.alignItems': styleSetter('alignItems'),
   'style.alignmentBaseline': styleSetter('alignmentBaseline'),


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/480796620059175/515737276298249/f)

Very short review but prepared for @matthewtoast to reject the solution in favor of something that doesn't leave technical debt behind.

This is a suitable one-liner to grandfather in old Haikus created with `backgroundColor` instead of `style.backgroundColor`. There are more elegant ways to do this, but this definitely works.