### PR TITLE
Fix gradual UI slowdown during timeline looping playback

### DIFF
--- a/packages/haiku-serialization/src/bll/BaseModel.js
+++ b/packages/haiku-serialization/src/bll/BaseModel.js
@@ -54,9 +54,11 @@ class BaseModel extends EventEmitter {
       }
     }
 
-    patchEmitter(this, (args) => {
-      this.constructor.emit(args[0], this, args[1], args[2], args[3])
-    })
+    const emit = this.emit
+    this.emit = (a, b, c, d, e, f, g, h, i) => {
+      emit.call(this, a, b, c, d, e, f, g, h, i)
+      this.constructor.emit(a, this, b, c, d, e, f, g, h, i)
+    }
 
     this.assign(props)
 
@@ -355,14 +357,6 @@ function createCollection (klass, collection, opts) {
     collection.forEach((item) => {
       item.cacheClear()
     })
-  }
-}
-
-function patchEmitter (emitter, other) {
-  const old = emitter.emit
-  emitter.emit = function emit () {
-    old.apply(emitter, arguments)
-    other(arguments)
   }
 }
 

--- a/packages/haiku-timeline/src/components/ClusterRow.js
+++ b/packages/haiku-timeline/src/components/ClusterRow.js
@@ -101,7 +101,6 @@ export default class ClusterRow extends React.Component {
             textAlign: 'left'
           }}>
           <ClusterInputField
-            $update={this.props.$update}
             parent={this}
             row={this.props.row}
             index={this.props.row.getAddress()}
@@ -125,7 +124,6 @@ export default class ClusterRow extends React.Component {
             includeDraggables={false}
             preventDragging
             row={this.props.row}
-            $update={this.props.$update}
             component={this.props.component}
             timeline={this.props.timeline}
             rowHeight={this.props.rowHeight} />
@@ -139,6 +137,5 @@ ClusterRow.propTypes = {
   row: React.PropTypes.object.isRequired,
   timeline: React.PropTypes.object.isRequired,
   component: React.PropTypes.object.isRequired,
-  rowHeight: React.PropTypes.number.isRequired,
-  $update: React.PropTypes.object.isRequired
+  rowHeight: React.PropTypes.number.isRequired
 }

--- a/packages/haiku-timeline/src/components/CollapsedPropertyTimelineSegments.js
+++ b/packages/haiku-timeline/src/components/CollapsedPropertyTimelineSegments.js
@@ -20,7 +20,6 @@ export default class CollapsedPropertyTimelineSegments extends React.Component {
           preventDragging
           row={this.props.row}
           component={this.props.component}
-          $update={this.props.$update}
           timeline={this.props.timeline}
           rowHeight={this.props.rowHeight} />
       </div>
@@ -32,6 +31,5 @@ CollapsedPropertyTimelineSegments.propTypes = {
   row: React.PropTypes.object.isRequired,
   timeline: React.PropTypes.object.isRequired,
   component: React.PropTypes.object.isRequired,
-  rowHeight: React.PropTypes.number.isRequired,
-  $update: React.PropTypes.object.isRequired
+  rowHeight: React.PropTypes.number.isRequired
 }

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -90,7 +90,6 @@ export default class ComponentHeadingRow extends React.Component {
                 }
             </span>
             <ComponentHeadingRowHeading
-              $update={this.props.$update}
               row={this.props.row}
               onEventHandlerTriggered={this.props.onEventHandlerTriggered} />
           </div>
@@ -149,7 +148,6 @@ export default class ComponentHeadingRow extends React.Component {
           }}>
           {(!this.props.row.isExpanded())
             ? <CollapsedPropertyTimelineSegments
-              $update={this.props.$update}
               component={this.props.component}
               timeline={this.props.timeline}
               rowHeight={this.props.rowHeight}
@@ -166,6 +164,5 @@ ComponentHeadingRow.propTypes = {
   component: React.PropTypes.object.isRequired,
   timeline: React.PropTypes.object.isRequired,
   rowHeight: React.PropTypes.number.isRequired,
-  $update: React.PropTypes.object.isRequired,
   onEventHandlerTriggered: React.PropTypes.func.isRequired
 }

--- a/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
@@ -117,6 +117,5 @@ export default class ComponentHeadingRowHeading extends React.Component {
 }
 
 ComponentHeadingRowHeading.propTypes = {
-  row: React.PropTypes.object.isRequired,
-  $update: React.PropTypes.object.isRequired
+  row: React.PropTypes.object.isRequired
 }

--- a/packages/haiku-timeline/src/components/ConstantBody.js
+++ b/packages/haiku-timeline/src/components/ConstantBody.js
@@ -109,6 +109,5 @@ ConstantBody.propTypes = {
   keyframe: React.PropTypes.object.isRequired,
   timeline: React.PropTypes.object.isRequired,
   rowHeight: React.PropTypes.number.isRequired,
-  $update: React.PropTypes.object.isRequired,
   preventDragging: React.PropTypes.bool.isRequired
 }

--- a/packages/haiku-timeline/src/components/ControlsArea.js
+++ b/packages/haiku-timeline/src/components/ControlsArea.js
@@ -28,26 +28,6 @@ const STYLES = {
 }
 
 export default class ControlsArea extends React.Component {
-  constructor (props) {
-    super(props)
-    this.handleUpdate = this.handleUpdate.bind(this)
-  }
-
-  componentWillUnmount () {
-    this.mounted = false
-    this.props.timeline.removeListener('update', this.handleUpdate)
-  }
-
-  componentDidMount () {
-    this.mounted = true
-    this.props.timeline.on('update', this.handleUpdate)
-  }
-
-  handleUpdate (what) {
-    if (!this.mounted) return null
-    if (what === 'timeline-frame') this.forceUpdate()
-  }
-
   render () {
     return (
       <div style={STYLES.wrapper}>

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -1178,7 +1178,6 @@ export default class ExpressionInput extends React.Component {
 }
 
 ExpressionInput.propTypes = {
-  $update: React.PropTypes.object.isRequired,
   timeline: React.PropTypes.object.isRequired,
   component: React.PropTypes.object.isRequired,
   reactParent: React.PropTypes.object.isRequired,

--- a/packages/haiku-timeline/src/components/FrameGrid.js
+++ b/packages/haiku-timeline/src/components/FrameGrid.js
@@ -99,6 +99,5 @@ export default class FrameGrid extends React.Component {
 }
 
 FrameGrid.propTypes = {
-  timeline: React.PropTypes.object.isRequired,
-  $update: React.PropTypes.object.isRequired
+  timeline: React.PropTypes.object.isRequired
 }

--- a/packages/haiku-timeline/src/components/Gauge.js
+++ b/packages/haiku-timeline/src/components/Gauge.js
@@ -78,6 +78,5 @@ export default class Gauge extends React.Component {
 
 Gauge.propTypes = {
   timeline: React.PropTypes.object.isRequired,
-  timeDisplayMode: React.PropTypes.string.isRequired,
-  $update: React.PropTypes.object.isRequired
+  timeDisplayMode: React.PropTypes.string.isRequired
 }

--- a/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
+++ b/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
@@ -114,6 +114,5 @@ InvisibleKeyframeDragger.propTypes = {
   keyframe: React.PropTypes.object.isRequired,
   rowHeight: React.PropTypes.number.isRequired,
   timeline: React.PropTypes.object.isRequired,
-  component: React.PropTypes.object.isRequired,
-  $update: React.PropTypes.object.isRequired
+  component: React.PropTypes.object.isRequired
 }

--- a/packages/haiku-timeline/src/components/PlaybackButtons.js
+++ b/packages/haiku-timeline/src/components/PlaybackButtons.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Radium from 'radium'
+import lodash from 'lodash'
 import Palette from 'haiku-ui-common/lib/Palette'
 import SkipBackIconSVG from 'haiku-ui-common/lib/react/icons/SkipBackIconSVG'
 import SkipForwardIconSVG from 'haiku-ui-common/lib/react/icons/SkipForwardIconSVG'
@@ -37,6 +38,7 @@ class PlaybackButtons extends React.Component {
   constructor (props) {
     super(props)
     this.handleUpdate = this.handleUpdate.bind(this)
+    this.throttledForceUpdate = lodash.throttle(this.forceUpdate.bind(this), 64 * 2)
   }
 
   componentWillUnmount () {
@@ -51,7 +53,9 @@ class PlaybackButtons extends React.Component {
 
   handleUpdate (what) {
     if (!this.mounted) return null
-    if (what === 'timeline-frame') this.forceUpdate()
+    if (what === 'timeline-frame') {
+      this.throttledForceUpdate()
+    }
   }
 
   render () {

--- a/packages/haiku-timeline/src/components/PropertyRow.js
+++ b/packages/haiku-timeline/src/components/PropertyRow.js
@@ -94,7 +94,6 @@ export default class PropertyRow extends React.Component {
             textAlign: 'left'
           }}>
           <PropertyInputField
-            $update={this.props.$update}
             parent={this}
             row={this.props.row}
             index={this.props.row.getAddress()}
@@ -131,7 +130,6 @@ export default class PropertyRow extends React.Component {
             height: 'inherit'
           }}>
           <PropertyTimelineSegments
-            $update={this.props.$update}
             component={this.props.component}
             timeline={this.props.timeline}
             rowHeight={this.props.rowHeight}
@@ -146,6 +144,5 @@ PropertyRow.propTypes = {
   row: React.PropTypes.object.isRequired,
   timeline: React.PropTypes.object.isRequired,
   component: React.PropTypes.object.isRequired,
-  rowHeight: React.PropTypes.number.isRequired,
-  $update: React.PropTypes.object.isRequired
+  rowHeight: React.PropTypes.number.isRequired
 }

--- a/packages/haiku-timeline/src/components/PropertyTimelineSegments.js
+++ b/packages/haiku-timeline/src/components/PropertyTimelineSegments.js
@@ -11,7 +11,6 @@ export default class PropertyTimelineSegments extends React.Component {
           preventDragging={false}
           row={this.props.row}
           component={this.props.component}
-          $update={this.props.$update}
           timeline={this.props.timeline}
           rowHeight={this.props.rowHeight} />
       </div>
@@ -23,6 +22,5 @@ PropertyTimelineSegments.propTypes = {
   row: React.PropTypes.object.isRequired,
   component: React.PropTypes.object.isRequired,
   timeline: React.PropTypes.object.isRequired,
-  rowHeight: React.PropTypes.number.isRequired,
-  $update: React.PropTypes.object.isRequired
+  rowHeight: React.PropTypes.number.isRequired
 }

--- a/packages/haiku-timeline/src/components/RowSegments.js
+++ b/packages/haiku-timeline/src/components/RowSegments.js
@@ -49,7 +49,6 @@ export default class RowSegments extends React.Component {
               <TransitionBody
                 preventDragging={this.props.preventDragging}
                 key={`keyframe-${keyframe.getUniqueKeyWithoutTimeIncluded()}-transition-body`}
-                $update={this.props.$update}
                 component={this.props.component}
                 timeline={this.props.timeline}
                 rowHeight={this.props.rowHeight}
@@ -61,7 +60,6 @@ export default class RowSegments extends React.Component {
                 <ConstantBody
                   preventDragging={this.props.preventDragging}
                   key={`keyframe-${keyframe.getUniqueKeyWithoutTimeIncluded()}-constant-body`}
-                  $update={this.props.$update}
                   timeline={this.props.timeline}
                   rowHeight={this.props.rowHeight}
                   keyframe={keyframe} />
@@ -72,7 +70,6 @@ export default class RowSegments extends React.Component {
                 <SoloKeyframe
                   preventDragging={this.props.preventDragging}
                   key={`keyframe-${keyframe.getUniqueKeyWithoutTimeIncluded()}-solo-keyframe`}
-                  $update={this.props.$update}
                   timeline={this.props.timeline}
                   rowHeight={this.props.rowHeight}
                   keyframe={keyframe} />
@@ -86,7 +83,6 @@ export default class RowSegments extends React.Component {
                 <InvisibleKeyframeDragger
                   key={`keyframe-${keyframe.getUniqueKeyWithoutTimeIncluded()}-invisible-1`}
                   offset={-10}
-                  $update={this.props.$update}
                   component={this.props.component}
                   timeline={this.props.timeline}
                   rowHeight={this.props.rowHeight}
@@ -97,7 +93,6 @@ export default class RowSegments extends React.Component {
               <InvisibleKeyframeDragger
                 key={`keyframe-${keyframe.getUniqueKeyWithoutTimeIncluded()}-invisible-2`}
                 offset={0}
-                $update={this.props.$update}
                 component={this.props.component}
                 timeline={this.props.timeline}
                 rowHeight={this.props.rowHeight}
@@ -108,7 +103,6 @@ export default class RowSegments extends React.Component {
                 <InvisibleKeyframeDragger
                   key={`keyframe-${keyframe.getUniqueKeyWithoutTimeIncluded()}-invisible-3`}
                   offset={+10}
-                  $update={this.props.$update}
                   component={this.props.component}
                   timeline={this.props.timeline}
                   rowHeight={this.props.rowHeight}
@@ -141,7 +135,6 @@ RowSegments.propTypes = {
   timeline: React.PropTypes.object.isRequired,
   component: React.PropTypes.object.isRequired,
   rowHeight: React.PropTypes.number.isRequired,
-  $update: React.PropTypes.object.isRequired,
   includeDraggables: React.PropTypes.bool.isRequired,
   preventDragging: React.PropTypes.bool.isRequired
 }

--- a/packages/haiku-timeline/src/components/Scrubber.js
+++ b/packages/haiku-timeline/src/components/Scrubber.js
@@ -1,128 +1,47 @@
 import React from 'react'
-import lodash from 'lodash'
 import { DraggableCore } from 'react-draggable'
-import Palette from 'haiku-ui-common/lib/Palette'
-
-const THROTTLE_TIME = 17 // ms
+import ScrubberInterior from './ScrubberInterior'
 
 export default class Scrubber extends React.Component {
   constructor (props) {
     super(props)
-    this.handleUpdate = this.handleUpdate.bind(this)
+    this.onStartDrag = this.onStartDrag.bind(this)
+    this.onStopDrag = this.onStopDrag.bind(this)
+    this.onDrag = this.onDrag.bind(this)
   }
 
-  componentWillUnmount () {
-    this.mounted = false
-    this.props.timeline.removeListener('update', this.handleUpdate)
+  onStartDrag (dragEvent, dragData) {
+    this.props.timeline.setScrubberDragStart(dragData.x)
+    this.props.timeline.setFrameBaseline(this.props.timeline.getCurrentFrame())
+    this.props.reactParent.setState({
+      avoidTimelinePointerEvents: true
+    })
   }
 
-  componentDidMount () {
-    this.mounted = true
-    this.props.timeline.on('update', this.handleUpdate)
+  onStopDrag (dragEvent, dragData) {
+    this.props.timeline.setScrubberDragStart(null)
+    this.props.timeline.setFrameBaseline(this.props.timeline.getCurrentFrame())
+    this.props.reactParent.setState({
+      avoidTimelinePointerEvents: false
+    })
   }
 
-  handleUpdate (what) {
-    if (!this.mounted) return null
-    if (what === 'timeline-frame' || what === 'timeline-frame-range') this.forceUpdate()
+  onDrag (dragEvent, dragData) {
+    this.props.timeline.changeScrubberPosition(dragData.x)
   }
 
   render () {
-    const frameInfo = this.props.timeline.getFrameInfo()
-
-    if (this.props.timeline.getCurrentFrame() < frameInfo.friA) {
-      return <span />
-    }
-
-    if (this.props.timeline.getCurrentFrame() > frameInfo.friB) {
-      return <span />
-    }
-
-    const currFrame = this.props.timeline.getCurrentFrame()
-
-    const frameOffset = currFrame - frameInfo.friA
-    const pxOffset = frameOffset * frameInfo.pxpf
-
     return (
       <DraggableCore
         axis='x'
-        onStart={(dragEvent, dragData) => {
-          this.props.timeline.setScrubberDragStart(dragData.x)
-          this.props.timeline.setFrameBaseline(this.props.timeline.getCurrentFrame())
-          this.props.reactParent.setState({
-            avoidTimelinePointerEvents: true
-          })
-        }}
-        onStop={(dragEvent, dragData) => {
-          this.props.timeline.setScrubberDragStart(null)
-          this.props.timeline.setFrameBaseline(this.props.timeline.getCurrentFrame())
-          this.props.reactParent.setState({
-            avoidTimelinePointerEvents: false
-          })
-        }}
-        onDrag={lodash.throttle((dragEvent, dragData) => {
-          this.props.timeline.changeScrubberPosition(dragData.x)
-        }, THROTTLE_TIME)}>
-        <div
-          style={{
-            overflow: 'hidden'
-          }}>
-          <div
-            style={{
-              position: 'absolute',
-              backgroundColor: Palette.SUNSTONE,
-              color: Palette.FATHER_COAL,
-              textAlign: 'center',
-              height: 19,
-              width: 19,
-              top: 13,
-              left: pxOffset - 9,
-              borderRadius: '50%',
-              cursor: 'move',
-              boxShadow: '0 0 2px 0 rgba(0, 0, 0, .9)',
-              zIndex: 2006
-            }}>
-            <span style={{
-              position: 'absolute',
-              top: 2,
-              left: 0,
-              width: '100%'
-            }}>
-              {!this.props.isScrubbing && this.props.displayTime}
-            </span>
-            <span style={{
-              position: 'absolute',
-              zIndex: 2006,
-              width: 0,
-              height: 0,
-              top: 15,
-              left: 3,
-              borderLeft: '7px solid transparent',
-              borderRight: '7px solid transparent',
-              borderTop: '9px solid ' + Palette.SUNSTONE
-            }} />
-            <span style={{
-              position: 'absolute',
-              zIndex: 2006,
-              width: 0,
-              height: 0,
-              left: 2,
-              top: 15,
-              borderLeft: '7px solid transparent',
-              borderRight: '7px solid transparent',
-              borderTop: '9px solid ' + Palette.SUNSTONE
-            }} />
-          </div>
-          <div
-            style={{
-              position: 'absolute',
-              zIndex: 2006,
-              backgroundColor: Palette.SUNSTONE,
-              height: 9999,
-              width: 1,
-              top: 35,
-              left: pxOffset,
-              pointerEvents: 'none'
-            }} />
+        onStart={this.onStartDrag}
+        onStop={this.onStopDrag}
+        onDrag={this.onDrag}>
+        <div> {/* draggable requires this div wrapper */}
+          <ScrubberInterior
+            timeline={this.props.timeline}
+            isScrubbing={this.props.isScrubbing}
+            displayTime={this.props.displayTime} />
         </div>
       </DraggableCore>
     )
@@ -132,6 +51,5 @@ export default class Scrubber extends React.Component {
 Scrubber.propTypes = {
   timeline: React.PropTypes.object.isRequired,
   reactParent: React.PropTypes.object.isRequired,
-  $update: React.PropTypes.object.isRequired,
   isScrubbing: React.PropTypes.bool.isRequired
 }

--- a/packages/haiku-timeline/src/components/ScrubberInterior.js
+++ b/packages/haiku-timeline/src/components/ScrubberInterior.js
@@ -1,0 +1,117 @@
+import React from 'react'
+import lodash from 'lodash'
+import Palette from 'haiku-ui-common/lib/Palette'
+
+export default class ScrubberInterior extends React.Component {
+  constructor (props) {
+    super(props)
+    this.handleUpdate = this.handleUpdate.bind(this)
+    this.throttledForceUpdate = lodash.throttle(this.forceUpdate.bind(this), 64)
+  }
+
+  componentWillUnmount () {
+    this.mounted = false
+    this.props.timeline.removeListener('update', this.handleUpdate)
+  }
+
+  componentDidMount () {
+    this.mounted = true
+    this.props.timeline.on('update', this.handleUpdate)
+  }
+
+  handleUpdate (what) {
+    if (!this.mounted) return null
+    if (what === 'timeline-frame') {
+      this.forceUpdate()
+    } else if (what === 'timeline-frame-range') {
+      this.forceUpdate()
+    }
+  }
+
+  render () {
+    const frameInfo = this.props.timeline.getFrameInfo()
+
+    if (this.props.timeline.getCurrentFrame() < frameInfo.friA) {
+      return <span />
+    }
+
+    if (this.props.timeline.getCurrentFrame() > frameInfo.friB) {
+      return <span />
+    }
+
+    const currFrame = this.props.timeline.getCurrentFrame()
+
+    const frameOffset = currFrame - frameInfo.friA
+    const pxOffset = frameOffset * frameInfo.pxpf
+
+    return (
+      <div
+        style={{
+          overflow: 'hidden'
+        }}>
+        <div
+          style={{
+            position: 'absolute',
+            backgroundColor: Palette.SUNSTONE,
+            color: Palette.FATHER_COAL,
+            textAlign: 'center',
+            height: 19,
+            width: 19,
+            top: 13,
+            left: pxOffset - 9,
+            borderRadius: '50%',
+            cursor: 'move',
+            boxShadow: '0 0 2px 0 rgba(0, 0, 0, .9)',
+            zIndex: 2006
+          }}>
+          <span style={{
+            position: 'absolute',
+            top: 2,
+            left: 0,
+            width: '100%'
+          }}>
+            {!this.props.isScrubbing && this.props.displayTime}
+          </span>
+          <span style={{
+            position: 'absolute',
+            zIndex: 2006,
+            width: 0,
+            height: 0,
+            top: 15,
+            left: 3,
+            borderLeft: '7px solid transparent',
+            borderRight: '7px solid transparent',
+            borderTop: '9px solid ' + Palette.SUNSTONE
+          }} />
+          <span style={{
+            position: 'absolute',
+            zIndex: 2006,
+            width: 0,
+            height: 0,
+            left: 2,
+            top: 15,
+            borderLeft: '7px solid transparent',
+            borderRight: '7px solid transparent',
+            borderTop: '9px solid ' + Palette.SUNSTONE
+          }} />
+        </div>
+        <div
+          style={{
+            position: 'absolute',
+            zIndex: 2006,
+            backgroundColor: Palette.SUNSTONE,
+            height: 9999,
+            width: 1,
+            top: 35,
+            left: pxOffset,
+            pointerEvents: 'none'
+          }} />
+      </div>
+    )
+  }
+}
+
+ScrubberInterior.propTypes = {
+  isScrubbing: React.PropTypes.bool.isRequired,
+  timeline: React.PropTypes.object.isRequired
+}

--- a/packages/haiku-timeline/src/components/SoloKeyframe.js
+++ b/packages/haiku-timeline/src/components/SoloKeyframe.js
@@ -65,6 +65,5 @@ export default class SoloKeyframe extends React.Component {
 
 SoloKeyframe.propTypes = {
   keyframe: React.PropTypes.object.isRequired,
-  $update: React.PropTypes.object.isRequired,
   preventDragging: React.PropTypes.bool.isRequired
 }

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -60,7 +60,6 @@ const DEFAULTS = {
   isAltKeyDown: false,
   avoidTimelinePointerEvents: false,
   isPreviewModeActive: false,
-  $update: { time: Date.now() }, // legacy?
   isRepeat: true
 }
 
@@ -664,7 +663,6 @@ class Timeline extends React.Component {
           top: 17
         }}>
         <ControlsArea
-          $update={this.state.$update}
           timeline={this.getActiveComponent().getCurrentTimeline()}
           activeComponentDisplayName={this.props.userconfig.name}
           selectedTimelineName={this.getActiveComponent().getCurrentTimeline().getName()}
@@ -856,15 +854,12 @@ class Timeline extends React.Component {
             paddingTop: 12,
             color: Palette.ROCK_MUTED }}>
           <FrameGrid
-            $update={this.state.$update}
             timeline={this.getActiveComponent().getCurrentTimeline()}
             onShowFrameActionsEditor={this.showFrameActionsEditor} />
           <Gauge
-            $update={this.state.$update}
             timeDisplayMode={this.state.timeDisplayMode}
             timeline={this.getActiveComponent().getCurrentTimeline()} />
           <Scrubber
-            $update={this.state.$update}
             reactParent={this}
             displayTime={displayTime}
             isScrubbing={this.getActiveComponent().getCurrentTimeline().isScrubberDragging()}
@@ -890,7 +885,6 @@ class Timeline extends React.Component {
           zIndex: 10000
         }}>
         <TimelineRangeScrollbar
-          $update={this.state.$update}
           reactParent={this}
           timeline={this.getActiveComponent().getCurrentTimeline()} />
         {this.renderTimelinePlaybackControls()}
@@ -919,7 +913,6 @@ class Timeline extends React.Component {
             return (
               <ClusterRow
                 key={row.getUniqueKey()}
-                $update={this.state.$update}
                 rowHeight={this.state.rowHeight}
                 isPlayerPlaying={this.state.isPlayerPlaying}
                 timeline={this.getActiveComponent().getCurrentTimeline()}
@@ -933,7 +926,6 @@ class Timeline extends React.Component {
             return (
               <PropertyRow
                 key={row.getUniqueKey()}
-                $update={this.state.$update}
                 rowHeight={this.state.rowHeight}
                 isPlayerPlaying={this.state.isPlayerPlaying}
                 timeline={this.getActiveComponent().getCurrentTimeline()}
@@ -947,7 +939,6 @@ class Timeline extends React.Component {
             return (
               <ComponentHeadingRow
                 key={row.getUniqueKey()}
-                $update={this.state.$update}
                 rowHeight={this.state.rowHeight}
                 isPlayerPlaying={this.state.isPlayerPlaying}
                 timeline={this.getActiveComponent().getCurrentTimeline()}
@@ -1052,7 +1043,6 @@ class Timeline extends React.Component {
         {this.renderBottomControls()}
         <ExpressionInput
           ref='expressionInput'
-          $update={this.state.$update}
           reactParent={this}
           component={this.getActiveComponent()}
           timeline={this.getActiveComponent().getCurrentTimeline()}

--- a/packages/haiku-timeline/src/components/TimelineRangeScrollbarPlayheadIndicator.js
+++ b/packages/haiku-timeline/src/components/TimelineRangeScrollbarPlayheadIndicator.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import Palette from 'haiku-ui-common/lib/Palette'
+import lodash from 'lodash'
+
+const KNOB_RADIUS = 5
+
+export default class TimelineRangeScrollbarPlayheadIndicator extends React.Component {
+  constructor (props) {
+    super(props)
+    this.handleUpdate = this.handleUpdate.bind(this)
+    this.throttledForceUpdate = lodash.throttle(this.forceUpdate.bind(this), 64)
+  }
+
+  componentWillUnmount () {
+    this.mounted = false
+    this.props.timeline.removeListener('update', this.handleUpdate)
+  }
+
+  componentDidMount () {
+    this.mounted = true
+    this.props.timeline.on('update', this.handleUpdate)
+  }
+
+  handleUpdate (what) {
+    if (!this.mounted) return null
+    if (what === 'timeline-frame') {
+      this.throttledForceUpdate()
+    }
+  }
+
+  getPlayheadPc (frameInfo) {
+    if (frameInfo.friMaxVirt < 1) return 0
+    const frame = this.props.timeline.getCurrentFrame()
+    if (frame < 1) return 0
+    return (frame / frameInfo.friMax) * 100
+  }
+
+  render () {
+    const frameInfo = this.props.timeline.getFrameInfo()
+
+    return (
+      <div
+        id='timeline-playhead-indicator-container'
+        style={{
+          width: this.props.timeline.getPropertiesPixelWidth() + this.props.timeline.getTimelinePixelWidth() - 35,
+          left: 10,
+          position: 'relative'
+        }}>
+        <div
+          id='timeline-playhead-indicator'
+          style={{
+            position: 'absolute',
+            pointerEvents: 'none',
+            height: KNOB_RADIUS * 2,
+            width: 1,
+            backgroundColor: Palette.ROCK,
+            left: this.getPlayheadPc(frameInfo) + '%'
+          }} />
+      </div>
+    )
+  }
+}
+
+TimelineRangeScrollbarPlayheadIndicator.propTypes = {
+  timeline: React.PropTypes.object.isRequired
+}

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -286,6 +286,5 @@ TransitionBody.propTypes = {
   keyframe: React.PropTypes.object.isRequired,
   timeline: React.PropTypes.object.isRequired,
   component: React.PropTypes.object.isRequired,
-  $update: React.PropTypes.object.isRequired,
   preventDragging: React.PropTypes.bool.isRequired
 }


### PR DESCRIPTION
OK to merge. Medium review.

What:

- Modify meta programming hack to avoid memory leak
- Refactor Timeline UI React components to update in a more granular way
- Debounce some timeline-frame updates

Before these changes, a simple project would see the Timeline UI playback slow down to total stall after 10 or 20 seconds.

After these changes, the Timeline UI can play on a loop for over 1 minute with only a very slight apparent slowdown.