### PR TITLE
Require token when connecting to our websocket server

### DIFF
--- a/packages/haiku-creator/src/dom.js
+++ b/packages/haiku-creator/src/dom.js
@@ -28,7 +28,7 @@ export default function dom (modus, haiku) {
   window.addEventListener('resize', lodash.debounce(resizeHandler, 64))
 
   const websocket = (haiku.plumbing)
-    ? new Websocket(_fixPlumbingUrl(haiku.plumbing.url), haiku.folder, 'commander', 'creator')
+    ? new Websocket(_fixPlumbingUrl(haiku.plumbing.url), haiku.folder, 'commander', 'creator', null, haiku.socket.token)
     : new MockWebsocket()
 
   websocket.on('close', () => {

--- a/packages/haiku-creator/src/electron.js
+++ b/packages/haiku-creator/src/electron.js
@@ -52,7 +52,7 @@ if (!haiku.plumbing.url) {
     throw new Error(`Oops! You must define a HAIKU_PLUMBING_PORT env var!`)
   }
 
-  haiku.plumbing.url = `http://${global.process.env.HAIKU_PLUMBING_HOST || '0.0.0.0'}:${global.process.env.HAIKU_PLUMBING_PORT}/`
+  haiku.plumbing.url = `http://${global.process.env.HAIKU_PLUMBING_HOST || '0.0.0.0'}:${global.process.env.HAIKU_PLUMBING_PORT}/?token=${process.env.HAIKU_WS_SECURITY_TOKEN}`
 }
 
 function different (a, b) {

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -98,6 +98,7 @@ export default class Creator extends React.Component {
     }
 
     this.envoyOptions = {
+      token: this.props.haiku.envoy.token,
       port: this.props.haiku.envoy.port,
       host: this.props.haiku.envoy.host,
       WebSocket: window.WebSocket
@@ -627,7 +628,7 @@ export default class Creator extends React.Component {
         return Project.setup(
           projectFolder,
           'creator', // alias
-          this.props.websocket, // websocket
+          this.props.websocket, // websocket (already initialized)
           window, // platform
           this.props.userconfig, // userconfig
           this.fileOptions,

--- a/packages/haiku-creator/src/react/components/Stage.js
+++ b/packages/haiku-creator/src/react/components/Stage.js
@@ -67,7 +67,8 @@ export default class Stage extends React.Component {
       email: this.props.username,
       envoy: {
         host: this.props.envoyClient.getOption('host'),
-        port: this.props.envoyClient.getOption('port')
+        port: this.props.envoyClient.getOption('port'),
+        token: this.props.envoyClient.getOption('token')
       }
     }))
 

--- a/packages/haiku-creator/src/react/components/Timeline.js
+++ b/packages/haiku-creator/src/react/components/Timeline.js
@@ -47,7 +47,8 @@ export default class Timeline extends React.Component {
       email: this.props.username,
       envoy: {
         host: this.props.envoyClient.getOption('host'),
-        port: this.props.envoyClient.getOption('port')
+        port: this.props.envoyClient.getOption('port'),
+        token: this.props.envoyClient.getOption('token')
       }
     }))
 

--- a/packages/haiku-glass/src/react/index.js
+++ b/packages/haiku-glass/src/react/index.js
@@ -48,7 +48,7 @@ function go () {
   const userconfig = require(path.join(config.folder, 'haiku.js'))
 
   const websocket = (config.plumbing)
-    ? new Websocket(_fixPlumbingUrl(config.plumbing), config.folder, 'controllee', 'glass')
+    ? new Websocket(_fixPlumbingUrl(config.plumbing), config.folder, 'controllee', 'glass', null, config.socket.token)
     : new MockWebsocket()
 
   // Add extra context to Sentry reports, this info is also used

--- a/packages/haiku-sdk-creator/package.json
+++ b/packages/haiku-sdk-creator/package.json
@@ -23,10 +23,11 @@
   ],
   "license": "UNLICENSED",
   "dependencies": {
-    "bluebird": "^3.5.0",
     "@haiku/sdk-client": "2.3.70",
     "@haiku/sdk-inkstone": "2.3.70",
+    "bluebird": "^3.5.0",
     "haiku-serialization": "2.3.70",
+    "qs": "6.4.0",
     "ws": "3.2.0"
   },
   "devDependencies": {

--- a/packages/haiku-sdk-creator/src/envoy/EnvoyClient.ts
+++ b/packages/haiku-sdk-creator/src/envoy/EnvoyClient.ts
@@ -164,7 +164,9 @@ export default class EnvoyClient<T> {
     if (this.connectingPromise) {
       return this.connectingPromise;
     }
-    const url = options.protocol + '://' + options.host + ':' + options.port + options.path;
+
+    const url = `${options.protocol}://${options.host}:${options.port}${options.path}?token=${options.token}`;
+
     this.logger.info('[haiku envoy client] connecting to websocket server %s', url);
 
     this.connectingPromise = new Promise((accept, _) => {

--- a/packages/haiku-sdk-creator/src/envoy/index.ts
+++ b/packages/haiku-sdk-creator/src/envoy/index.ts
@@ -28,6 +28,7 @@ export interface EnvoyOptions {
   WebSocket?: any;
   logger?: any;
   mock?: boolean;
+  token?: string; // Access/authentication token
 }
 
 export const DEFAULT_ENVOY_OPTIONS: EnvoyOptions = {

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -138,10 +138,8 @@ class Timeline extends BaseModel {
     }
 
     if (this.isPlaying()) {
-      console.log('PAUSE')
       this.pause()
     } else {
-      console.log('PLAY')
       this.play()
     }
   }

--- a/packages/haiku-serialization/src/ws/Websocket.js
+++ b/packages/haiku-serialization/src/ws/Websocket.js
@@ -10,7 +10,7 @@ var STATES = {
 }
 
 // Simple wrapper over an in-browser websocket client
-function Websocket (url, folder, clientType, clientAlias, WebSocket) {
+function Websocket (url, folder, clientType, clientAlias, WebSocket, token) {
   EventEmitter.call(this)
 
   this.WebSocket = WebSocket
@@ -29,6 +29,7 @@ function Websocket (url, folder, clientType, clientAlias, WebSocket) {
   // NOTE: The plumbing uses these URL query params to manage comms between clients
   this.url = url + '?type=' + clientType + '&alias=' + clientAlias
   if (folder) this.url += ('&folder=' + folder)
+  if (token) this.url += ('&token=' + token)
 
   this.folder = folder
   this.queue = []

--- a/packages/haiku-timeline/src/index.js
+++ b/packages/haiku-timeline/src/index.js
@@ -42,13 +42,14 @@ function go () {
   const search = (window.location.search || '').split('?')[1] || ''
   const params = qs.parse(search, { plainObjects: true })
   const config = lodash.assign({}, params)
+
   if (!config.folder) throw new Error('A folder (the absolute path to the user project) is required')
   function _fixPlumbingUrl (url) { return url.replace(/^http/, 'ws') }
 
   const userconfig = require(path.join(config.folder, 'haiku.js'))
 
   const websocket = (config.plumbing)
-    ? new Websocket(_fixPlumbingUrl(config.plumbing), config.folder, 'controllee', 'timeline')
+    ? new Websocket(_fixPlumbingUrl(config.plumbing), config.folder, 'controllee', 'timeline', null, config.socket.token)
     : new MockWebsocket()
 
   // Add extra context to Sentry reports, this info is also used


### PR DESCRIPTION
OK to merge; short review.

What:

- Create a hard-to-guess token when we start up, and pass that token to the subviews; then require that all clients provide that token when connecting; forbid those that do not. This prevents unauthorized connections to our websocket server (e.g. a malicious website trying to connect to our websocket server for nefarious purposes).

To the reviewer:

- In the interest of speed, I intentionally did not do any clean up work around the pathways which are involved in setting up the websocket clients nor passing parameters into them. But in looking at this code, it will eventually need a refactor.