### PR TITLE
Allow user to save time display setting (frames vs seconds) per project

### DIFF
--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -320,7 +320,7 @@ class Project extends BaseModel {
   emitHook (...args) {
     const method = args.shift()
     const metadata = args.pop()
-    if (metadata.from === this.getAlias()) {
+    if (metadata && metadata.from === this.getAlias()) {
       this.emit.apply(this, ['update', method].concat(args))
     } else {
       // Otherwise we received an update and may need to update ourselves
@@ -332,7 +332,7 @@ class Project extends BaseModel {
     const method = args.shift()
     const metadata = args.pop()
     // If we originated the action, notify all other views
-    if (metadata.from === this.getAlias()) {
+    if (metadata && metadata.from === this.getAlias()) {
       log.info(`[project (${this.getAlias()})] method hook: ${method}`)
       this.batchedWebsocketAction(
         method,

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -88,6 +88,14 @@ class Timeline extends BaseModel {
     return this._timeDisplayMode
   }
 
+  setTimeDisplayMode (newMode) {
+    this._timeDisplayMode = newMode === 'seconds'
+      ? Timeline.TIME_DISPLAY_MODE.SECONDS
+      : Timeline.TIME_DISPLAY_MODE.FRAMES
+
+    this.emit('update', 'time-display-mode-change')
+  }
+
   toggleTimeDisplayMode () {
     if (this.getTimeDisplayMode() === Timeline.TIME_DISPLAY_MODE.FRAMES) {
       this._timeDisplayMode = Timeline.TIME_DISPLAY_MODE.SECONDS

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -89,10 +89,7 @@ class Timeline extends BaseModel {
   }
 
   setTimeDisplayMode (newMode) {
-    this._timeDisplayMode = newMode === 'seconds'
-      ? Timeline.TIME_DISPLAY_MODE.SECONDS
-      : Timeline.TIME_DISPLAY_MODE.FRAMES
-
+    this._timeDisplayMode = newMode
     this.emit('update', 'time-display-mode-change')
   }
 

--- a/packages/haiku-timeline/src/components/GaugeTimeReadout.js
+++ b/packages/haiku-timeline/src/components/GaugeTimeReadout.js
@@ -30,6 +30,7 @@ export default class GaugeTimeReadout extends React.Component {
 
   handleClick () {
     this.props.timeline.toggleTimeDisplayMode()
+    this.props.reactParent.saveTimeDisplayModeSetting()
   }
 
   render () {

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -21,7 +21,7 @@ import GaugeTimeReadout from './GaugeTimeReadout'
 import TimelineRangeScrollbar from './TimelineRangeScrollbar'
 import HorzScrollShadow from './HorzScrollShadow'
 import {isPreviewMode} from '@haiku/player/lib/helpers/interactionModes'
-import { USER_CHANNEL, User } from 'haiku-sdk-creator/lib/bll/User'
+import { USER_CHANNEL } from 'haiku-sdk-creator/lib/bll/User'
 
 const Globals = require('haiku-ui-common/lib/Globals').default // Sorry, hack
 

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -21,6 +21,8 @@ import GaugeTimeReadout from './GaugeTimeReadout'
 import TimelineRangeScrollbar from './TimelineRangeScrollbar'
 import HorzScrollShadow from './HorzScrollShadow'
 import {isPreviewMode} from '@haiku/player/lib/helpers/interactionModes'
+import formatSeconds from 'haiku-ui-common/lib/helpers/formatSeconds'
+import { USER_CHANNEL, User } from 'haiku-sdk-creator/lib/bll/User'
 
 const Globals = require('haiku-ui-common/lib/Globals').default // Sorry, hack
 
@@ -115,6 +117,18 @@ class Timeline extends React.Component {
 
   componentDidMount () {
     this.mounted = true
+
+    this.project.getEnvoyClient().get(USER_CHANNEL).then(
+      (user) => {
+        this.user = user
+
+        user.getConfig('timeDisplayMode').then(
+          (timeDisplayMode) => {
+            timeDisplayMode && this.setState({timeDisplayMode})
+          }
+        )
+      }
+    )
   }
 
   getActiveComponent () {
@@ -597,6 +611,12 @@ class Timeline extends React.Component {
         this.state[key] = updates[key]
       }
     }
+  }
+
+  toggleTimeDisplayMode () {
+    const mode = this.state.timeDisplayMode === 'frames' ? 'seconds' : 'frames'
+    this.setState({timeDisplayMode: mode})
+    this.user.setConfig('timeDisplayMode', mode)
   }
 
   playbackSkipBack () {


### PR DESCRIPTION
It also updates a default time display setting every time the setting is changed on any project, so that new projects will use the user's preference (or their last preference at least).