### PR TITLE
feat: add endpoints to sdk-instone for password management

### DIFF
--- a/packages/@haiku/sdk-inkstone/src/index.ts
+++ b/packages/@haiku/sdk-inkstone/src/index.ts
@@ -19,7 +19,7 @@ const ENDPOINTS = {
   SUPPORT_UPLOAD_GET_PRESIGNED_URL: 'v0/support/upload/:UUID',
   UPDATES: 'v0/updates',
   RESET_PASSWORD: 'v0/reset-password',
-  RESET_PASSWORD_CLAIM: 'v0/reset-password/:UUID',
+  RESET_PASSWORD_CLAIM: 'v0/reset-password/:UUID/claim',
 };
 
 let request = requestLib.defaults({
@@ -170,17 +170,17 @@ export namespace inkstone {
     }
 
     export function claimResetPassword(
-      resetPasswordUUID: string, password: string, passwordConfirmation: string, cb: inkstone.Callback<boolean>) {
+      resetPasswordUUID: string, password: string, cb: inkstone.Callback<boolean>) {
 
       const options: requestLib.UrlOptions & requestLib.CoreOptions = {
         url: inkstoneConfig.baseUrl + ENDPOINTS.RESET_PASSWORD_CLAIM.replace(':UUID', resetPasswordUUID),
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({password, passwordConfirmation}),
+        body: JSON.stringify({password}),
       };
 
-      request.put(options, (err, httpResponse, body) => {
+      request.post(options, (err, httpResponse, body) => {
         if (httpResponse && httpResponse.statusCode === 200) {
           cb(undefined, true, httpResponse);
         } else {

--- a/packages/@haiku/sdk-inkstone/src/index.ts
+++ b/packages/@haiku/sdk-inkstone/src/index.ts
@@ -18,6 +18,8 @@ const ENDPOINTS = {
   PROJECT_DELETE_BY_NAME: 'v0/project/:NAME',
   SUPPORT_UPLOAD_GET_PRESIGNED_URL: 'v0/support/upload/:UUID',
   UPDATES: 'v0/updates',
+  RESET_PASSWORD: 'v0/reset-password',
+  RESET_PASSWORD_CLAIM: 'v0/reset-password/:UUID',
 };
 
 let request = requestLib.defaults({
@@ -145,6 +147,44 @@ export namespace inkstone {
         } else {
           const response = body as string;
           cb(response, undefined, httpResponse);
+        }
+      });
+    }
+
+    export function requestResetPassword(email: string, cb: inkstone.Callback<boolean>) {
+      const options: requestLib.UrlOptions & requestLib.CoreOptions = {
+        url: inkstoneConfig.baseUrl + ENDPOINTS.RESET_PASSWORD,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({email}),
+      };
+
+      request.post(options, (err, httpResponse, body) => {
+        if (httpResponse && httpResponse.statusCode === 200) {
+          cb(undefined, true, httpResponse);
+        } else {
+          cb(safeError(err), undefined, httpResponse);
+        }
+      });
+    }
+
+    export function claimResetPassword(
+      resetPasswordUUID: string, password: string, passwordConfirmation: string, cb: inkstone.Callback<boolean>) {
+
+      const options: requestLib.UrlOptions & requestLib.CoreOptions = {
+        url: inkstoneConfig.baseUrl + ENDPOINTS.RESET_PASSWORD_CLAIM.replace(':UUID', resetPasswordUUID),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({password, passwordConfirmation}),
+      };
+
+      request.put(options, (err, httpResponse, body) => {
+        if (httpResponse && httpResponse.statusCode === 200) {
+          cb(undefined, true, httpResponse);
+        } else {
+          cb(safeError(err), undefined, httpResponse);
         }
       });
     }


### PR DESCRIPTION
This PR is part of a series of efforts destined to enable a password reset workflow, it's ready for review, but please hold on merging this until https://github.com/HaikuTeam/inkstone/pull/18 is merged.

If you want to test this locally, please merge the above mentioned PR in Inkstone and point to your local URL.

[Asana ticket](https://app.asana.com/0/482906470227387/480796620059192)