### PR TITLE
fix: delete stading-zeroth keyframe if sibling is dragged to zero

### DIFF
--- a/packages/haiku-serialization/src/bll/Row.js
+++ b/packages/haiku-serialization/src/bll/Row.js
@@ -302,7 +302,6 @@ class Row extends BaseModel {
   }
 
   ensureZerothKeyframe (metadata) {
-
     if (!this.hasZerothKeyframe()) {
       this.createKeyframe(this.getFallbackValue(), 0, metadata)
     } else {

--- a/packages/haiku-serialization/src/bll/Row.js
+++ b/packages/haiku-serialization/src/bll/Row.js
@@ -302,12 +302,15 @@ class Row extends BaseModel {
   }
 
   ensureZerothKeyframe (metadata) {
-    const keyframes = this.getKeyframes()
+
     if (!this.hasZerothKeyframe()) {
       this.createKeyframe(this.getFallbackValue(), 0, metadata)
-    } else if (keyframes[1] && keyframes[1].ms === 0) {
+    } else {
       // if a keyframe was dragged onto zero position we want to delete the zero keyframe
-      this.deleteKeyframe(keyframes[0], metadata)
+      const keyframes = this.getKeyframes()
+      while (keyframes.length > 1 && keyframes[1].ms === 0) {
+        this.deleteKeyframe(keyframes.shift(), metadata)
+      }
     }
   }
 

--- a/packages/haiku-serialization/src/bll/Row.js
+++ b/packages/haiku-serialization/src/bll/Row.js
@@ -302,8 +302,12 @@ class Row extends BaseModel {
   }
 
   ensureZerothKeyframe (metadata) {
+    const keyframes = this.getKeyframes()
     if (!this.hasZerothKeyframe()) {
       this.createKeyframe(this.getFallbackValue(), 0, metadata)
+    } else if (keyframes[1] && keyframes[1].ms === 0) {
+      // if a keyframe was dragged onto zero position we want to delete the zero keyframe
+      this.deleteKeyframe(keyframes[0], metadata)
     }
   }
 


### PR DESCRIPTION
[Ticket](https://app.asana.com/0/480796620059175/506363302552363)

bug: when dragging a segment away from starting-point 0 then trying to drag back, we get two zero-keyframes