### PR TITLE
Perf improvements for launch #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "Matthew Trost <matthew@trost.co>",
   "license": "UNLICENSED",
   "scripts": {
+    "add-experiment": "node ./scripts/add-experiment.js",
     "doctor": "node ./scripts/doctor.js",
     "go": "yarn start default",
     "setup": "node ./scripts/setup.js",
@@ -57,6 +58,7 @@
     "standard": "^10.0.2",
     "tap-spec": "^4.1.1",
     "tape": "^4.8.0",
+    "typescript": "^2.5.2",
     "uglify-es": "^3.3.2",
     "yargs": "^6.6.0"
   },

--- a/packages/@haiku/player/demo/templates/debug.html.handlebars
+++ b/packages/@haiku/player/demo/templates/debug.html.handlebars
@@ -19,7 +19,7 @@
   <div id="mount"></div>
   {{{after}}}
   <script>
-    window.HaikuDOMAdapter.default(window.bytecode)(document.getElementById('mount'));
+    window.HaikuDOMAdapter.default(window.bytecode)(document.getElementById('mount'), {loop: true});
   </script>
 </body>
 </html>

--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -29,5 +29,9 @@
   "AsyncClientActions": {
     "development": true,
     "production": true
+  },
+  "NoNormalizeOnSetup": {
+    "development": true,
+    "production": true
   }
 }

--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -8,7 +8,7 @@
   },
   "JustInTimeProperties": {
     "development": true,
-    "production": false
+    "production": true
   },
   "InstantiationOfPrimitivesAsComponents": {
     "development": false,

--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -25,5 +25,9 @@
   "CommentsOnStage": {
     "development": false,
     "production": false
+  },
+  "AsyncClientActions": {
+    "development": true,
+    "production": true
   }
 }

--- a/packages/haiku-common/src/experiments/index.ts
+++ b/packages/haiku-common/src/experiments/index.ts
@@ -16,6 +16,7 @@ export enum Experiment {
   MergeDesignChangesAtCurrentTime = 'MergeDesignChangesAtCurrentTime',
   CommentsOnStage = 'CommentsOnStage',
   AsyncClientActions = 'AsyncClientActions',
+  NoNormalizeOnSetup = 'NoNormalizeOnSetup',
 }
 
 /**

--- a/packages/haiku-common/src/experiments/index.ts
+++ b/packages/haiku-common/src/experiments/index.ts
@@ -15,6 +15,7 @@ export enum Experiment {
   HideInstantiatedElementUntilTimeInstantiated = 'HideInstantiatedElementUntilTimeInstantiated',
   MergeDesignChangesAtCurrentTime = 'MergeDesignChangesAtCurrentTime',
   CommentsOnStage = 'CommentsOnStage',
+  AsyncClientActions = 'AsyncClientActions',
 }
 
 /**

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -470,9 +470,9 @@ export default class Creator extends React.Component {
   }
 
   haveAllProjectsRegisteredStateNameForFolder (folder, what, value = true) {
-    if (!this._projectStates[folder]) return false
-    if (!this._projectStates[folder][what]) return false
     return (
+      this._projectStates[folder] &&
+      this._projectStates[folder][what] &&
       this._projectStates[folder][what].creator === value &&
       this._projectStates[folder][what].glass === value &&
       this._projectStates[folder][what].timeline === value

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -19,6 +19,7 @@ import { TimelineHandler } from 'haiku-sdk-creator/lib/timeline'
 import { TourHandler } from 'haiku-sdk-creator/lib/tour'
 import { inkstone } from '@haiku/sdk-inkstone'
 import { client as sdkClient } from '@haiku/sdk-client'
+import { Experiment, experimentIsEnabled } from 'haiku-common/lib/experiments'
 import StateObject from 'haiku-state-object'
 import serializeError from 'haiku-serialization/src/utils/serializeError'
 import logger from 'haiku-serialization/src/utils/LoggerInstance'
@@ -1047,7 +1048,8 @@ export default class Plumbing extends StateObject {
 
     // Start with the glass, since that's most visible, then move through the rest, and end
     // with master at the end, which results in a file system update reflecting the change
-    return async.eachSeries([Q_GLASS, Q_TIMELINE, Q_CREATOR, MASTER_SPEC], (clientSpec, nextStep) => {
+    const asyncMethod = experimentIsEnabled(Experiment.AsyncClientActions) ? 'each' : 'eachSeries'
+    return async[asyncMethod]([Q_GLASS, Q_TIMELINE, Q_CREATOR, MASTER_SPEC], (clientSpec, nextStep) => {
       if (clientSpec === MASTER_SPEC) {
         logger.info(`[plumbing] -> client action ${method} being sent to master`)
         return this.awaitMasterAndCallMethod(folder, method, params.concat({ from: alias }), cb)

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -1980,12 +1980,7 @@ class ActiveComponent extends BaseModel {
     }
 
     // We'll end up with stale attributes in the DOM unless we do this; this calls .tick()
-    if (reloadOptions.onlyForceFlushIf !== undefined) {
-      if (reloadOptions.onlyForceFlushIf) {
-        this.forceFlush()
-      }
-    } else {
-      // Always force flush unless we have an explicit conditional that wants to decide
+    if (reloadOptions.onlyForceFlushIf === undefined || reloadOptions.onlyForceFlushIf) {
       this.forceFlush()
     }
 
@@ -2170,11 +2165,9 @@ class ActiveComponent extends BaseModel {
     }, {})
 
     // Expand the top row by default, only if this is the first run
-    if (elementHeadingRow.place === 0) {
-      if (!elementHeadingRow._wasInitiallyExpanded) {
-        elementHeadingRow._isExpanded = true
-        elementHeadingRow._wasInitiallyExpanded = true
-      }
+    if (elementHeadingRow.place === 0 && !elementHeadingRow._wasInitiallyExpanded) {
+      elementHeadingRow._isExpanded = true
+      elementHeadingRow._wasInitiallyExpanded = true
     }
 
     if (parentElementRow) {

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -2270,7 +2270,7 @@ class ActiveComponent extends BaseModel {
     // TODO: Instead of rehydrating, only create the entity "on demand" when the object is being edited
     // TODO: Row is only really coherent from the POV of the Timeline UI, so only use it there
     // TODO: Likely lots more optimizations we can do as well... or just rearchitect this to be smarter
-    if (rowDepth < 2) {
+    if (rowDepth < 1) {
       if (virtualNode.children) {
         for (let i = 0; i < virtualNode.children.length; i++) {
           let virtualChild = virtualNode.children[i]

--- a/packages/haiku-serialization/src/bll/BaseModel.js
+++ b/packages/haiku-serialization/src/bll/BaseModel.js
@@ -330,9 +330,7 @@ function createCollection (klass, collection, opts) {
   //       Rather than combing for the unknowable pathways where this logic is get/set (wistful sigh: types) I've hacked the findById logic to search using regex.
   //       Should be drop-in compatible with exact id matching as well.
   klass.findById = (id) => {
-    const MATCHES_ID = new RegExp(id + '$')
-    let all = klass.all().filter((elem) => { return MATCHES_ID.test(elem[klass.config.primaryKey]) })
-    return all[0] // TODO:perf could save some µs by immediately returning first found instead of filtering all
+    return klass.all().find((elem) => elem[klass.config.primaryKey].endsWith(id))
   }
 
   klass.create = (props, opts) => {

--- a/packages/haiku-serialization/src/bll/BaseModel.js
+++ b/packages/haiku-serialization/src/bll/BaseModel.js
@@ -273,9 +273,7 @@ function createCollection (klass, collection, opts) {
     return collection[idx]
   }
 
-  klass.has = (instance) => {
-    return !!klass.get(instance)
-  }
+  klass.has = (instance) => !!klass.get(instance)
 
   klass.add = (instance) => {
     if (!klass.has(instance)) collection.push(instance)
@@ -289,37 +287,21 @@ function createCollection (klass, collection, opts) {
     return collection
   }
 
-  klass.all = () => {
-    return collection.filter((item) => {
-      return !item.isDestroyed()
-    })
-  }
+  klass.all = () => collection.filter((item) => !item.isDestroyed())
 
-  klass.collection = () => {
-    return collection
-  }
+  klass.collection = () => collection
 
-  klass.count = () => {
-    return klass.all().length
-  }
+  klass.count = () => klass.all().length
 
-  klass.filter = (iteratee) => {
-    return klass.all().filter(iteratee)
-  }
+  klass.filter = (iteratee) => klass.all().filter(iteratee)
 
   klass.where = (criteria) => {
     if (!criteria) return klass.all()
     if (Object.keys(criteria).length < 0) return klass.all()
-    return klass.filter((instance) => {
-      return instance.hasAll(criteria)
-    })
+    return klass.filter((instance) => instance.hasAll(criteria))
   }
 
-  klass.any = (criteria) => {
-    return klass.filter((instance) => {
-      return instance.hasAny(criteria)
-    })
-  }
+  klass.any = (criteria) => klass.filter((instance) => instance.hasAny(criteria))
 
   klass.find = (criteria) => {
     const found = klass.where(criteria)
@@ -329,13 +311,10 @@ function createCollection (klass, collection, opts) {
   // HACK:  this logic that searched by id was broken, as uids are in the format '/Users/zack/.haiku/projects/zack3/Romp::main::e4a9e4d8baa7' instead of 'e4a9e4d8baa7'
   //       Rather than combing for the unknowable pathways where this logic is get/set (wistful sigh: types) I've hacked the findById logic to search using regex.
   //       Should be drop-in compatible with exact id matching as well.
-  klass.findById = (id) => {
-    return klass.all().find((elem) => elem[klass.config.primaryKey].endsWith(id))
-  }
+  klass.findById = (id) => klass.all().find((elem) => elem[klass.config.primaryKey].endsWith(id))
 
-  klass.create = (props, opts) => {
-    return new klass(props, opts) // eslint-disable-line
-  }
+  // eslint-disable-next-line
+  klass.create = (props, opts) => new klass(props, opts)
 
   klass.upsert = (props, opts) => {
     klass.clearCaches()
@@ -347,8 +326,7 @@ function createCollection (klass, collection, opts) {
       if (found.afterInitialize) found.afterInitialize()
       return found
     }
-    const created = klass.create(props, opts)
-    return created
+    return klass.create(props, opts)
   }
 
   klass.clearCaches = () => {

--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -5,6 +5,7 @@ const async = require('async')
 const WebSocket = require('ws')
 const dedent = require('dedent')
 const pascalcase = require('pascalcase')
+const { Experiment, experimentIsEnabled } = require('haiku-common/lib/experiments')
 const EnvoyClient = require('haiku-sdk-creator/lib/envoy/EnvoyClient').default
 const EnvoyLogger = require('haiku-sdk-creator/lib/envoy/EnvoyLogger').default
 const { GLASS_CHANNEL } = require('haiku-sdk-creator/lib/glass')
@@ -784,7 +785,7 @@ class Project extends BaseModel {
     // Only write these files if they don't exist yet; don't overwrite the user's own content
     if (!fse.existsSync(path.join(this.getFolder(), `code/${scenename}/code.js`))) {
       fse.outputFileSync(path.join(this.getFolder(), `code/${scenename}/code.js`), rootComponentId)
-    } else {
+    } else if (!experimentIsEnabled(Experiment.NoNormalizeOnSetup)) {
       // If the file already exists, we can run any migration steps we might want
       AST.mutateWith(path.join(this.getFolder(), `code/${scenename}/code.js`), (ast) => {
         normalizeBytecodeFile(ast)

--- a/scripts/add-experiment.js
+++ b/scripts/add-experiment.js
@@ -1,0 +1,61 @@
+const fs = require('fs')
+const path = require('path')
+const args = require('yargs').argv._
+const typescript = require('typescript')
+
+const log = require('./helpers/log')
+
+if (args.length !== 1) {
+  log.warn('Usage: `yarn add-experiment <ExperimentName>`')
+  global.process.exit(1)
+}
+
+const experimentName = args[0]
+
+if (!/^([A-Z][a-z]*)+$/.test(experimentName)) {
+  log.warn(`Invalid experiment name: ${experimentName}. Experiment names should be in StudlyCase.`)
+  global.process.exit(1)
+}
+
+const haikuCommonPath = path.join(global.process.cwd(), 'packages', 'haiku-common')
+const experimentJsonPath = path.join(haikuCommonPath, 'config', 'experiments.json')
+const experimentIndexPath = path.join(haikuCommonPath, 'src', 'experiments', 'index.ts')
+
+const experimentJson = JSON.parse(fs.readFileSync(experimentJsonPath).toString())
+if (Object.prototype.hasOwnProperty.call(experimentJson, experimentName)) {
+  log.warn(`Experiment named ${experimentName} already exists!`)
+  global.process.exit(1)
+}
+
+experimentJson[experimentName] = {
+  development: true,
+  production: false
+}
+
+fs.writeFileSync(experimentJsonPath, JSON.stringify(experimentJson, null, 2) + '\n')
+
+const experimentSource = fs.readFileSync(experimentIndexPath).toString()
+const sourceFile = typescript.createSourceFile(
+  experimentIndexPath, experimentSource, typescript.ScriptTarget.ES2015, true
+)
+
+typescript.forEachChild(sourceFile, (node) => {
+  if (node.kind === typescript.SyntaxKind.EnumDeclaration && node.name.escapedText === 'Experiment') {
+    const enumEndPosition = node.members[node.members.length - 1].end
+    // Hack in the new enum value.
+    fs.writeFileSync(
+      experimentIndexPath,
+      experimentSource.slice(0, enumEndPosition) +
+        `,\n  ${experimentName} = '${experimentName}'` +
+        experimentSource.slice(enumEndPosition)
+    )
+  }
+})
+
+log.hat(`Added experiment ${experimentName}!
+
+Usage:
+
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+...
+if (experimentIsEnabled(Experiment.${experimentName})) { ... }`)

--- a/scripts/lint-report.js
+++ b/scripts/lint-report.js
@@ -4,7 +4,7 @@ const log = require('./helpers/log')
 const allPackages = require('./helpers/packages')()
 const unbuildables = require('./helpers/unbuildables')
 
-let hadError  = false
+let hadError = false
 async.each(allPackages, function (pack, next) {
   if (unbuildables.includes(pack.name) || !pack.pkg.scripts || !pack.pkg.scripts['lint-report']) {
     next()

--- a/scripts/test-report.js
+++ b/scripts/test-report.js
@@ -4,7 +4,7 @@ const log = require('./helpers/log')
 const allPackages = require('./helpers/packages')()
 const unbuildables = require('./helpers/unbuildables')
 
-let hadError  = false
+let hadError = false
 async.each(allPackages, function (pack, next) {
   if (unbuildables.includes(pack.name) || !pack.pkg.scripts || !pack.pkg.scripts['test-report']) {
     next()


### PR DESCRIPTION
I plan to continue shipping incremental improvements to this branch, but this is all ready to merge.

 - Adds `yarn add-experiment` in mono to give us no excuse for registering experiments for potentially destabilizing tweaks.
 - Turns on JIT properties in prod build.
 - Adds looping in Player debug mode, which is helpful in tracing memory leaks that accumulate over time.
 - Fixes the `maxDepth` hack, which was going a level deeper than it needed to.
 - Adds and activates experiment for performing client actions async (i.e. `async.each` instead of `async.eachSeries`).
 - Adds and activates experiment for skipping bytecode normalization on project launch. This removes the extra commit and saves a ton of time on project launch.