### PR TITLE
Fix: A few UI bugs

### DIFF
--- a/packages/haiku-timeline/src/components/ClusterRow.js
+++ b/packages/haiku-timeline/src/components/ClusterRow.js
@@ -52,16 +52,6 @@ export default class ClusterRow extends React.Component {
           cursor: 'pointer'
         }}>
         <div>
-          {!this.props.row.isPropertyOnLastComponent() &&
-            <div style={{
-              position: 'absolute',
-              left: 36,
-              width: 5,
-              zIndex: 1005,
-              borderLeft: '1px solid ' + Palette.GRAY_FIT1,
-              height: this.props.rowHeight
-            }} />
-          }
           <div
             style={{
               position: 'absolute',

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -82,11 +82,25 @@ export default class ComponentHeadingRow extends React.Component {
                 }
               }}
               style={{
-                marginLeft: 10
+                display: 'inline-block',
+                transform: this.props.row.isRootRow() ? 'translate(0, -1px)' : 'translate(15px, -1px)'
               }}>
               {(this.props.row.isExpanded())
-                  ? <span className='utf-icon' style={{ top: 1, left: -1 }}><DownCarrotSVG color={Palette.ROCK} /></span>
-                  : <span className='utf-icon' style={{ top: 3 }}><RightCarrotSVG /></span>
+                  ? <span className='utf-icon'
+                      style={{
+                        top: 1,
+                        pointerEvents: 'none',
+                        left: -1
+                      }}>
+                      <DownCarrotSVG color={Palette.ROCK} />
+                    </span>
+                  : <span className='utf-icon'
+                      style={{
+                        top: 3,
+                        pointerEvents: 'none'
+                      }}>
+                      <RightCarrotSVG />
+                    </span>
                 }
             </span>
             <ComponentHeadingRowHeading

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -87,20 +87,20 @@ export default class ComponentHeadingRow extends React.Component {
               }}>
               {(this.props.row.isExpanded())
                   ? <span className='utf-icon'
-                      style={{
-                        top: 1,
-                        pointerEvents: 'none',
-                        left: -1
-                      }}>
-                      <DownCarrotSVG color={Palette.ROCK} />
-                    </span>
+                    style={{
+                      top: 1,
+                      pointerEvents: 'none',
+                      left: -1
+                    }}>
+                    <DownCarrotSVG color={Palette.ROCK} />
+                  </span>
                   : <span className='utf-icon'
-                      style={{
-                        top: 3,
-                        pointerEvents: 'none'
-                      }}>
-                      <RightCarrotSVG />
-                    </span>
+                    style={{
+                      top: 3,
+                      pointerEvents: 'none'
+                    }}>
+                    <RightCarrotSVG />
+                  </span>
                 }
             </span>
             <ComponentHeadingRowHeading

--- a/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
@@ -54,34 +54,17 @@ export default class ComponentHeadingRowHeading extends React.Component {
     return (
       (this.props.row.isRootRow())
         ? (<div style={{height: 27, display: 'inline-block', transform: 'translateY(1px)'}}>
+          <span style={{marginRight: 4, display: 'inline-block', transform: 'translateY(4px)'}}>
+            <ComponentIconSVG />
+          </span>
           {truncate(this.props.row.element.getTitle() || elementName, 12)}
         </div>)
-        : (<span className='no-select'>
-          <span
-            style={{
-              display: 'inline-block',
-              fontSize: 21,
-              position: 'relative',
-              zIndex: 1005,
-              verticalAlign: 'middle',
-              color: Palette.GRAY_FIT1,
-              marginRight: 7,
-              marginTop: 1
-            }}>
-            <span style={{
-              marginLeft: 5,
-              backgroundColor: Palette.GRAY_FIT1,
-              position: 'absolute',
-              width: 1,
-              height: 25
-            }} />
-            <span style={{marginLeft: 4}}>—</span>
-          </span>
-          <span
+        : (<span
             style={{
               color,
               position: 'relative',
               zIndex: 1005,
+              marginLeft: 10,
               display: 'inline-block',
               width: 100,
               height: 20
@@ -94,9 +77,8 @@ export default class ComponentHeadingRowHeading extends React.Component {
                 left: 0,
                 top: 8
               }}>
-              {(this.props.row.element.isComponent())
-                ? <ComponentIconSVG />
-                : ''}
+              {(this.props.row.element.isComponent()) &&
+                <ComponentIconSVG />}
             </span>
             <span
               style={{
@@ -104,14 +86,13 @@ export default class ComponentHeadingRowHeading extends React.Component {
                 display: 'inline-block',
                 height: 20,
                 left: (this.props.row.element.isComponent())
-                  ? 20
-                  : 0,
+                  ? 25
+                  : 5,
                 top: 7
               }}>
               {truncate(this.props.row.element.getTitle() || `<${elementName}>`, 8)}
             </span>
-          </span>
-        </span>)
+          </span>)
     )
   }
 }

--- a/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
@@ -60,39 +60,39 @@ export default class ComponentHeadingRowHeading extends React.Component {
           {truncate(this.props.row.element.getTitle() || elementName, 12)}
         </div>)
         : (<span
+          style={{
+            color,
+            position: 'relative',
+            zIndex: 1005,
+            marginLeft: 10,
+            display: 'inline-block',
+            width: 100,
+            height: 20
+          }}>
+          <span
             style={{
-              color,
-              position: 'relative',
-              zIndex: 1005,
-              marginLeft: 10,
+              position: 'absolute',
               display: 'inline-block',
-              width: 100,
-              height: 20
+              height: 20,
+              left: 0,
+              top: 8
             }}>
-            <span
-              style={{
-                position: 'absolute',
-                display: 'inline-block',
-                height: 20,
-                left: 0,
-                top: 8
-              }}>
-              {(this.props.row.element.isComponent()) &&
-                <ComponentIconSVG />}
-            </span>
-            <span
-              style={{
-                position: 'absolute',
-                display: 'inline-block',
-                height: 20,
-                left: (this.props.row.element.isComponent())
+            {(this.props.row.element.isComponent()) &&
+            <ComponentIconSVG />}
+          </span>
+          <span
+            style={{
+              position: 'absolute',
+              display: 'inline-block',
+              height: 20,
+              left: (this.props.row.element.isComponent())
                   ? 25
                   : 5,
-                top: 7
-              }}>
-              {truncate(this.props.row.element.getTitle() || `<${elementName}>`, 8)}
-            </span>
-          </span>)
+              top: 7
+            }}>
+            {truncate(this.props.row.element.getTitle() || `<${elementName}>`, 8)}
+          </span>
+        </span>)
     )
   }
 }

--- a/packages/haiku-timeline/src/components/PropertyRow.js
+++ b/packages/haiku-timeline/src/components/PropertyRow.js
@@ -41,8 +41,8 @@ export default class PropertyRow extends React.Component {
               this.props.row.parent.collapse()
             }
           }}>
-          {(this.props.row.isFirstRowOfPropertyCluster())
-            ? <div
+          {(this.props.row.isFirstRowOfPropertyCluster()) &&
+            <div
               style={{
                 position: 'absolute',
                 width: 14,
@@ -53,19 +53,7 @@ export default class PropertyRow extends React.Component {
                 height: 'inherit'
               }}>
               <span className='utf-icon' style={{ top: -4, left: -3 }}><DownCarrotSVG /></span>
-            </div>
-            : ''
-          }
-          {(!this.props.row.isPropertyOnLastComponent() && humanName !== 'background color') &&
-            <div style={{
-              position: 'absolute',
-              left: 36,
-              width: 5,
-              zIndex: 1005,
-              borderLeft: '1px solid ' + Palette.GRAY_FIT1,
-              height: this.props.rowHeight
-            }} />
-          }
+            </div>}
           <div
             className='property-row-label no-select'
             style={{

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -307,7 +307,9 @@ class Timeline extends React.Component {
         type === 'cluster-row'
       ),
       onClick: (event) => {
-        const { ms } = this.getEventPositionInfo(event, offset)
+        const timeline = this.getActiveComponent().getCurrentTimeline()
+        const frameInfo = timeline.getFrameInfo()
+        const ms = Math.round(timeline.getHoveredFrame() * frameInfo.mspf)
         // The model here might be
         model.createKeyframe(undefined, ms, { from: 'timeline' })
       }
@@ -490,18 +492,6 @@ class Timeline extends React.Component {
     })
 
     return items
-  }
-
-  getEventPositionInfo (event, extra) {
-    const frameInfo = this.getActiveComponent().getCurrentTimeline().getFrameInfo()
-
-    const offset = event.offsetX || 0
-    const total = (extra || 0) + offset + Math.round(frameInfo.pxA / frameInfo.pxpf)
-
-    const frame = Math.round(total / frameInfo.pxpf)
-    const ms = Math.round(frame * frameInfo.mspf)
-
-    return { offset, total, frame, ms }
   }
 
   handleScroll (scrollEvent) {


### PR DESCRIPTION
**Fix broken treeline**
Removes the treeline on the timeline. I wasn't a huge fan of it in the first place — too much visual noise for a simple two-tier hierarchy. Feels cleaner now. I also put our component icon next to the root component, which helps with the tier distinction.

**FIx incorrect location of keyframe creation on right click**
[ticket](https://app.asana.com/0/482906470227367/505957877019443)
fix timeline issue where keyframes sometimes don't show up where created (seems to be at certain widths and/or zoom levels)

**Fix Right click create keyframe within a segment appears to be broken**
[ticket](https://app.asana.com/0/480796620059175/519080338804547)