### PR TITLE
noop eval instead of throwing

### DIFF
--- a/packages/haiku-creator/index.html
+++ b/packages/haiku-creator/index.html
@@ -16,7 +16,7 @@
   <div id="mount" style="width: 100%; height: 100%; overflow: hidden;"></div>
   <script>
     window.eval = global.eval = function () {
-      throw new Error('Sorry, eval is forbidden')
+      // noop: eval is forbidden
     }
   </script>
   <script src="../../node_modules/raven-js/dist/raven.js"></script>

--- a/packages/haiku-glass/index.html
+++ b/packages/haiku-glass/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="./public/icons.css">
     <script>
       window.eval = global.eval = function () {
-        throw new Error('Sorry, eval is forbidden')
+        // noop: eval is forbidden
       }
     </script>
     <script>

--- a/packages/haiku-plumbing/HaikuHelper.js
+++ b/packages/haiku-plumbing/HaikuHelper.js
@@ -6,7 +6,7 @@ var cp = require('child_process')
 var path = require('path')
 
 global.eval = function () {
-  throw new Error('Sorry, eval is forbidden')
+  // noop: eval is forbidden
 }
 
 if (process.env.NODE_ENV === 'production') {

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -30,7 +30,7 @@ import { HOMEDIR_PATH } from 'haiku-serialization/src/utils/HaikuHomeDir'
 import Master from './Master'
 
 global.eval = function () { // eslint-disable-line
-  throw new Error('Sorry, eval is forbidden')
+  // noop: eval is forbidden
 }
 
 // Useful debugging originator of calls in shared model code

--- a/packages/haiku-timeline/index.html
+++ b/packages/haiku-timeline/index.html
@@ -14,7 +14,7 @@
     <div id="root"></div>
     <script>
       window.eval = global.eval = function () {
-        throw new Error('Sorry, eval is forbidden')
+        // noop: eval is forbidden
       }
     </script>
     <script src="../../node_modules/raven-js/dist/raven.js"></script>


### PR DESCRIPTION
Instead of throwing when `eval()` is invoked, make it a silent noop.

Fixes https://app.asana.com/0/480796620059175/521910445960082

Even despite the Rollup change, arguably we still don't want to crash the app in the case that some third-party library or untrusted code happens to try to `eval()` something, hence this PR