### PR TITLE
tweak: add terms and privacy policy to the help menu

### DIFF
--- a/packages/haiku-creator/src/TopMenu.js
+++ b/packages/haiku-creator/src/TopMenu.js
@@ -235,6 +235,19 @@ export default class TopMenu extends EventEmitter {
           },
           { type: 'separator' },
           {
+            label: 'Terms of Service',
+            click: () => {
+              shell.openExternal('https://www.haiku.ai/terms-of-service.html')
+            }
+          },
+          {
+            label: 'Privacy Policy',
+            click: () => {
+              shell.openExternal('https://www.haiku.ai/privacy-policy.html')
+            }
+          },
+          { type: 'separator' },
+          {
             label: 'Haiku Community on Slack',
             click: () => {
               shell.openExternal('https://haiku-community.slack.com/')


### PR DESCRIPTION
OK to merge (see note to reviewer).

Short review.

Asana task link: https://app.asana.com/0/515552372320151/524076824989009

Changes in this PR:

- [x] Add links to terms of service and privacy policy on the help menu

![screen shot 2018-01-16 at 11 31 39](https://user-images.githubusercontent.com/4419992/34993979-d85a2702-fab0-11e7-887f-077b3577f9d0.png)

Notes for the reviewer:

- I tried to add a test, but I had difficulties mocking electron methods that are not available in testing. @matthewtoast mentioned that @stristr implemented some utilities to bypass `require()` in order to mock. I'm adding the WIP label until Sasha is online, but if the reviewer considers that is safe to merge without it, go for it.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [x] Ran the automated tests and linted the code
- [ ] Wrote an automated test covering new functionality


cc: @nadonomy 