### PR TITLE
fix: Remove call to method that doesn't exist

### DIFF
--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -794,10 +794,7 @@ export default class Plumbing extends StateObject {
         this.sentryError('createProject', projectCreateErr)
         return cb(projectCreateErr)
       }
-
       const remoteProjectObject = remapProjectObjectToExpectedFormat(projectPayload, this.get('organizationName'))
-      this.createEmptyProjectFolderToHackilyAvoidInitialClone(remoteProjectObject)
-
       return cb(null, remoteProjectObject)
     })
   }


### PR DESCRIPTION
OK to merge.

Short review.

Changes in this PR:

- [x] Fix `TypeError: n.createEmptyProjectFolderToHackilyAvoidInitialClone is not a function` crash on project create