### PR TITLE
Disable async client actions experiment

### DIFF
--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -27,8 +27,8 @@
     "production": false
   },
   "AsyncClientActions": {
-    "development": true,
-    "production": true
+    "development": false,
+    "production": false
   },
   "NoNormalizeOnSetup": {
     "development": true,


### PR DESCRIPTION
OK to merge.

Short review.

Asana task link: n/a -- hotfix for bug noticed on the lfy

Changes in this PR:

- [x] Disable the `AsyncClientAction` experiment to fix bug where elements aren't offset correctly, likely due to `applyPropertyGroupDelta` calc interacting badly with async messages

---

I saw this bug consistently (repro'd four times) when the `AsyncClientAction` experiment was on. I turned it off and then things worked correctly.