### PR TITLE
Reinstate artboards

### DIFF
--- a/packages/haiku-serialization/src/bll/Sketch.js
+++ b/packages/haiku-serialization/src/bll/Sketch.js
@@ -57,10 +57,10 @@ Sketch.sketchtoolPipeline = (abspath) => {
 
   logger.info('[sketchtool] got', abspath)
 
-  // Note: We used to generate Artboards and Pages too (and adding those hooks back here
+  // Note: We used to generate Pages too (and adding those hooks back here
   // would obviously be easy, but we had no docs for how to use them, and all of our collateral
-  // is focused on slices, so for a fairly significant optimization, I've set this up
-  // to only export slices. Feel free to change back if this is a problem.
+  // is focused on slices, so for an optimization, I've set this up
+  // to only export slices and artboards. Feel free to change back if this is a problem.
   const assetBaseFolder = abspath + '.contents/'
 
   // Clear out all old contents that may exist in the folder, so the user doesn't see
@@ -70,11 +70,16 @@ Sketch.sketchtoolPipeline = (abspath) => {
   const sliceFolder = assetBaseFolder + 'slices/'
   fse.mkdirpSync(sliceFolder)
 
+  const artboardFolder = assetBaseFolder + 'artboards/'
+  fse.mkdirpSync(artboardFolder)
+
   // Full Command:
   // $ /Applications/Sketch.app/Contents/Resources/sketchtool/bin/sketchtool export --format=svg --output=~/TEST.sketch.export/artboards/ artboards ~/TEST.sketch
   logger.info('[sketchtool] running commands')
   const outputSlicesCmd = `${PARSER_CLI_PATH} export --format=svg --output=${_escapeShell(sliceFolder)} slices ${_escapeShell(abspath)}`
   execSync(outputSlicesCmd)
+  const outputArtboardsCmd = `${PARSER_CLI_PATH} export --format=svg --output=${_escapeShell(artboardFolder)} artboards ${_escapeShell(abspath)}`
+  execSync(outputArtboardsCmd)
 
   logger.info('[sketchtool] fix gamma correction')
 

--- a/packages/haiku-serialization/test/bll/03_Asset.test.js
+++ b/packages/haiku-serialization/test/bll/03_Asset.test.js
@@ -9,7 +9,7 @@ const PROJECT_MODEL_STUB = {
 }
 
 test('Asset.assetsToDirectoryStructure', (t) => {
-  t.plan(9)
+  t.plan(10)
   const assets = Asset.ingestAssets(PROJECT_MODEL_STUB, {
     'code/main/code.js': {
       relpath: 'code/main/code.js',
@@ -58,7 +58,8 @@ test('Asset.assetsToDirectoryStructure', (t) => {
   t.equal(assets[0].children.length, 1, 'base asset has one child')
   t.equal(assets[0].children[0].kind, 'sketch', 'child asset is sketch')
   t.equal(assets[0].children[0].type, 'container', 'child asset is container')
-  t.equal(assets[0].children[0].children[0].relpath, 'designs/TEST.sketch.contents/slices/Dicey.svg', 'grandchild is svg')
-  t.equal(assets[0].children[0].children[0].kind, 'vector', 'grandchild is vector')
-  t.equal(assets[0].children[0].children[0].type, 'file', 'grandchild is file')
+  t.equal(assets[0].children[0].children[0].relpath, 'designs/designs/TEST.sketch/slices', 'grandchild is slices folder')
+  t.equal(assets[0].children[0].children[0].kind, 'folder', 'grandchild is folder')
+  t.equal(assets[0].children[0].children[0].type, 'container', 'grandchild is container')
+  t.equal(assets[0].dump(), "designs\n  designs/TEST.sketch\n    designs/designs/TEST.sketch/slices\n      designs/TEST.sketch.contents/slices/Dicey.svg\n      designs/TEST.sketch.contents/slices/Slicey.svg\n    designs/designs/TEST.sketch/artboards\n      designs/TEST.sketch.contents/artboards/Another Artboard.svg\n      designs/TEST.sketch.contents/artboards/Artboard.svg",'tree looks ok')
 })


### PR DESCRIPTION
OK to merge.

Short review.

Asana task link: n/a; did on the fly (was removed during corner-cutting in mc)

Changes in this PR:

- [x] Add back the artboard gen hook
- [x] Display artboards in the library

<img width="150" alt="screen shot 2018-01-19 at 12 32 11 pm" src="https://user-images.githubusercontent.com/573480/35163534-1da4888c-fd15-11e7-9543-d4f144f14783.png">

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [x] Ran the automated tests and linted the code
- [x] Wrote an automated test covering new functionality
