### PR TITLE
Stop unmounted dashboard components from rendering in the background

### DIFF
--- a/packages/haiku-creator/src/react/components/ProjectPreview.js
+++ b/packages/haiku-creator/src/react/components/ProjectPreview.js
@@ -41,7 +41,6 @@ class ProjectPreview extends React.Component {
   componentDidMount () {
     if (this.bytecode && this.mount) {
       try {
-
         this.timeline = this.mountAndReturnHaikuComponent().getDefaultTimeline()
       } catch (exception) {
         // noop. Probably caught a backward-incompatible change that doesn't work with the current version of Player.

--- a/packages/haiku-creator/src/react/components/ProjectPreview.js
+++ b/packages/haiku-creator/src/react/components/ProjectPreview.js
@@ -17,6 +17,7 @@ class ProjectPreview extends React.Component {
     this.bytecode = null
     this.mount = null
     this.timeline = null
+    this.component = null
   }
 
   componentWillMount () {
@@ -33,19 +34,15 @@ class ProjectPreview extends React.Component {
     }
   }
 
+  componentWillUnmount () {
+    this.stopComponentClock() // Avoid wasted CPU rendering for unseen DOM nodes
+  }
+
   componentDidMount () {
     if (this.bytecode && this.mount) {
       try {
-        this.timeline = HaikuDOMAdapter(this.bytecode)(
-          this.mount,
-          {
-            sizing: 'cover',
-            alwaysComputeSizing: false,
-            loop: true,
-            interactionMode: InteractionMode.EDIT,
-            autoplay: false
-          }
-        ).getDefaultTimeline()
+
+        this.timeline = this.mountAndReturnHaikuComponent().getDefaultTimeline()
       } catch (exception) {
         // noop. Probably caught a backward-incompatible change that doesn't work with the current version of Player.
       }
@@ -66,6 +63,33 @@ class ProjectPreview extends React.Component {
 
   shouldComponentUpdate () {
     return true
+  }
+
+  stopComponentClock () {
+    if (!this.component) {
+      return
+    }
+
+    this.component.getClock().stop()
+  }
+
+  mountAndReturnHaikuComponent () {
+    const factory = HaikuDOMAdapter(this.bytecode)
+
+    this.stopComponentClock() // Shuts down previous one prevent wasted CPU
+
+    this.component = factory(
+      this.mount,
+      {
+        sizing: 'cover',
+        alwaysComputeSizing: false,
+        loop: true,
+        interactionMode: InteractionMode.EDIT,
+        autoplay: false
+      }
+    )
+
+    return this.component
   }
 
   render () {


### PR DESCRIPTION
OK to merge.

Short review.

Asana task link: n/a, perf improvement

Summary:

All the thumbnails on the dashboard are Haiku components. I discovered that when the user opens a project, those components' contexts (one for each) were all continuing to tick in the background. That was resulting in a small amount of CPU overhead. Profiling showed 2-3ms frames continuously ticking as the user edited. So, we get those ms back by stopping the clock.

In addition and more importantly, I discovered that components on the dashboard would be mounted anew every time the dashboard is loaded: You'd have `num_visits_to_dash * num_projects` HaikuContext objects ticking in the background at all times. (If you had had 10 projects and went to the dashboard 8 times, you'd end up 80 HaikuContext objects always ticking.) This makes the gain likely more significant.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Ran the automated tests and linted the code
- [ ] Wrote an automated test covering new functionality
