### PR TITLE
Launch perf #2

### DIFF
--- a/packages/@haiku/player/src/HaikuComponent.ts
+++ b/packages/@haiku/player/src/HaikuComponent.ts
@@ -945,7 +945,7 @@ HaikuComponent.prototype._clearDetectedInputChanges = function _clearDetectedInp
   return this;
 };
 
-HaikuComponent.prototype.patch = function patch(container, patchOptions) {
+HaikuComponent.prototype.patch = function patch(container, patchOptions, skipCache = false) {
   if (this.isDeactivated()) {
     // If deactivated, pretend like there is nothing to render
     return {};
@@ -974,6 +974,7 @@ HaikuComponent.prototype.patch = function patch(container, patchOptions) {
     this._context,
     timelinesRunning,
     patchOptions,
+    skipCache,
   );
 
   for (const flexId in this._nestedComponentElements) {
@@ -1154,7 +1155,7 @@ function bindContextualEventHandlers(component) {
   }
 }
 
-function applyBehaviors(timelinesRunning, deltas, component, context, isPatchOperation) {
+function applyBehaviors(timelinesRunning, deltas, component, context, isPatchOperation, skipCache = false) {
   // We shouldn't need to add event handlers for patch operations since theoretically that same listener
   // would remain a constant throughout the lifetime of the component
   if (!isPatchOperation) {
@@ -1208,6 +1209,7 @@ function applyBehaviors(timelinesRunning, deltas, component, context, isPatchOpe
           propertiesGroup,
           isPatchOperation,
           component,
+          skipCache,
         );
 
         // [#LEGACY?]
@@ -1231,14 +1233,15 @@ function applyBehaviors(timelinesRunning, deltas, component, context, isPatchOpe
   }
 }
 
-function gatherDeltaPatches(component, template, container, context, timelinesRunning, patchOptions) {
+function gatherDeltaPatches(
+  component, template, container, context, timelinesRunning, patchOptions, skipCache = false) {
   // handlers/vanities depend on attributes objects existing in the first place.
   Layout3D.initializeTreeAttributes(template, container);
   initializeComponentTree(template, component, context, null);
 
   const deltas = {}; // This is what we're going to return - a dictionary of ids to elements
 
-  applyBehaviors(timelinesRunning, deltas, component, context, /*isPatchOperation=*/true);
+  applyBehaviors(timelinesRunning, deltas, component, context, /*isPatchOperation=*/true, skipCache);
 
   if (patchOptions.sizing) {
     computeAndApplyPresetSizing(template, container, patchOptions.sizing, deltas);

--- a/packages/@haiku/player/src/HaikuComponent.ts
+++ b/packages/@haiku/player/src/HaikuComponent.ts
@@ -104,7 +104,7 @@ export default function HaikuComponent(bytecode, context, config, metadata) {
 
   // TIMELINES
   this._timelineInstances = {};
-  this._mutableTimelines = {};
+  this._mutableTimelines = undefined;
   this._hydrateMutableTimelines();
 
   // TEMPLATE
@@ -450,6 +450,7 @@ HaikuComponent.prototype.clearCaches = function clearCaches(options) {
   this._clearDetectedInputChanges();
 
   this._builder.clearCaches(options);
+  this._hydrateMutableTimelines();
 
   this.cache = {};
 
@@ -1059,6 +1060,7 @@ HaikuComponent.prototype.findElementsByHaikuId = function findElementsByHaikuId(
 };
 
 HaikuComponent.prototype._hydrateMutableTimelines = function _hydrateMutableTimelines() {
+  this._mutableTimelines = {};
   if (this._bytecode.timelines) {
     for (const timelineName in this._bytecode.timelines) {
       for (const selector in this._bytecode.timelines[timelineName]) {

--- a/packages/@haiku/player/src/HaikuContext.ts
+++ b/packages/@haiku/player/src/HaikuContext.ts
@@ -222,7 +222,7 @@ HaikuContext.prototype.performFullFlushRender = function performFullFlushRender(
 };
 
 // Call to update elements of the this.component tree - but only those that we detect have changed
-HaikuContext.prototype.performPatchRender = function performPatchRender() {
+HaikuContext.prototype.performPatchRender = function performPatchRender(skipCache = false) {
   if (!this._mount) {
     return void (0);
   }
@@ -230,7 +230,7 @@ HaikuContext.prototype.performPatchRender = function performPatchRender() {
   const container = this._renderer.shouldCreateContainer
     ? this._renderer.createContainer(this._mount)
     : this._renderer.getLastContainer();
-  const patches = this.component.patch(container, this.config.options);
+  const patches = this.component.patch(container, this.config.options, skipCache);
 
   this._renderer.patch(this._mount, patches, this.component);
 };
@@ -281,7 +281,7 @@ HaikuContext.prototype.updateMountRootStyles = function updateMountRootStyles() 
   // }
 };
 
-HaikuContext.prototype.tick = function tick() {
+HaikuContext.prototype.tick = function tick(skipCache = false) {
   let flushed = false;
 
   // Only continue ticking and updating if our root component is still activated and awake;
@@ -294,7 +294,7 @@ HaikuContext.prototype.tick = function tick() {
 
       flushed = true;
     } else {
-      this.performPatchRender();
+      this.performPatchRender(skipCache);
     }
 
     // We update the mount root *after* we complete the render pass ^^ because configuration

--- a/packages/@haiku/player/src/ValueBuilder.ts
+++ b/packages/@haiku/player/src/ValueBuilder.ts
@@ -1210,6 +1210,7 @@ ValueBuilder.prototype.build = function _build(
   propertiesGroup,
   isPatchOperation,
   haikuComponent,
+  skipCache = false,
 ) {
   let isAnythingWorthUpdating = false;
 
@@ -1223,6 +1224,7 @@ ValueBuilder.prototype.build = function _build(
       timelineTime,
       haikuComponent,
       isPatchOperation,
+      skipCache,
     );
 
     // We use undefined as a signal that it's not worthwhile to put this value in the list of updates.
@@ -1273,6 +1275,7 @@ ValueBuilder.prototype.build = function _build(
  * @param haikuComponent {Object} Instance of HaikuPlayer
  * @param isPatchOperation {Boolean} Is this a patch?
  * @param skipCache {Boolean} Skip caching?
+ * @param clearSortedKeyframesCache
  */
 ValueBuilder.prototype.grabValue = function _grabValue(
   timelineName,
@@ -1309,7 +1312,7 @@ ValueBuilder.prototype.grabValue = function _grabValue(
 
   let computedValueForTime;
 
-  // Important: The ActiveComponent depends on the ability to be able to get fresh values via the skipCache optino
+  // Important: The ActiveComponent depends on the ability to be able to get fresh values via the skipCache option.
   if (isPatchOperation && !skipCache) {
     computedValueForTime = Transitions.calculateValueAndReturnUndefinedIfNotWorthwhile(
       parsedValueCluster,

--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -93,6 +93,14 @@ class Library extends React.Component {
 
     // Debounced to avoid 'flicker' when multiple updates are received quickly
     this.handleAssetsChanged = lodash.debounce(this.handleAssetsChanged.bind(this), 250)
+
+    this.broadcastListener = this.broadcastListener.bind(this)
+  }
+
+  broadcastListener ({ name, assets }) {
+    if (name === 'assets-changed') {
+      this.handleAssetsChanged(assets, {isLoading: false})
+    }
   }
 
   handleAssetsChanged (assetsDictionary, otherStates) {
@@ -107,15 +115,15 @@ class Library extends React.Component {
 
     this.reloadAssetList()
 
-    this.props.websocket.on('broadcast', ({ name, assets }) => {
-      if (name === 'assets-changed') {
-        this.handleAssetsChanged(assets, {isLoading: false})
-      }
-    })
+    this.props.websocket.on('broadcast', this.broadcastListener)
 
     sketchUtils.checkIfInstalled().then(isInstalled => {
       this.isSketchInstalled = isInstalled
     })
+  }
+
+  componentWillUnmount () {
+    this.props.websocket.removeListener('broadcast', this.broadcastListener)
   }
 
   reloadAssetList () {

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -364,6 +364,7 @@ export class Glass extends React.Component {
 
   handleFrameChange () {
     let seekMs = 0
+    let deltaMs = 0
 
     // this._stopwatch is null unless we've received an action from the timeline.
     // If we're developing the glass solo, i.e. without a connection to envoy which
@@ -372,7 +373,7 @@ export class Glass extends React.Component {
     if (this._stopwatch !== null) {
       const fps = 60 // TODO:  support variable
       const baseMs = this._lastAuthoritativeFrame * 1000 / fps
-      const deltaMs = (this._playing) ? Date.now() - this._stopwatch : 0
+      deltaMs = (this._playing) ? Date.now() - this._stopwatch : 0
       seekMs = baseMs + deltaMs
     }
 
@@ -384,7 +385,12 @@ export class Glass extends React.Component {
     seekMs = Math.round(seekMs)
 
     if (this.getActiveComponent()) {
-      this.getActiveComponent().setTimelineTimeValue(seekMs, true)
+      this.getActiveComponent().setTimelineTimeValue(
+        seekMs,
+        /* skipTransmit= */ true,
+        /* forceSeek= */ false,
+        /* skipCache= */ deltaMs > 16.666 // iff we have advanced by more than one frame; else regular patch is suitable
+      )
     }
   }
 

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -364,17 +364,14 @@ export class Glass extends React.Component {
 
   handleFrameChange () {
     let seekMs = 0
-    let deltaMs = 0
 
     // this._stopwatch is null unless we've received an action from the timeline.
     // If we're developing the glass solo, i.e. without a connection to envoy which
     // provides the system clock, we can just lock the time value to zero as a hack.
     // TODO: Would be nice to allow full-fledged solo development of glass...
     if (this._stopwatch !== null) {
-      const fps = 60 // TODO:  support variable
-      const baseMs = this._lastAuthoritativeFrame * 1000 / fps
-      deltaMs = (this._playing) ? Date.now() - this._stopwatch : 0
-      seekMs = baseMs + deltaMs
+      // TODO: support variable fps
+      seekMs = (this._lastAuthoritativeFrame * 1000 / 60) + (this._playing ? Date.now() - this._stopwatch : 0)
     }
 
     // This rounding is required otherwise we'll see bizarre behavior on stage.

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -385,12 +385,7 @@ export class Glass extends React.Component {
     seekMs = Math.round(seekMs)
 
     if (this.getActiveComponent()) {
-      this.getActiveComponent().setTimelineTimeValue(
-        seekMs,
-        /* skipTransmit= */ true,
-        /* forceSeek= */ false,
-        /* skipCache= */ deltaMs > 16.666 // iff we have advanced by more than one frame; else regular patch is suitable
-      )
+      this.getActiveComponent().setTimelineTimeValue(seekMs, true)
     }
   }
 

--- a/packages/haiku-plumbing/src/Git.js
+++ b/packages/haiku-plumbing/src/Git.js
@@ -156,7 +156,7 @@ export function upsertRemoteDirectly (pwd, name, url, cb) {
       if (found) {
         // In case we have a project folder that was initially set up with Code Commit, ensure the remote URLs are
         // correct.
-        Remote.lookup(repository, name).then((remote) => {
+        return Remote.lookup(repository, name).then((remote) => {
           if (remote.url() !== url) {
             Remote.setUrl(repository, name, url)
           }

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -880,15 +880,6 @@ export default class Plumbing extends StateObject {
     // Params always arrive with the folder as the first argument, so we strip that off
     params = params.slice(1)
 
-    // This special method gets called frequently (up to 60 times per second) so fast-path it and don't log it
-    if (method === 'setTimelineTime') {
-      if (alias === 'timeline') {
-        return this.sendFolderSpecificClientMethodQuery(folder, Q_GLASS, method, params.concat({ from: alias }), () => {})
-      } else if (alias === 'glass') {
-        return this.sendFolderSpecificClientMethodQuery(folder, Q_TIMELINE, method, params.concat({ from: alias }), () => {})
-      }
-    }
-
     // Start with the glass, since that's most visible, then move through the rest, and end
     // with master at the end, which results in a file system update reflecting the change
     const asyncMethod = experimentIsEnabled(Experiment.AsyncClientActions) ? 'each' : 'eachSeries'

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -325,22 +325,18 @@ class ActiveComponent extends BaseModel {
     return cb(null, pretty(html))
   }
 
-  setTimelineTimeValue (timelineTime, skipTransmit = false, forceSeek = false, skipCache = false) {
+  setTimelineTimeValue (timelineTime, skipTransmit = false, forceSeek = false) {
     timelineTime = Math.round(timelineTime)
     if (timelineTime !== this.getCurrentTimelineTime()) {
       // Note that this call reaches in and updates our instance's timeline objects
       Timeline.setCurrentTime({ component: this }, timelineTime, skipTransmit, forceSeek)
-      if (skipCache) {
-        // If we're supposed to skip the cache in our next tick (this is expected to happen if we have skipped more
-        // than one frame at a time), we should trigger a special "skipCache" tick for each active player component.
-        // This will essentially perform a lightweight full flush render, recomputing all values without without trying
-        // to be clever about which properties have actually changed.
-        this.getActiveInstancesOfHaikuPlayerComponent().forEach((instance) => {
-          if (instance._context && instance._context.tick) {
-            instance._context.tick(true)
-          }
-        })
-      }
+      // Perform a lightweight full flush render, recomputing all values without without trying to be clever about
+      // which properties have actually changed.
+      this.getActiveInstancesOfHaikuPlayerComponent().forEach((instance) => {
+        if (instance._context && instance._context.tick) {
+          instance._context.tick(true)
+        }
+      })
     }
   }
 

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -343,11 +343,11 @@ class Keyframe extends BaseModel {
       this.component.handleKeyframeMove()
 
       if (this.prev()) {
-        this.prev().emit('update', 'keyframe-neighbor-move')
+        this.prev().notifyUpdateReceivers('keyframe-neighbor-move')
       }
 
       if (this.next()) {
-        this.next().emit('update', 'keyframe-neighbor-move')
+        this.next().notifyUpdateReceivers('keyframe-neighbor-move')
       }
     }
 

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -43,17 +43,18 @@ class Keyframe extends BaseModel {
    * @returns {function()}
    */
   registerUpdateReceiver (source, cb) {
+    if (typeof cb !== 'function') {
+      return () => {}
+    }
     this._updateReceivers[source] = cb
     return () => {
-      this._updateReceivers[source] = undefined
+      delete this._updateReceivers[source]
     }
   }
 
   notifyUpdateReceivers (what) {
     Object.keys(this._updateReceivers).forEach((receiver) => {
-      if (typeof this._updateReceivers[receiver] === 'function') {
-        this._updateReceivers[receiver](what)
-      }
+      this._updateReceivers[receiver](what)
     })
   }
 

--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -780,7 +780,12 @@ class Project extends BaseModel {
   }
 
   bootstrapSceneFilesSync (scenename) {
-    const rootComponentId = getCodeJs(Template.getHash(scenename, 12))
+    const rootComponentId = getCodeJs(
+      Template.getHash(scenename, 12),
+      experimentIsEnabled(Experiment.MultiComponentFeatures)
+        ? scenename
+        : path.basename(this.getFolder())
+    )
 
     // Only write these files if they don't exist yet; don't overwrite the user's own content
     if (!fse.existsSync(path.join(this.getFolder(), `code/${scenename}/code.js`))) {
@@ -929,7 +934,7 @@ const File = require('./File')
 const ModuleWrapper = require('./ModuleWrapper')
 const Template = require('./Template')
 
-function getCodeJs (haikuId) {
+function getCodeJs (haikuId, haikuComponentName) {
   return dedent`
     var Haiku = require('@haiku/player')
     module.exports = {
@@ -944,7 +949,7 @@ function getCodeJs (haikuId) {
         elementName: 'div',
         attributes: {
           'haiku-id': '${haikuId}',
-          'haiku-title': 'HaikuComponent'
+          'haiku-title': '${haikuComponentName}'
         },
         children: []
       }

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -955,9 +955,9 @@ Timeline.getMillisecondModulus = function getMillisecondModulus (pxpf) {
   if (pxpf >= 15) return 50
   if (pxpf >= 10) return 100
   if (pxpf >= 5) return 200
-  if (pxpf === 4) return 250
-  if (pxpf === 3) return 500
-  if (pxpf === 2) return 1000
+  if (pxpf >= 4) return 250
+  if (pxpf >= 3) return 500
+  if (pxpf >= 2) return 1000
   return 5000
 }
 

--- a/packages/haiku-timeline/package.json
+++ b/packages/haiku-timeline/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "AUTOSTART=main electron --enable-logging --remote-debugging-port=9222 ./lib/electron.js",
-    "watch": "babel --watch src --out-dir lib --source-maps inline",
+    "watch": "NODE_ENV=development babel --watch src --out-dir lib --source-maps inline",
     "compile": "NODE_ENV=development babel src --out-dir lib --source-maps inline",
     "test": "NODE_ENV=development yarn compile && tape \"test/**/*.test.js\" | tap-spec",
     "test-report": "tape \"test/**/*.test.js\" > test-result.tap",

--- a/packages/haiku-timeline/package.json
+++ b/packages/haiku-timeline/package.json
@@ -52,7 +52,8 @@
     "react-draggable": "2.2.3",
     "react-popover": "^0.4.18",
     "react-scroll-to-component": "^1.0.1",
-    "strip-indent": "^2.0.0"
+    "strip-indent": "^2.0.0",
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/packages/haiku-timeline/src/components/ClusterInputField.js
+++ b/packages/haiku-timeline/src/components/ClusterInputField.js
@@ -36,17 +36,18 @@ class ClusterInputFieldValueDisplay extends React.Component {
   constructor (props) {
     super(props)
     this.handleUpdate = this.handleUpdate.bind(this)
-    this.throttledForceUpdate = lodash.throttle(this.forceUpdate.bind(this), 64)
     this.complexValueElementsEllipsis = [<span key={0}>{'{…}'}</span>]
   }
 
   componentWillUnmount () {
+    this.throttledForceUpdate.cancel()
     this.mounted = false
     this.props.timeline.removeListener('update', this.handleUpdate)
   }
 
   componentDidMount () {
     this.mounted = true
+    this.throttledForceUpdate = lodash.throttle(this.forceUpdate.bind(this), 64)
     this.props.timeline.on('update', this.handleUpdate)
   }
 

--- a/packages/haiku-timeline/src/components/ConstantBody.js
+++ b/packages/haiku-timeline/src/components/ConstantBody.js
@@ -6,17 +6,19 @@ import Globals from 'haiku-ui-common/lib/Globals'
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
 
 export default class ConstantBody extends React.Component {
+  componentWillMount () {
+    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver(uuid(), (what) => {
+      this.handleUpdate(what)
+    })
+  }
+
+  componentDidMount () {
+    this.mounted = true
+  }
 
   componentWillUnmount () {
     this.mounted = false
     this.teardownKeyframeUpdateReceiver()
-  }
-
-  componentDidMount () {
-    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver(uuid(), (what) => {
-      this.handleUpdate(what)
-    })
-    this.mounted = true
   }
 
   handleUpdate (what) {

--- a/packages/haiku-timeline/src/components/ConstantBody.js
+++ b/packages/haiku-timeline/src/components/ConstantBody.js
@@ -3,18 +3,18 @@ import Color from 'color'
 import Palette from 'haiku-ui-common/lib/Palette'
 import Globals from 'haiku-ui-common/lib/Globals'
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
-import Keyframe from 'haiku-serialization/src/bll/Keyframe'
 
 export default class ConstantBody extends React.Component {
   constructor (props) {
     super(props)
-    Keyframe.on('update', (keyframe, what) => {
-      if (keyframe === this.props.keyframe && this.mounted) this.handleUpdate(what)
+    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver('constantBody', (what) => {
+      this.handleUpdate(what)
     })
   }
 
   componentWillUnmount () {
     this.mounted = false
+    this.teardownKeyframeUpdateReceiver()
   }
 
   componentDidMount () {

--- a/packages/haiku-timeline/src/components/ConstantBody.js
+++ b/packages/haiku-timeline/src/components/ConstantBody.js
@@ -1,16 +1,11 @@
 import React from 'react'
 import Color from 'color'
+import uuid from 'uuid/v1'
 import Palette from 'haiku-ui-common/lib/Palette'
 import Globals from 'haiku-ui-common/lib/Globals'
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
 
 export default class ConstantBody extends React.Component {
-  constructor (props) {
-    super(props)
-    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver('constantBody', (what) => {
-      this.handleUpdate(what)
-    })
-  }
 
   componentWillUnmount () {
     this.mounted = false
@@ -18,6 +13,9 @@ export default class ConstantBody extends React.Component {
   }
 
   componentDidMount () {
+    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver(uuid(), (what) => {
+      this.handleUpdate(what)
+    })
     this.mounted = true
   }
 

--- a/packages/haiku-timeline/src/components/Gauge.js
+++ b/packages/haiku-timeline/src/components/Gauge.js
@@ -36,7 +36,7 @@ export default class Gauge extends React.Component {
         <div
           className='gauge'>
           {this.props.timeline.mapVisibleFrames((frameNumber, pixelOffsetLeft, pixelsPerFrame, frameModulus) => {
-            if (frameNumber === 0 || frameNumber % frameModulus === 0) {
+            if ((frameNumber % frameModulus) === 0) {
               return (
                 <span key={`frame-${frameNumber}`} style={{ pointerEvents: 'none', display: 'inline-block', position: 'absolute', left: pixelOffsetLeft, transform: 'translateX(-50%)' }}>
                   <span style={{

--- a/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
+++ b/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
@@ -3,20 +3,23 @@ import lodash from 'lodash'
 import TimelineDraggable from './TimelineDraggable'
 import Globals from 'haiku-ui-common/lib/Globals'
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
-import Keyframe from 'haiku-serialization/src/bll/Keyframe'
 
 const THROTTLE_TIME = 17 // ms
 
 export default class InvisibleKeyframeDragger extends React.Component {
   constructor (props) {
     super(props)
-    Keyframe.on('update', (keyframe, what) => {
-      if (keyframe === this.props.keyframe && this.mounted) this.handleUpdate(what)
-    })
+    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver(
+      'invisibleKeyframeDragger',
+      (what) => {
+        this.handleUpdate(what)
+      }
+    )
   }
 
   componentWillUnmount () {
     this.mounted = false
+    this.teardownKeyframeUpdateReceiver()
   }
 
   componentDidMount () {

--- a/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
+++ b/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import lodash from 'lodash'
+import uuid from 'uuid/v1'
 import TimelineDraggable from './TimelineDraggable'
 import Globals from 'haiku-ui-common/lib/Globals'
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
@@ -7,15 +8,6 @@ import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
 const THROTTLE_TIME = 17 // ms
 
 export default class InvisibleKeyframeDragger extends React.Component {
-  constructor (props) {
-    super(props)
-    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver(
-      'invisibleKeyframeDragger',
-      (what) => {
-        this.handleUpdate(what)
-      }
-    )
-  }
 
   componentWillUnmount () {
     this.mounted = false
@@ -23,6 +15,9 @@ export default class InvisibleKeyframeDragger extends React.Component {
   }
 
   componentDidMount () {
+    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver(uuid(), (what) => {
+      this.handleUpdate(what)
+    })
     this.mounted = true
   }
 

--- a/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
+++ b/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
@@ -8,17 +8,19 @@ import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
 const THROTTLE_TIME = 17 // ms
 
 export default class InvisibleKeyframeDragger extends React.Component {
+  componentWillMount () {
+    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver(uuid(), (what) => {
+      this.handleUpdate(what)
+    })
+  }
+
+  componentDidMount () {
+    this.mounted = true
+  }
 
   componentWillUnmount () {
     this.mounted = false
     this.teardownKeyframeUpdateReceiver()
-  }
-
-  componentDidMount () {
-    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver(uuid(), (what) => {
-      this.handleUpdate(what)
-    })
-    this.mounted = true
   }
 
   handleUpdate (what) {

--- a/packages/haiku-timeline/src/components/PropertyInputField.js
+++ b/packages/haiku-timeline/src/components/PropertyInputField.js
@@ -103,16 +103,17 @@ class PropertyInputFieldValueDisplay extends React.Component {
   constructor (props) {
     super(props)
     this.handleUpdate = this.handleUpdate.bind(this)
-    this.throttledForceUpdate = lodash.throttle(this.forceUpdate.bind(this), 64)
   }
 
   componentWillUnmount () {
     this.mounted = false
+    this.throttledForceUpdate.cancel()
     this.props.timeline.removeListener('update', this.handleUpdate)
   }
 
   componentDidMount () {
     this.mounted = true
+    this.throttledForceUpdate = lodash.throttle(this.forceUpdate.bind(this), 64)
     this.props.timeline.on('update', this.handleUpdate)
   }
 

--- a/packages/haiku-timeline/src/components/SoloKeyframe.js
+++ b/packages/haiku-timeline/src/components/SoloKeyframe.js
@@ -4,17 +4,19 @@ import Palette from 'haiku-ui-common/lib/Palette'
 import KeyframeSVG from 'haiku-ui-common/lib/react/icons/KeyframeSVG'
 
 export default class SoloKeyframe extends React.Component {
+  componentWillMount () {
+    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver(uuid(), (what) => {
+      this.handleUpdate(what)
+    })
+  }
+
+  componentDidMount () {
+    this.mounted = true
+  }
 
   componentWillUnmount () {
     this.mounted = false
     this.teardownKeyframeUpdateReceiver()
-  }
-
-  componentDidMount () {
-    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver(uuid(), (what) => {
-      this.handleUpdate(what)
-    })
-    this.mounted = true
   }
 
   handleUpdate (what) {

--- a/packages/haiku-timeline/src/components/SoloKeyframe.js
+++ b/packages/haiku-timeline/src/components/SoloKeyframe.js
@@ -1,18 +1,18 @@
 import React from 'react'
 import Palette from 'haiku-ui-common/lib/Palette'
 import KeyframeSVG from 'haiku-ui-common/lib/react/icons/KeyframeSVG'
-import Keyframe from 'haiku-serialization/src/bll/Keyframe'
 
 export default class SoloKeyframe extends React.Component {
   constructor (props) {
     super(props)
-    Keyframe.on('update', (keyframe, what) => {
-      if (keyframe === this.props.keyframe && this.mounted) this.handleUpdate(what)
+    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver('soloKeyframe', (what) => {
+      this.handleUpdate(what)
     })
   }
 
   componentWillUnmount () {
     this.mounted = false
+    this.teardownKeyframeUpdateReceiver()
   }
 
   componentDidMount () {

--- a/packages/haiku-timeline/src/components/SoloKeyframe.js
+++ b/packages/haiku-timeline/src/components/SoloKeyframe.js
@@ -1,14 +1,9 @@
 import React from 'react'
+import uuid from 'uuid/v1'
 import Palette from 'haiku-ui-common/lib/Palette'
 import KeyframeSVG from 'haiku-ui-common/lib/react/icons/KeyframeSVG'
 
 export default class SoloKeyframe extends React.Component {
-  constructor (props) {
-    super(props)
-    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver('soloKeyframe', (what) => {
-      this.handleUpdate(what)
-    })
-  }
 
   componentWillUnmount () {
     this.mounted = false
@@ -16,6 +11,9 @@ export default class SoloKeyframe extends React.Component {
   }
 
   componentDidMount () {
+    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver(uuid(), (what) => {
+      this.handleUpdate(what)
+    })
     this.mounted = true
   }
 

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -298,6 +298,10 @@ class Timeline extends React.Component {
   }
 
   handleInteractionModeChange (relpath, interactionMode) {
+    const timeline = this.getActiveComponent().getCurrentTimeline()
+    if (timeline.isPlaying()) {
+      timeline.pause()
+    }
     this.setState({isPreviewModeActive: isPreviewMode(interactionMode)})
   }
 

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -6,7 +6,6 @@ import TimelineDraggable from './TimelineDraggable'
 import KeyframeSVG from 'haiku-ui-common/lib/react/icons/KeyframeSVG'
 import Globals from 'haiku-ui-common/lib/Globals'
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
-import Keyframe from 'haiku-serialization/src/bll/Keyframe'
 
 import {
   EaseInBackSVG,
@@ -81,13 +80,14 @@ const THROTTLE_TIME = 17 // ms
 export default class TransitionBody extends React.Component {
   constructor (props) {
     super(props)
-    Keyframe.on('update', (keyframe, what) => {
-      if (keyframe === this.props.keyframe && this.mounted) this.handleUpdate(what)
+    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver('transitionBody', (what) => {
+      this.handleUpdate(what)
     })
   }
 
   componentWillUnmount () {
     this.mounted = false
+    this.teardownKeyframeUpdateReceiver()
   }
 
   componentDidMount () {

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -79,17 +79,19 @@ const CURVESVGS = {
 const THROTTLE_TIME = 17 // ms
 
 export default class TransitionBody extends React.Component {
+  componentWillMount () {
+    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver(uuid(), (what) => {
+      this.handleUpdate(what)
+    })
+  }
+
+  componentDidMount () {
+    this.mounted = true
+  }
 
   componentWillUnmount () {
     this.mounted = false
     this.teardownKeyframeUpdateReceiver()
-  }
-
-  componentDidMount () {
-    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver(uuid(), (what) => {
-      this.handleUpdate(what)
-    })
-    this.mounted = true
   }
 
   handleUpdate (what) {

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Color from 'color'
 import lodash from 'lodash'
+import uuid from 'uuid/v1'
 import Palette from 'haiku-ui-common/lib/Palette'
 import TimelineDraggable from './TimelineDraggable'
 import KeyframeSVG from 'haiku-ui-common/lib/react/icons/KeyframeSVG'
@@ -78,12 +79,6 @@ const CURVESVGS = {
 const THROTTLE_TIME = 17 // ms
 
 export default class TransitionBody extends React.Component {
-  constructor (props) {
-    super(props)
-    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver('transitionBody', (what) => {
-      this.handleUpdate(what)
-    })
-  }
 
   componentWillUnmount () {
     this.mounted = false
@@ -91,6 +86,9 @@ export default class TransitionBody extends React.Component {
   }
 
   componentDidMount () {
+    this.teardownKeyframeUpdateReceiver = this.props.keyframe.registerUpdateReceiver(uuid(), (what) => {
+      this.handleUpdate(what)
+    })
     this.mounted = true
   }
 

--- a/scripts/helpers/packages.js
+++ b/scripts/helpers/packages.js
@@ -14,6 +14,9 @@ packagePatterns.forEach((pattern) => {
   const packages = glob.sync(path.join(PACKAGE_ROOT, pattern))
   packages.forEach((packageDir) => {
     const pkgJsonPath = path.join(packageDir, 'package.json')
+    if (!fs.existsSync(pkgJsonPath)) {
+      return
+    }
     const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath))
     const shortname = pkgJson.name.replace('haiku-', '').replace('@haiku/', '')
     const pkg = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12155,6 +12155,10 @@ uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
+uuid@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+
 v8flags@^2.0.2, v8flags@^2.0.9, v8flags@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"


### PR DESCRIPTION
Changes in this PR:

- [x] Elide unnecessary full flush renders during glass playback in favor of surgical cache-skipping patches, only when necessary. This greatly speeds up our ability to render a WIP Haiku. 
 - [x] Fix `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 501 update listeners added. Use emitter.setMaxListeners() to increase limit` on percy playback.
 - [x] Rehydrate mutable timelines during cache clearing, which we do frequently while mutating bytecode in place. Failing to do this was a longstanding player bug introduced by the perf pass, mainly due to my prior ignorance of how the component is reloaded during hot editing. The unnecessary full flush rendering we were always doing in Player was obscuring the negative side effects of not doing this, since the entire optimization routine is bypassed in full flush. This may indirectly clear the path to @matthewtoast's in-mem undo/redo moonshot!
 - [x] Fix `setState()` sometimes called an unmounted `<Library />` in Glass, which caused an occasional bug where the user is unable to select elements on the stage. I incorrectly described this as a tour bug as this was the first place I noticed it (sorry @roperzh), but it was an actual issue now fixed.
 - [x] Fix for [Gauge doesn't show enough values on longer projects](https://app.asana.com/0/480796620059175/529942638926528/f)
 - [x] Fix for [Parent label in timeline is HaikuC…mponent (HaikuComponent)](https://app.asana.com/0/480796620059175/529933088332841/f)
 - [x] Fix for [Race on forceUpdate() when collapsing timeline property rows](https://app.asana.com/0/480796620059175/530298508710782/f)
 - [x] Fix for [Triggering preview mode during timeline playback should stop timeline playback](https://app.asana.com/0/480796620059175/530308731229517/f)