### PR TITLE
fix: for Lottie: Translation issues reported by user

### DIFF
--- a/packages/haiku-formats/src/exporters/bodymovin/bodymovinUtils.ts
+++ b/packages/haiku-formats/src/exporters/bodymovin/bodymovinUtils.ts
@@ -353,3 +353,33 @@ export const keyframesFromTimelineProperty = (timelineProperty): number[] => {
  */
 export const timelineValuesAreEquivalent = (valueA: any, valueB: any): boolean =>
   JSON.stringify(valueA) === JSON.stringify(valueB);
+
+/**
+ * Performs "addition" of two timeline properties to achieve naive composition for perfectly commutative additive
+ * properties like translation.x/y/z.
+ *
+ * This approach should be deprecated in favor of a complete solution that composes affine transformation matrices
+ * when time allows.
+ * @param childProperty
+ * @param parentProperty
+ * @returns {any}
+ */
+export const addTimelineProperties = (childProperty: any, parentProperty: any): any => {
+  const childKeyframes = keyframesFromTimelineProperty(childProperty);
+  const outProperty = {};
+  for (let i = 0; i < childKeyframes.length; i++) {
+    if (!parentProperty.hasOwnProperty(childKeyframes[i])) {
+      // If we landed on a keyframe that isn't defined on the parent, "soft panic" and let the entire childProperty
+      // win.
+      // #FIXME: Actually perform conflict resolution on parent properties, same as we do with sibling properties that
+      // need to be combined in Bodymovin such as scale.x/y/z.
+      return childProperty;
+    }
+
+    outProperty[childKeyframes[i]] = {
+      value: childProperty[childKeyframes[i]].value + parentProperty[childKeyframes[i]].value,
+    };
+  }
+
+  return outProperty;
+};

--- a/packages/haiku-formats/test/exporters/bodymovin.test.ts
+++ b/packages/haiku-formats/test/exporters/bodymovin.test.ts
@@ -470,7 +470,11 @@ tape('BodymovinExporter', (test: tape.Test) => {
     // Shim in a group to wrap our shape.
     bytecode.timelines.Default['haiku:group'] = {
       'stroke-width': {0: {value: 5}},
+      'translation.x': {0: {value: 10}},
+      'translation.y': {0: {value: 10}},
     };
+    bytecode.timelines.Default['haiku:shape']['translation.x'] = {0: {value: -10}};
+    bytecode.timelines.Default['haiku:shape']['translation.y'] = {0: {value: -10}};
     bytecode.template.children[0].children = [{
       elementName: 'g',
       attributes: {'haiku-id': 'group'},
@@ -480,10 +484,11 @@ tape('BodymovinExporter', (test: tape.Test) => {
     {
       const {
         layers: [{
-          shapes: [{it: [_, stroke, __]}],
+          shapes: [{it: [_, stroke, __, transform]}],
         }],
       } = rawOutput(bytecode);
       test.equal(stroke.w.k, 10, 'child shape properties override parent group properties');
+      test.deepEqual(transform.p.k, [0, 0], 'parent translations are composed with child translations');
     }
 
     {


### PR DESCRIPTION
OK to merge.

Short review.

[Asana task link](https://app.asana.com/0/480796620059175/515376246146331/f)

Changes in this PR:

- [x] Implement a (very) naive translation composition algorithm to address common Sketch vs. Lottie collapsed groups translation issues we have encountered in the wild, starting with @nadonomy's Facebook emojis. Although the composition is not perfectly valid for all things we're allowed to do in SVG and the correct approach (as noted in comments) would be to calculate, compose, and then decompose layout matrices, this covers the user-facing issues we've heard of so far.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran the automated tests and linted the code
- [x] Wrote an automated test covering new functionality
