### PR TITLE
feat: Adds caret-matches @haiku/player versioning in project folders.

### DIFF
--- a/packages/haiku-plumbing/src/ProjectFolder.js
+++ b/packages/haiku-plumbing/src/ProjectFolder.js
@@ -165,7 +165,7 @@ export function buildProjectContent (_ignoredLegacyArg, projectPath, projectName
           "license": "LicenseRef-LICENSE",
           "main": "index.js",
           "dependencies": {
-            "@haiku/player": "${haikuPlayerVersion}"
+            "@haiku/player": "^${haikuPlayerVersion}"
           }
         }
       `)
@@ -180,7 +180,7 @@ export function buildProjectContent (_ignoredLegacyArg, projectPath, projectName
       if (packageJson.name !== npmPackageName) packageJson.name = npmPackageName
       if (packageJson.dependencies) packageJson.dependencies = {}
       if (!packageJson.dependencies['@haiku/player']) {
-        packageJson.dependencies['@haiku/player'] = haikuPlayerVersion
+        packageJson.dependencies['@haiku/player'] = `^${haikuPlayerVersion}`
       }
 
       logger.info('[project folder] @haiku/player version is', packageJson.dependencies['@haiku/player'])
@@ -189,7 +189,7 @@ export function buildProjectContent (_ignoredLegacyArg, projectPath, projectName
       let upgradeDiff = semver.diff(packageJson.dependencies['@haiku/player'], haikuPlayerVersion)
       if (upgradeDiff === 'patch') {
         logger.sacred('[project folder] upgraded @haiku/player to', haikuPlayerVersion)
-        packageJson.dependencies['@haiku/player'] = haikuPlayerVersion
+        packageJson.dependencies['@haiku/player'] = `^${haikuPlayerVersion}`
       }
     }
 

--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -966,7 +966,7 @@ const DOM_JS = dedent`
 
 const DOM_EMBED_JS = dedent`
   var code = require('./code')
-  var adapter = window.HaikuPlayer && window.HaikuPlayer['${ModuleWrapper.PLAYER_VERSION}']
+  var adapter = window.HaikuResolve && window.HaikuResolve('${ModuleWrapper.PLAYER_VERSION}')
   if (adapter) {
     module.exports = adapter(code)
   } else  {


### PR DESCRIPTION
~~OK to merge.~~

Short review.

[Asana task](https://app.asana.com/0/506410768732346/485744871767400/f)

Changes in this PR:

- [x] In browser mode, use dependency-free caret-semver matching ala `semver` (except without special rules for 0-versions) via `window.HaikuResolve`. Use this resolver instead of checking for an exact version in embed mode.

Completed checkin tasks:

- [ ] Did manual testing of interrelated functionality
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Ran the automated tests and linted the code
- [ ] Wrote an automated test covering new functionality
