### PR TITLE
fix: for crash on loading template projects Move and Moto.

### DIFF
--- a/packages/haiku-plumbing/src/ProjectFolder.js
+++ b/packages/haiku-plumbing/src/ProjectFolder.js
@@ -238,13 +238,6 @@ export function buildProjectContent (_ignoredLegacyArg, projectPath, projectName
         fse.outputFileSync(dir(projectPath, nextFilePath), contentsToCopy)
         fse.removeSync(dir(projectPath, formerFilePath))
       }
-      // Now fix any legacy content that may be present inside of the updated file, e.g. references
-      if (fse.existsSync(dir(projectPath, nextFilePath))) {
-        let fileContents = fse.readFileSync(dir(projectPath, nextFilePath)).toString()
-        fileContents.split('bytecode.js').join('code.js') // Respective to the code/main dir
-        fileContents.split('interpreter.js').join('dom.js') // Respective to the code/main dir
-        fse.outputFileSync(dir(projectPath, nextFilePath), fileContents)
-      }
     }
 
     logger.info('[project folder] removing unneeded files')

--- a/packages/haiku-plumbing/src/ProjectFolder.js
+++ b/packages/haiku-plumbing/src/ProjectFolder.js
@@ -220,10 +220,7 @@ export function buildProjectContent (_ignoredLegacyArg, projectPath, projectName
       'readme.md': 'README.md', // LEGACY: I think we used to name it lowercase, but we want upper
       'license.txt': 'LICENSE.txt', // LEGACY: I think we used to name it lowercase, but we want upper
       // Core code files
-      'bytecode.js': 'code/main/code.js',
-      'interpreter.js': 'code/main/dom.js',
-      'embed.js': 'code/main/dom-embed.js',
-      'react-dom.js': 'code/main/react-dom.js'
+      'bytecode.js': 'code/main/code.js'
 
       // --
       // TODO: Switch the bundle code files to these paths, once we're ready to make the equivalent
@@ -254,7 +251,10 @@ export function buildProjectContent (_ignoredLegacyArg, projectPath, projectName
 
     let filesToRemove = [
       'index.embed.html',
-      'index.standalone.html'
+      'index.standalone.html',
+      'interpreter.js',
+      'embed.js',
+      'react-dom.js'
     ]
     filesToRemove.forEach((fileToRemove) => {
       fse.removeSync(dir(projectPath, fileToRemove))


### PR DESCRIPTION
OK to merge.

Short review.

[Asana task](https://app.asana.com/0/480796620059175/532035242462772)

Changes in this PR:

- [x] Fix crash on loading fresh template projects Move and Moto.

Context: the files formerly known as `<rootDir>/interpreter.js`, `<rootDir>/embed.js`, and `<rootDir>/react-dom.js` aren't necessarily drop-in replacements for their replacements in `<rootDir>/code/main`. In particular, Move and Moto are trying to load `./bytecode.js` instead of `./code.js`, which leads to problems. There's no need to move these files, because they are created by `ProjectFolder` when they don't exist during project bootstrapping.