### PR TITLE
fix: properly disable mouse interaction on timeline when scrubbing

### DIFF
--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -819,8 +819,10 @@ class Timeline extends React.Component {
           id='gauge-box'
           className='gauge-box'
           onMouseDown={(event) => {
-            this.state.doHandleMouseMovesInGauge = true
-            this.state.avoidTimelinePointerEvents = true
+            this.setState({
+              doHandleMouseMovesInGauge: true,
+              avoidTimelinePointerEvents: true
+            })
             this.mouseMoveListener(event)
           }}
           style={{
@@ -875,8 +877,10 @@ class Timeline extends React.Component {
   }
 
   mouseUpListener () {
-    this.state.doHandleMouseMovesInGauge = false
-    this.state.avoidTimelinePointerEvents = false
+    this.setState({
+      doHandleMouseMovesInGauge: false,
+      avoidTimelinePointerEvents: false
+    })
   }
 
   renderBottomControls () {


### PR DESCRIPTION
Deferring decision to merge to @matthewtoast.

Short review.

Asana task links/Changes in this PR:

- [x] [Dragging on timeline sometimes drags properties element](https://app.asana.com/0/480796620059175/532681822311470)

- [x] [TImeline shouldn't vertical scroll while ticker is being dragged](https://app.asana.com/0/480796620059175/529942638926527)



Notes for the reviewer:

Setting/unsetting `pointer-events` and `user-select` on the timeline
rows is handled by a state conditional, which was being set
directly (`this.state.foo = 'bar'`) instead of triggering a render
via `setState`.

I will do the E2E checklist once I get the 👍 by Matthew, since this is likely to affect his performance changes.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [x] Ran the automated tests and linted the code
- [ ] Wrote an automated test covering new functionality
