### PR TITLE
fix: wait until state is set to call gauge events

### DIFF
--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -819,11 +819,14 @@ class Timeline extends React.Component {
           id='gauge-box'
           className='gauge-box'
           onMouseDown={(event) => {
+            event.persist()
+
             this.setState({
               doHandleMouseMovesInGauge: true,
               avoidTimelinePointerEvents: true
+            }, () => {
+              this.mouseMoveListener(event)
             })
-            this.mouseMoveListener(event)
           }}
           style={{
             position: 'absolute',


### PR DESCRIPTION
OK to merge.

Short review.

Changes in this PR:

- [x] Wait until state is completely set to handle scrubber moves

Notes to the reviewer:

While doing the E2E testing of my previous PR (#231), I have found that the ability to click on the gauge to set the scrubber position was broken, this fixes it by waiting until the state is properly set before calling the mouse callback.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
