### PR TITLE
Launch perf #3

### DIFF
--- a/packages/@haiku/player/src/HaikuComponent.ts
+++ b/packages/@haiku/player/src/HaikuComponent.ts
@@ -1062,13 +1062,6 @@ HaikuComponent.prototype.findElementsByHaikuId = function findElementsByHaikuId(
 };
 
 HaikuComponent.prototype._hydrateMutableTimelines = function _hydrateMutableTimelines() {
-  if (this.config.options.hotEditingMode) {
-    // In hot editing mode, any timeline is fair game for mutation, even if it's not actually animated (e.g.
-    // dragging an SVG at keyframe 0).
-    this._mutableTimelines = this._bytecode.timelines;
-    return;
-  }
-
   this._mutableTimelines = {};
   if (this._bytecode.timelines) {
     for (const timelineName in this._bytecode.timelines) {
@@ -1177,7 +1170,9 @@ function applyBehaviors(timelinesRunning, deltas, component, context, isPatchOpe
   for (let i = 0; i < timelinesRunning.length; i++) {
     const timelineInstance = timelinesRunning[i];
     const timelineName = timelineInstance.getName();
-    const timelineDescriptor = isPatchOperation
+    // In hot editing mode, any timeline is fair game for mutation, even if it's not actually animated (e.g.
+    // dragging an SVG at keyframe 0).
+    const timelineDescriptor = isPatchOperation && !component.config.options.hotEditingMode
       ? component._mutableTimelines[timelineName]
       : component._bytecode.timelines[timelineName];
 

--- a/packages/@haiku/player/src/HaikuComponent.ts
+++ b/packages/@haiku/player/src/HaikuComponent.ts
@@ -1062,6 +1062,13 @@ HaikuComponent.prototype.findElementsByHaikuId = function findElementsByHaikuId(
 };
 
 HaikuComponent.prototype._hydrateMutableTimelines = function _hydrateMutableTimelines() {
+  if (this.config.options.hotEditingMode) {
+    // In hot editing mode, any timeline is fair game for mutation, even if it's not actually animated (e.g.
+    // dragging an SVG at keyframe 0).
+    this._mutableTimelines = this._bytecode.timelines;
+    return;
+  }
+
   this._mutableTimelines = {};
   if (this._bytecode.timelines) {
     for (const timelineName in this._bytecode.timelines) {

--- a/packages/@haiku/player/test/render/dom/hotEditingMode.test.js
+++ b/packages/@haiku/player/test/render/dom/hotEditingMode.test.js
@@ -1,0 +1,74 @@
+var test = require('tape')
+var TestHelpers = require('./../../TestHelpers')
+
+test('render.dom.hotEditingMode.on', function (t) {
+  const template = {
+    elementName: 'div',
+    attributes: { 'haiku-id': 'abcde' },
+    children: []
+  }
+
+  const timelines = {
+    Default: {
+      'haiku:abcde': {
+        'opacity': { 0: { value: 1 } }
+      }
+    }
+  }
+
+  const config = { options: { hotEditingMode: true } }
+
+  TestHelpers.createRenderTest(
+    template,
+    timelines,
+    config,
+    function (err, mount, renderer, context, component, teardown) {
+      if (err) throw err
+      context.tick()
+      t.equal(mount.firstChild.haiku.virtual.layout.opacity, 1, 'initial opacity is 1')
+      component._bytecode.timelines.Default['haiku:abcde'].opacity['0'].value = 0.5
+      component.clearCaches()
+      context.tick()
+      t.equal(mount.firstChild.haiku.virtual.layout.opacity, 0.5, 'non-animated property updated in hot-editing mode')
+      teardown()
+    }
+  )
+
+  t.end()
+})
+
+test('render.dom.hotEditingMode.off', function (t) {
+  const template = {
+    elementName: 'div',
+    attributes: { 'haiku-id': 'abcde' },
+    children: []
+  }
+
+  const timelines = {
+    Default: {
+      'haiku:abcde': {
+        'opacity': { 0: { value: 1 } }
+      }
+    }
+  }
+
+  const config = { options: { hotEditingMode: false } }
+
+  TestHelpers.createRenderTest(
+    template,
+    timelines,
+    config,
+    function (err, mount, renderer, context, component, teardown) {
+      if (err) throw err
+      context.tick()
+      t.equal(mount.firstChild.haiku.virtual.layout.opacity, 1, 'initial opacity is 1')
+      component._bytecode.timelines.Default['haiku:abcde'].opacity['0'].value = 0.5
+      component.clearCaches()
+      context.tick()
+      t.equal(mount.firstChild.haiku.virtual.layout.opacity, 1, 'non-animated property is static without hot-editing mode')
+      teardown()
+    }
+  )
+
+  t.end()
+})

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -315,6 +315,7 @@ export class Glass extends React.Component {
     // turning preview mode off, but needs discussion with the team.
     if (this.isPreviewMode()) {
       this.hideEventHandlersEditor()
+      this._playing = false
     }
 
     this.getActiveComponent().getCurrentTimeline().togglePreviewPlayback(this.isPreviewMode())
@@ -356,6 +357,10 @@ export class Glass extends React.Component {
   }
 
   handleTimelineDidPause (frameData) {
+    if (!this._playing) {
+      // If we have already been paused by a higher level event (e.g. toggling preview mode), do nothing.
+      return
+    }
     const ac = this.getActiveComponent()
     // Ensure preview mode is inactive before activating hot editing mode. If we toggle preview mode on during timeline
     // playback, we will typically receive the pause *after* the interaction mode change.

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -347,11 +347,21 @@ export class Glass extends React.Component {
   }
 
   handleTimelineDidPlay () {
+    const ac = this.getActiveComponent()
+    if (ac) {
+      ac.setHotEditingMode(false)
+    }
     this._playing = true
     this._stopwatch = Date.now()
   }
 
   handleTimelineDidPause (frameData) {
+    const ac = this.getActiveComponent()
+    // Ensure preview mode is inactive before activating hot editing mode. If we toggle preview mode on during timeline
+    // playback, we will typically receive the pause *after* the interaction mode change.
+    if (ac && !ac.isPreviewModeActive()) {
+      ac.setHotEditingMode(true)
+    }
     this._playing = false
     this._lastAuthoritativeFrame = frameData.frame
     this._stopwatch = Date.now()

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -439,6 +439,12 @@ class ActiveComponent extends BaseModel {
     })
   }
 
+  setHotEditingMode (hotEditingMode) {
+    this.getActiveInstancesOfHaikuPlayerComponent().forEach((instance) => {
+      instance.assignConfig({ options: { hotEditingMode } })
+    })
+  }
+
   createComponentFromElements (elements, metadata, cb) {
     if (elements.length < 1) return cb()
 

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -2028,7 +2028,7 @@ class ActiveComponent extends BaseModel {
     }
 
     // We'll end up with stale attributes in the DOM unless we do this; this calls .tick()
-    if (reloadOptions.onlyForceFlushIf === undefined || reloadOptions.onlyForceFlushIf) {
+    if (reloadOptions.onlyForceFlushIf) {
       this.forceFlush()
     }
 

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -426,7 +426,9 @@ class ActiveComponent extends BaseModel {
     this.getActiveInstancesOfHaikuPlayerComponent().forEach((instance) => {
       instance.assignConfig({
         options: {
-          interactionMode: this._interactionMode
+          interactionMode: interactionMode,
+          // Disable hot editing mode during preview mode for smooth playback.
+          hotEditingMode: !this.isPreviewModeActive()
         }
       })
     })


### PR DESCRIPTION
OK to merge.

Short review.

Asana tasks:
 - [element movement via arrow keys on glass seems to stop working after a few keypresses](https://app.asana.com/0/480796620059175/530449952311263/f)
 - [Perf: On-stage updates overaggressively tell player to do full flush render](https://app.asana.com/0/480796620059175/515785338805656/f)
 - [playback state gets weird when entering preview mode during playback](https://app.asana.com/0/480796620059175/531516433118284/f)

Changes in this PR:

- [x] Skip `forceFlush()` during `softReload()` unless explicitly requested.
- [x] Bypass the "this thing is probably immutable" optimizations in hot editing mode so we don't have to rely on `forceFlush()` to update non-animated properties (e.g. a static background layer being dragged around at keyframe 0).
- [x] Coordinate hot-patching of hot editing mode in our visible non-headless (headful) context (Glass) when playback is active, so playback can continue to benefit from the "this thing is probably immutable" optimizations.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] ~~Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)~~
- [ ] ~~Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)~~
- [x] Ran the automated tests and linted the code
- [x] Wrote an automated test covering new functionality