### PR TITLE
Fix copy of share link when on-stage element is selected

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -383,8 +383,16 @@ export default class Creator extends React.Component {
     })
 
     this.envoyClient.get(GLASS_CHANNEL).then((glassChannel) => {
-      document.addEventListener('cut', glassChannel.cut)
-      document.addEventListener('copy', glassChannel.copy)
+      document.addEventListener('cut', (clipboardEvent) => {
+        if (!this.isShareLinkCopyEvent(clipboardEvent)) {
+          glassChannel.cut(clipboardEvent)
+        }
+      })
+      document.addEventListener('copy', (clipboardEvent) => {
+        if (!this.isShareLinkCopyEvent(clipboardEvent)) {
+          glassChannel.copy(clipboardEvent)
+        }
+      })
     })
 
     document.addEventListener('paste', (pasteEvent) => {
@@ -453,6 +461,13 @@ export default class Creator extends React.Component {
         }, 1000)
       })
     })
+  }
+
+  isShareLinkCopyEvent (clipboardEvent) {
+    return (
+      clipboardEvent &&
+      clipboardEvent.target
+    )
   }
 
   componentWillUnmount () {


### PR DESCRIPTION
OK to merge after @roperzh reviews.

Short review.

Asana task link: n/a

Changes in this PR:

- [x] If the clipboard cut/copy event originates from a local (Creator webview) DOM element, assume it is _not_ a candidate to be handled by Envoy. This fixes the issue observed by @nadonomy that copying the clipboard link while an element was selected on stage would result in the element bytecode being copied.

Notes for the reviewer:

- Any red flags on this @roperzh?

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran the automated tests and linted the code
