### PR TITLE
Feat: tour back button

### DIFF
--- a/packages/haiku-creator/src/react/components/Tour/Steps/Finish.js
+++ b/packages/haiku-creator/src/react/components/Tour/Steps/Finish.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export default function ({ styles, finish, openLink }) {
+export default function ({ styles, openLink }) {
   return (
     <div>
       <h2 style={styles.heading}>That’s a wrap!</h2>
@@ -14,12 +14,6 @@ export default function ({ styles, finish, openLink }) {
           - Email: <a onClick={openLink} href='mailto:support@haiku.ai' style={styles.link}>support@haiku.ai</a> <br />
         </div>
       </div>
-      <button
-        style={styles.btn}
-        onClick={() => finish(true, false)}
-      > Finish
-      </button>
-      <div style={{clear: 'both'}} />
     </div>
   )
 }

--- a/packages/haiku-creator/src/react/components/Tour/Tooltip.js
+++ b/packages/haiku-creator/src/react/components/Tour/Tooltip.js
@@ -173,45 +173,45 @@ function Tooltip (props) {
 
             {/* Don't show buttons on the first and last slides */}
             {stepData.current > 0 && (
-                <div
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    marginTop: 30
-                  }}
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                marginTop: 30
+              }}
                 >
-                  <button
-                    style={TOUR_STYLES.btnSecondary}
-                    onClick={() => finish(true, true)}
+              <button
+                style={TOUR_STYLES.btnSecondary}
+                onClick={() => finish(true, true)}
                   >
                     Finish
                   </button>
-                  <div style={{display: 'flex', alignItems: 'center'}}>
-                    {showPreviousButton && (
-                      <button
-                        style={{...TOUR_STYLES.btnSecondary, marginRight: 10}}
-                        onClick={() => prev(true, true)}
+              <div style={{display: 'flex', alignItems: 'center'}}>
+                {showPreviousButton && (
+                <button
+                  style={{...TOUR_STYLES.btnSecondary, marginRight: 10}}
+                  onClick={() => prev(true, true)}
                       >
                         Back
                       </button>
                     )}
 
-                    {/* Show the next button if we aren't waiting for user interaction */}
-                    {!waitUserAction && stepData.current < stepData.total && (
-                      <button style={TOUR_STYLES.btn} onClick={() => next()}>
+                {/* Show the next button if we aren't waiting for user interaction */}
+                {!waitUserAction && stepData.current < stepData.total && (
+                <button style={TOUR_STYLES.btn} onClick={() => next()}>
                         Next
                       </button>
                     )}
 
-                    {stepData.current === stepData.total && (
-                      <button
-                        style={TOUR_STYLES.btn}
-                        onClick={() => finish(true, false)}
+                {stepData.current === stepData.total && (
+                <button
+                  style={TOUR_STYLES.btn}
+                  onClick={() => finish(true, false)}
                       > Finish
                       </button>
                     )}
-                  </div>
-                </div>
+              </div>
+            </div>
               )}
           </div>
         </div>

--- a/packages/haiku-creator/src/react/components/Tour/Tooltip.js
+++ b/packages/haiku-creator/src/react/components/Tour/Tooltip.js
@@ -166,8 +166,7 @@ function Tooltip (props) {
             {children}
 
             {/* Don't show buttons on the first and last slides */}
-            {stepData.current > 0 &&
-              stepData.current < stepData.total && (
+            {stepData.current > 0 && (
                 <div
                   style={{
                     display: 'flex',
@@ -186,9 +185,17 @@ function Tooltip (props) {
                       {stepData.current} of {stepData.total}
                     </span>
                     {/* Show the next button if we aren't waiting for user interaction */}
-                    {!waitUserAction && (
+                    {!waitUserAction && stepData.current < stepData.total && (
                       <button style={TOUR_STYLES.btn} onClick={() => next()}>
                         Next
+                      </button>
+                    )}
+
+                    {stepData.current === stepData.total && (
+                      <button
+                        style={TOUR_STYLES.btn}
+                        onClick={() => finish(true, false)}
+                      > Finish
                       </button>
                     )}
                   </div>

--- a/packages/haiku-creator/src/react/components/Tour/Tooltip.js
+++ b/packages/haiku-creator/src/react/components/Tour/Tooltip.js
@@ -92,11 +92,13 @@ function Tooltip (props) {
     display,
     children,
     next,
+    prev,
     finish,
     stepData,
     waitUserAction,
     size,
-    isOverlayHideable
+    isOverlayHideable,
+    showPreviousButton
   } = props
   let {top, left} = coordinates
   let positionStyles = STYLES[display.toUpperCase()] || {}
@@ -165,6 +167,10 @@ function Tooltip (props) {
           <div style={STYLES.children}>
             {children}
 
+            <span style={{fontStyle: 'oblique', position: 'absolute', top: 50, right: 20}}>
+              {stepData.current} of {stepData.total}
+            </span>
+
             {/* Don't show buttons on the first and last slides */}
             {stepData.current > 0 && (
                 <div
@@ -181,9 +187,15 @@ function Tooltip (props) {
                     Finish
                   </button>
                   <div style={{display: 'flex', alignItems: 'center'}}>
-                    <span style={{marginRight: 10, fontStyle: 'oblique'}}>
-                      {stepData.current} of {stepData.total}
-                    </span>
+                    {showPreviousButton && (
+                      <button
+                        style={{...TOUR_STYLES.btnSecondary, marginRight: 10}}
+                        onClick={() => prev(true, true)}
+                      >
+                        Back
+                      </button>
+                    )}
+
                     {/* Show the next button if we aren't waiting for user interaction */}
                     {!waitUserAction && stepData.current < stepData.total && (
                       <button style={TOUR_STYLES.btn} onClick={() => next()}>

--- a/packages/haiku-creator/src/react/components/Tour/Tour.js
+++ b/packages/haiku-creator/src/react/components/Tour/Tour.js
@@ -11,6 +11,7 @@ class Tour extends React.Component {
     super()
 
     this.next = this.next.bind(this)
+    this.prev = this.prev.bind(this)
     this.finish = this.finish.bind(this)
     this.hide = this.hide.bind(this)
     this.showStep = this.showStep.bind(this)
@@ -86,6 +87,10 @@ class Tour extends React.Component {
     }
   }
 
+  prev () {
+    this.tourChannel.prev()
+  }
+
   finish (createFile, skipped) {
     this.tourChannel.finish(createFile)
     mixpanel.haikuTrack('tour', {
@@ -130,7 +135,8 @@ class Tour extends React.Component {
       stepData,
       waitUserAction,
       size,
-      isOverlayHideable
+      isOverlayHideable,
+      showPreviousButton
     } = this.state
 
     const Step = steps[component]
@@ -142,11 +148,13 @@ class Tour extends React.Component {
         display={display}
         spotlightRadius={spotlightRadius}
         next={this.next}
+        prev={this.prev}
         finish={this.finish}
         stepData={stepData}
         waitUserAction={waitUserAction}
         size={size}
         isOverlayHideable={isOverlayHideable}
+        showPreviousButton={showPreviousButton}
       >
         <Step
           styles={TOUR_STYLES}

--- a/packages/haiku-sdk-creator/src/tour/TourHandler.ts
+++ b/packages/haiku-sdk-creator/src/tour/TourHandler.ts
@@ -26,6 +26,7 @@ export class TourHandler implements Tour {
       waitUserAction: true,
       size: 'small',
       isOverlayHideable: false,
+      showPreviousButton: false,
     },
     {
       selector: `#js-utility-${TourUtils.ProjectName}`,
@@ -37,6 +38,7 @@ export class TourHandler implements Tour {
       waitUserAction: false,
       size: 'small',
       isOverlayHideable: false,
+      showPreviousButton: false,
     },
     {
       selector: '.gauge-time-readout',
@@ -48,6 +50,7 @@ export class TourHandler implements Tour {
       waitUserAction: false,
       size: 'default',
       isOverlayHideable: true,
+      showPreviousButton: false,
     },
     {
       selector: '.gauge-time-readout',
@@ -59,6 +62,7 @@ export class TourHandler implements Tour {
       waitUserAction: false,
       size: 'default',
       isOverlayHideable: true,
+      showPreviousButton: true,
     },
     {
       selector: '.gauge-time-readout',
@@ -70,6 +74,7 @@ export class TourHandler implements Tour {
       waitUserAction: false,
       size: 'default',
       isOverlayHideable: true,
+      showPreviousButton: true,
     },
     {
       selector: '.gauge-time-readout',
@@ -81,6 +86,7 @@ export class TourHandler implements Tour {
       waitUserAction: false,
       size: 'default',
       isOverlayHideable: true,
+      showPreviousButton: true,
     },
     {
       selector: '#publish',
@@ -92,6 +98,7 @@ export class TourHandler implements Tour {
       waitUserAction: false,
       size: 'default',
       isOverlayHideable: true,
+      showPreviousButton: true,
     },
     {
       selector: '#sidebar',
@@ -103,6 +110,7 @@ export class TourHandler implements Tour {
       waitUserAction: false,
       size: 'default',
       isOverlayHideable: true,
+      showPreviousButton: true,
     },
     {
       selector: '#sidebar',
@@ -114,6 +122,7 @@ export class TourHandler implements Tour {
       waitUserAction: false,
       size: 'default',
       isOverlayHideable: true,
+      showPreviousButton: true,
     },
     {
       selector: '#sidebar',
@@ -125,6 +134,7 @@ export class TourHandler implements Tour {
       waitUserAction: false,
       size: 'default',
       isOverlayHideable: true,
+      showPreviousButton: true,
     },
     {
       selector: '#go-to-dashboard',
@@ -136,6 +146,7 @@ export class TourHandler implements Tour {
       waitUserAction: false,
       size: 'default',
       isOverlayHideable: true,
+      showPreviousButton: true,
     },
   ];
 
@@ -256,6 +267,13 @@ export class TourHandler implements Tour {
       this.requestElementCoordinates(nextState);
     } else {
       this.finish();
+    }
+  }
+
+  prev() {
+    if (this.isActive && this.currentStep-- > 0) {
+      const nextState = this.getState();
+      this.requestElementCoordinates(nextState);
     }
   }
 }

--- a/packages/haiku-sdk-creator/src/tour/index.ts
+++ b/packages/haiku-sdk-creator/src/tour/index.ts
@@ -18,6 +18,7 @@ export interface TourState {
   waitUserAction: boolean;
   size: string;
   isOverlayHideable: boolean;
+  showPreviousButton: boolean;
 }
 
 export interface ClientBoundingRect {


### PR DESCRIPTION
OK to merge.

Short review.

Asana task link: https://app.asana.com/0/480796620059175/533884651941718

Changes in this PR:

- [x] Add a back button to some tour steps

Notes for the reviewer:

- It didn't make sense to add the button to the first and second steps (welcome to the tour and open project)
- Also, adding the button to the third step, which is the first step that pops when the project is open is going to be problematic

As a consequence of that, every step except the first three ones should have the 'back' button.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [x] Ran the automated tests and linted the code
- [ ] Wrote an automated test covering new functionality
