### PR TITLE
Tweaks and fixes

### DIFF
--- a/packages/haiku-creator/src/electron.js
+++ b/packages/haiku-creator/src/electron.js
@@ -119,10 +119,7 @@ function createWindow () {
   browserWindow = new BrowserWindow({
     title: 'Haiku',
     show: false, // Don't show the window until we are ready-to-show (see below)
-    titleBarStyle: 'hidden-inset',
-    webPreferences: {
-      webSecurity: false
-    }
+    titleBarStyle: 'hidden-inset'
   })
 
   browserWindow.setTitle('Haiku')

--- a/packages/haiku-creator/src/electron.js
+++ b/packages/haiku-creator/src/electron.js
@@ -1,13 +1,8 @@
-// Third-party dependencies
 import { BrowserWindow, app, ipcMain, systemPreferences } from 'electron'
 import EventEmitter from 'events'
 import path from 'path'
 import { inherits } from 'util'
-
-// First-party dependencies
 import mixpanel from 'haiku-serialization/src/utils/Mixpanel'
-
-// Local dependencies
 import TopMenu from './TopMenu'
 
 if (!app) {
@@ -134,6 +129,10 @@ function createWindow () {
   browserWindow.maximize()
   browserWindow.loadURL(appUrl)
 
+  if (process.env.DEV === '1') {
+    browserWindow.openDevTools()
+  }
+
   // Sending our haiku configuration into the view so it can correctly set up
   // its own websocket connections to our plumbing server, etc.
   browserWindow.webContents.on('did-finish-load', () => {
@@ -169,9 +168,6 @@ function createWindow () {
   browserWindow.on('ready-to-show', () => {
     browserWindow.show()
   })
-
-  // Uncomment me to automatically open the tools
-  // browserWindow.openDevTools()
 }
 
 if (app.isReady()) {

--- a/packages/haiku-creator/src/electron.js
+++ b/packages/haiku-creator/src/electron.js
@@ -145,13 +145,9 @@ function createWindow () {
     'redo',
     'save',
     'start-tour',
-    'toggle-dev-tools',
     'undo',
     'zoom-in',
-    'zoom-out',
-    // Active in dev & staging only.
-    'dump-system-info',
-    'open-hacker-helper'
+    'zoom-out'
   ]
 
   globalMenuPassthroughs.forEach((command) => {

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -1054,7 +1054,7 @@ class ActiveComponent extends BaseModel {
         { doHashWork: true }
       )
 
-      Bytecode.mergeTimelines(destinationTimelines, timelinesObject, (propertyName, oldValue, newValue) => {
+      const changesMade = Bytecode.mergeTimelines(destinationTimelines, timelinesObject, (propertyName, oldValue, newValue) => {
         if (typeof oldValue === 'string' && typeof newValue === 'string') {
           // HACK: Changing URL reference breaks the reference since our merge doesn't affect
           //       the structure of the element (TODO: Support merging structural changes too)
@@ -1069,6 +1069,13 @@ class ActiveComponent extends BaseModel {
 
         return true
       })
+
+      if (changesMade.length > 0) {
+        log.info(
+          `[active component] ${existingNode.attributes.source} merged design changes`,
+          JSON.stringify(changesMade)
+        )
+      }
     })
   }
 

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -325,9 +325,13 @@ class ActiveComponent extends BaseModel {
     return cb(null, pretty(html))
   }
 
-  setTimelineTimeValue (timelineTime, skipTransmit = false, forceSeek = false) {
+  setTimelineTimeValue (timelineTime, skipTransmit = false, forceSeek = false, forceSet = false) {
     timelineTime = Math.round(timelineTime)
-    if (timelineTime !== this.getCurrentTimelineTime()) {
+    // When doing a hardReload (in which we load a fresh component instance from disk)
+    // that component will be completely fresh and not yet in 'controlled time' mode, which
+    // means that it will initially start playing. Hard reload depends on being able to
+    // forceSet a time value to get it into 'controlled time' mode, hence this flag.
+    if (forceSet || timelineTime !== this.getCurrentTimelineTime()) {
       // Note that this call reaches in and updates our instance's timeline objects
       Timeline.setCurrentTime({ component: this }, timelineTime, skipTransmit, forceSeek)
       // Perform a lightweight full flush render, recomputing all values without without trying to be clever about
@@ -1897,7 +1901,7 @@ class ActiveComponent extends BaseModel {
           // If we don't do this here, continued edits at this time won't work properly.
           // We have to do this  __after rehydrate__ so we update all copies fo the models we've
           // just loaded into memory who have reset attributes.
-          this.setTimelineTimeValue(timelineTimeBeforeReload, true, true)
+          this.setTimelineTimeValue(timelineTimeBeforeReload, true, true, true)
           this.forceFlush()
 
           // Start the clock again, as we should now be ready to flow updated component.


### PR DESCRIPTION
NOT READY TO MERGE.

Short review.

Asana task links:

- https://app.asana.com/0/481696547044295/530409460017176

Changes in this PR:

- [x] Add back logic to force set the time of on-stage instances after a hard reload. This both prevents automatic playback and ensures that the scrubber time is preserved across hard reloads, which are triggered by things like undo/redo.
- [x] Re-enabled `webSecurity` on the Creator electron.js boot-up file. Doesn't seem to cause an issue when doing a quick check, and is probably best to keep on anyway. Docs for that option are here: https://electronjs.org/docs/api/browser-window
- [x] During merge design, record the changes that were made and log them if any were made. I think this is pretty handy to leave on by default since this is an area where we have historically had a bunch of bugs.
- [x] Removed a bit of cruft.

Notes for the reviewer:

- @stristr IIRC this was removed during other perf changes; but I would guess this should be fine. Let me know if you think this could cause any bad perf regressions.

Completed checkin tasks:

- [ ] Did manual testing of interrelated functionality
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Ran the automated tests and linted the code
