### PR TITLE
Tentative: Show loader until editor view is actually ready

### DIFF
--- a/packages/haiku-creator/src/react/components/SideBar.js
+++ b/packages/haiku-creator/src/react/components/SideBar.js
@@ -106,13 +106,16 @@ class SideBar extends React.Component {
       <div style={STYLES.container} className='layout-box' id='sidebar'>
         <div style={[STYLES.bar, {zIndex: 1, paddingLeft: this.state.isFullscreen ? 15 : 82}]} className='frame'>
           <LogoMiniSVG />
-          <button id='go-to-dashboard' key='dashboard' onClick={() => { this.goToDashboard() }}
-            style={[
-              BTN_STYLES.btnIcon, BTN_STYLES.btnIconHover, BTN_STYLES.btnText,
-              {width: 'auto', position: 'absolute', right: 6}
-            ]}>
-            <ChevronLeftMenuIconSVG />
-          </button>
+          {(this.props.doShowBackToDashboardButton)
+             ? <button id='go-to-dashboard' key='dashboard' onClick={() => { this.goToDashboard() }}
+               style={[
+                 BTN_STYLES.btnIcon, BTN_STYLES.btnIconHover, BTN_STYLES.btnText,
+                 {width: 'auto', position: 'absolute', right: 6}
+               ]}>
+               <ChevronLeftMenuIconSVG />
+             </button>
+            : ''
+          }
         </div>
         <div style={STYLES.nav}>
           <div style={[STYLES.activeIndicator, this.props.activeNav === 'state_inspector' && STYLES.activeSecond]} />


### PR DESCRIPTION
OK to merge, but only if OK with @taylorpoe and @zackbrown. This is just tentative in case y'all like this idea.

Short review.

Asana task link: n/a, just an experiment

Changes in this PR:

- Show the "reticulating splines" loader until the editor is totally finished loading.
  - Good because: User cannot nav back when things are in a race-able state.
  - Good because: User doesn't see the "sausage being made" while windows load.
  - Bad because: User doesn't see the Haikuified timeline loader that Taylor built.

Feel free to just leave this open for later discussion if you feel so-so or negative about it.