### PR TITLE
fix: for leaky envoy listener in timeline/tour

### DIFF
--- a/packages/haiku-sdk-creator/src/envoy/EnvoyClient.ts
+++ b/packages/haiku-sdk-creator/src/envoy/EnvoyClient.ts
@@ -130,8 +130,10 @@ export default class EnvoyClient<T> {
     subject['off'] = (eventName: string, handler: Function) => {
       const handlers = this.eventHandlers.get(eventName) || [];
       const idx = handlers.indexOf(handler);
-      handlers.splice(idx, 1);
-      this.eventHandlers.set(eventName, handlers);
+      if (idx !== -1) {
+        handlers.splice(idx, 1);
+        this.eventHandlers.set(eventName, handlers);
+      }
     };
 
     return subject;

--- a/packages/haiku-sdk-creator/test/envoy/client-mock/index.test.ts
+++ b/packages/haiku-sdk-creator/test/envoy/client-mock/index.test.ts
@@ -26,6 +26,8 @@ tape('envoy:client-mock', async (t) => {
         // never happens; this is a mock
       });
 
+      channel.off('thingthatwasneveron', 'doesntmatterthisisntevenafunction');
+
       t.ok(true, 'mock client api works without throwing an error');
     });
   },         1000);

--- a/packages/haiku-sdk-creator/test/envoy/index.test.ts
+++ b/packages/haiku-sdk-creator/test/envoy/index.test.ts
@@ -61,8 +61,6 @@ tape('envoy:index:schema', async (t) => {
 });
 
 tape('envoy:index:events', async (t) => {
-  t.plan(1);
-
   class TestEventHandler {
     private server: EnvoyServer;
 
@@ -89,10 +87,14 @@ tape('envoy:index:events', async (t) => {
     logger: new EnvoyLogger('error'),
   });
   client.get('foo-event').then(async (fooClient: TestEventHandler & EnvoyHandler) => {
-    fooClient.on('foo', (payload) => {
+    const handler = (payload) => {
       t.equal(payload, 'data for dayz');
       server.close();
-    });
+      fooClient.off('foo', handler);
+    };
+    fooClient.on('foo', handler);
     fooClient.doFoo('dayz');
+    fooClient.doFoo('wonthappensowontfail');
+    t.end();
   });
 });

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -111,7 +111,7 @@ class Timeline extends React.Component {
     this.removeEmitterListeners()
 
     if (this.tourClient) {
-      this.tourClient.removeListener('tour:requestElementCoordinates', this.handleRequestElementCoordinates)
+      this.tourClient.off('tour:requestElementCoordinates', this.handleRequestElementCoordinates)
     }
 
     this.project.getEnvoyClient().closeConnection()


### PR DESCRIPTION
OK to merge.

Short review, which I would like @roperzh to do in case I'm missing something.

Asana task link: n/a, just noticed this

Changes in this PR:

- [x] Actually unsubscribe from `'tour:requestElementCoordinates'` when unmounting the timeline. Fixes transient `setState()` complaint.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran the automated tests and linted the code
- [x] Wrote an automated test covering new functionality (just fixing `.off()` to be more robust)