### PR TITLE
fix: for unclickable asset library

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -28,7 +28,7 @@ import { EXPORTER_CHANNEL, ExporterFormat } from 'haiku-sdk-creator/lib/exporter
 // (which works even inside JS with supported editors, using jsdoc type annotations)
 import { USER_CHANNEL, User } from 'haiku-sdk-creator/lib/bll/User' // eslint-disable-line no-unused-vars
 import { GLASS_CHANNEL } from 'haiku-sdk-creator/lib/glass'
-import { isPreviewMode } from '@haiku/player/lib/helpers/interactionModes'
+import { InteractionMode, isPreviewMode } from '@haiku/player/lib/helpers/interactionModes'
 import Palette from 'haiku-ui-common/lib/Palette'
 import ActivityMonitor from '../utils/activityMonitor.js'
 import { HOMEDIR_LOGS_PATH, HOMEDIR_PATH } from 'haiku-serialization/src/utils/HaikuHomeDir'
@@ -828,7 +828,8 @@ export default class Creator extends React.Component {
     this.unsetAllProjectModelsState(this.state.projectModel.getFolder(), 'component:mounted')
     this.setState({
       projectModel: null,
-      activeNav: 'library' // Prevents race+crash loading StateInspector when switching projects
+      activeNav: 'library', // Prevents race+crash loading StateInspector when switching projects
+      interactionMode: InteractionMode.EDIT // So that the asset library will not be obscured on reentry
     })
 
     return this.props.websocket.request(

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -10,7 +10,7 @@ import { BTN_STYLES } from '../styles/btnShared'
 import CopyToClipboard from 'react-copy-to-clipboard'
 import ToolSelector from './ToolSelector'
 import Toggle from './Toggle'
-import {InteractionMode} from '@haiku/player/lib/helpers/interactionModes'
+import { InteractionMode } from '@haiku/player/lib/helpers/interactionModes'
 import {
   PublishSnapshotSVG,
   ConnectionIconSVG,


### PR DESCRIPTION
OK to merge.

Micro review.

[Asana task](https://app.asana.com/0/480796620059175/529170714854609/f) (incorrectly closed as can't reproduce)

Changes in this PR:

- [x] Fix stuck interaction mode leading to unclickable asset library after backing out to dashboard with preview mode active.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran the automated tests and linted the code
