### PR TITLE
fix: don't reapply parent transforms in a decomposed curve

### DIFF
--- a/packages/haiku-formats/src/exporters/bodymovin/bodymovinExporter.ts
+++ b/packages/haiku-formats/src/exporters/bodymovin/bodymovinExporter.ts
@@ -776,7 +776,7 @@ export class BodymovinExporter implements Exporter {
           attributes: {'haiku-id': newHaikuId},
           elementName: SvgTag.PathShape,
         },
-        parentNode,
+        undefined,
       );
     });
   }

--- a/packages/haiku-formats/src/exporters/bodymovin/bodymovinUtils.ts
+++ b/packages/haiku-formats/src/exporters/bodymovin/bodymovinUtils.ts
@@ -331,7 +331,7 @@ export const pointsToInterpolationTrace = (svgPoints: string) => {
  * @returns {string[]}
  */
 export const decomposeMaybeCompoundPath = (path: string): string[] =>
-  path.split(/z/ig).filter((segment) => segment !== '');
+  path.split(/z/ig).filter((segment) => !!segment);
 
 /**
  * Derives keyframes as an array of numbers from a timeline property.


### PR DESCRIPTION
OK to merge.

Microreview.

Asana task link: n/a

Changes in this PR:

- [x] Don't reapply parent transforms in subsequent segments of a decomposed curve. By the time we copy the timeline, its parent transforms (e.g. from `<g>` parents) have already been spliced into the timeline, and reapplying them will overcorrect leading to layout insanity.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran the automated tests and linted the code