### PR TITLE
fix: for the mysterious disappearing polygon

### DIFF
--- a/packages/@haiku/player/src/renderers/dom/assignStyle.ts
+++ b/packages/@haiku/player/src/renderers/dom/assignStyle.ts
@@ -7,10 +7,6 @@ export default function assignStyle(domElement, style, component, isPatchOperati
     domElement.__haikuExplicitStyles = {};
   }
 
-  // if (domElement.haiku.element.attributes['haiku-id'] === '1fe03cab1105') {
-  //   console.log(style);
-  // }
-
   if (!isPatchOperation) {
     // If we have an element from a previous run, remove any old styles that aren't part of the new one
     if (

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -1904,8 +1904,8 @@ class ActiveComponent extends BaseModel {
           // If we don't do this here, continued edits at this time won't work properly.
           // We have to do this  __after rehydrate__ so we update all copies fo the models we've
           // just loaded into memory who have reset attributes.
-          this.setTimelineTimeValue(timelineTimeBeforeReload, /* forceSeek= */ true)
           this.forceFlush()
+          this.setTimelineTimeValue(timelineTimeBeforeReload, /* forceSeek= */ true)
 
           // Start the clock again, as we should now be ready to flow updated component.
           this.getActiveInstancesOfHaikuPlayerComponent().forEach((instance) => {

--- a/packages/haiku-serialization/src/bll/Template.js
+++ b/packages/haiku-serialization/src/bll/Template.js
@@ -587,7 +587,7 @@ Template.ensureTitleAndUidifyTree = function ensureTitleAndUidifyTree (mana, sou
     mana.attributes[HAIKU_TITLE_ATTRIBUTE] = title
   }
 
-  // Now make sure all elements in the tree get a preditable identifier assigned. It is critical that
+  // Now make sure all elements in the tree get a predictable identifier assigned. It is critical that
   // the UID generation be based on the existing tree's contents so that this same logic can run
   // in different processes and still give us an identical result, otherwise they will get out of sync
   Template.visitManaTreeSpecial('*', hash, mana, (node, fqa) => {


### PR DESCRIPTION
OK to merge.

Short review.

Asana task link: n/a

Changes in this PR:

- [x] Fix for late-breaking "after instantiating, deleting, and reinstating a polygon with gradient fill, it shows up as disappeared".

Notes for the reviewer:

This comes down to switching the order of `forceFlush()` and `setTimelineTimeValue()`. The super-arcane reason this matters is actually a bug in player that I don't think we need to fix right now, stemming from the behavior of a special cache [here](https://github.com/HaikuTeam/mono/blob/master/packages/%40haiku/player/src/renderers/dom/assignAttributes.ts#L49-L59) for `d` and `points` attributes. With the previous invocation order, if we tick (which is what happens inside `setTimelineTimeValue(ms, true)`) before performing a full flush render, we populate the cache on the first tick, then skip setting `points`/`d` on full flush and detect no changes on subsequent patches. This is fundamentally broken but not critical to fix right now.

Note: gradient fill was 100% a red herring. This bug exists for all `<polygon points="..." />`- and `<path d="..." />`-type constructs.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Expanded/modified the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [x] Ran the automated tests and linted the code
- [ ] ~~Wrote an automated test covering new functionality~~ (literally don't know where to start 🙃 )
