### PR TITLE
fix: do not show reveal in finder for nonlocal projects

### DIFF
--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -194,6 +194,7 @@ class ProjectBrowser extends React.Component {
             key={projectObject.projectName}
             organizationName={this.props.organizationName}
             projectName={projectObject.projectName}
+            projectExistsLocally={projectObject.projectExistsLocally}
             projectPath={projectObject.projectPath}
             isDeleted={projectObject.isDeleted}
             launchProject={() => this.handleProjectLaunch(projectObject)}

--- a/packages/haiku-creator/src/react/components/ProjectThumbnail.js
+++ b/packages/haiku-creator/src/react/components/ProjectThumbnail.js
@@ -81,7 +81,7 @@ class ProjectThumbnail extends React.Component {
           >
             DELETE
           </span>
-          <span
+          {this.props.projectExistsLocally && <span
             key='reveal'
             onClick={() => shell.showItemInFolder(this.props.projectPath)}
             style={[
@@ -91,7 +91,7 @@ class ProjectThumbnail extends React.Component {
             ]}
           >
             REVEAL IN FINDER
-          </span>
+          </span>}
         </div>
         <div style={DASH_STYLES.titleStrip}>
           <span style={DASH_STYLES.title}>


### PR DESCRIPTION
OK to merge.

Short review.

Asana task link: n/a

Changes in this PR:

- [x] Don't show "reveal in finder" for projects that aren't available locally.

Notes for the reviewer:

- I did this async in Plumbing since we're stat-ing (number of projects).

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran the automated tests and linted the code