### PR TITLE
fix: don't show autoupdate prompt on start

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -362,7 +362,7 @@ export default class Creator extends React.Component {
         this.user = user
 
         // kick off initial report
-        this.onActivityReport(true)
+        this.onActivityReport(true, true)
       }
     )
 
@@ -799,7 +799,7 @@ export default class Creator extends React.Component {
     })
   }
 
-  onActivityReport (userWasActive) {
+  onActivityReport (userWasActive, shouldSkipOptIn = false) {
     if (userWasActive) {
       this.user.reportActivity()
     }
@@ -808,7 +808,7 @@ export default class Creator extends React.Component {
       updater: {
         shouldCheck: true,
         shouldRunOnBackground: true,
-        shouldSkipOptIn: false
+        shouldSkipOptIn
       }
     })
   }


### PR DESCRIPTION
Due to logic introduced in cf803441ab, we were checking for updates
with a prompt even when the app launches, this fixes the issue by
allowing an extra parameter to be passed for this special use case.

OK to merge.

Short review.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Ran the automated tests and linted the code
- [ ] Wrote an automated test covering new functionality
