### PR TITLE
fix: don't try to track activity if no user is present

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -800,7 +800,7 @@ export default class Creator extends React.Component {
   }
 
   onActivityReport (userWasActive, shouldSkipOptIn = false) {
-    if (userWasActive) {
+    if (userWasActive && this.user) {
       this.user.reportActivity()
     }
 


### PR DESCRIPTION
This prevents the app from erroring if we don't have an user yet.

h/t to @stristr, as he spotted and commented this on cf80344

OK to merge.

Short review.

No link to asana, but here's the Sentry error: https://sentry.io/haiku-systems/javascript-creator/issues/443181402/?referrer=slack

Changes in this PR:

- [x] Add a check for user before reporting activity

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [x] Ran the automated tests and linted the code
- [ ] Wrote an automated test covering new functionality
