### PR TITLE
tweak: add a notice on the publish popup

### DIFF
--- a/packages/haiku-creator/src/TopMenu.js
+++ b/packages/haiku-creator/src/TopMenu.js
@@ -77,7 +77,6 @@ export default class TopMenu extends EventEmitter {
     const projectSubmenu = [
       {
         label: 'Publish',
-        accelerator: 'CmdOrCtrl+S',
         enabled: !options.isSaving && isProjectOpen,
         click: () => {
           this.emit('global-menu:save')

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -115,6 +115,12 @@ const STYLES = {
   },
   previewToggle: {
     float: 'right'
+  },
+  popupNotice: {
+    display: 'inline-block',
+    marginTop: '10px',
+    fontSize: '13px',
+    fontStyle: 'oblique'
   }
 }
 
@@ -169,6 +175,7 @@ class PopoverBody extends React.Component {
               : <span style={STYLES.copy}><CliboardIconSVG /></span>}
           </CopyToClipboard>
         </div>
+        <span style={STYLES.popupNotice}>Anyone with the link can <strong>view &amp; embed</strong> your project.</span>
         {/* todo: show last updated? <div style={STYLES.footer}>UPDATED<span style={STYLES.time}>{'9:00am Jun 15, 2017'}</span></div> */}
       </div>
     )


### PR DESCRIPTION
OK to merge.

Short review.

Asana task link: https://app.asana.com/0/480796620059175/538004127725381

Changes in this PR:

- [x] Add a notice under the publish popup
- [x] Disable publish with `cmd + s`

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [x] Ran the automated tests and linted the code
- [ ] Wrote an automated test covering new functionality

Notes:

![screen shot 2018-01-29 at 17 21 21](https://user-images.githubusercontent.com/4419992/35532737-0f26d4f6-051a-11e8-893c-66e55dc4d91b.png)

Please note that `Project > Publish` from the menu still works
