### PR TITLE
Tour: fix z index issues with the library during preview mode

### DIFF
--- a/packages/haiku-creator/src/react/components/Stage.js
+++ b/packages/haiku-creator/src/react/components/Stage.js
@@ -27,6 +27,7 @@ export default class Stage extends React.Component {
   constructor (props) {
     super(props)
     this.webview = null
+    this.onRequestWebviewCoordinates = this.onRequestWebviewCoordinates.bind(this)
     this.state = {
       interactionMode: InteractionMode.EDIT
     }
@@ -40,7 +41,7 @@ export default class Stage extends React.Component {
     if (!this.props.envoyClient.isInMockMode()) {
       tourChannel.then((client) => {
         this.tourClient = client
-        this.tourClient.on('tour:requestWebviewCoordinates', this.onRequestWebviewCoordinates.bind(this))
+        this.tourClient.on('tour:requestWebviewCoordinates', this.onRequestWebviewCoordinates)
       })
     }
   }

--- a/packages/haiku-creator/src/react/components/Tour/Tooltip.js
+++ b/packages/haiku-creator/src/react/components/Tour/Tooltip.js
@@ -9,8 +9,7 @@ const STYLES = {
     position: 'absolute',
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'center',
-    zIndex: 3
+    justifyContent: 'center'
   },
   childrenWrapper: {
     position: 'absolute',
@@ -146,7 +145,7 @@ function Tooltip (props) {
   }
 
   return (
-    <div style={{top, left, ...STYLES.container, ...positionStyles.container}}>
+    <div style={{top, left, ...STYLES.container, ...positionStyles.container, zIndex: 9999999}}>
       <Spotlight
         offset={positionStyles.spotlight}
         position={{top, left}}


### PR DESCRIPTION
OK to merge.

Short review.

Asana task link: https://app.asana.com/0/480796620059175/537861811113861

Changes in this PR:

- [x] Fix a z-index issue between the library on preview mode and the tour
- [x] Bind a tour handler correctly so it gets actually removed on `componentWillUnmount`

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [x] Ran the automated tests and linted the code
- [ ] Wrote an automated test covering new functionality
