### PR TITLE
infra: add script for syndication with CDN invalidation

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -30,6 +30,7 @@ module.exports = {
       region: 'us-east-1',
       bucket: 'haiku-electron-releases-production',
       user: 'haiku-electron-releases-writer-2',
+      distribution: 'E29RYBWU7AU9',
       key: process.env.HAIKU_RELEASE_WRITER_KEY,
       secret: process.env.HAIKU_RELEASE_WRITER_SECRET
     },

--- a/scripts/distro-syndicate.js
+++ b/scripts/distro-syndicate.js
@@ -1,0 +1,116 @@
+const path = require('path')
+const inquirer = require('inquirer')
+const argv = require('yargs').argv
+
+require('../config')
+const deploy = require('./deploy')
+const initializeAWSService = require('./helpers/initializeAwsService')
+const log = require('./helpers/log')
+
+const platform = global.process.env.HAIKU_RELEASE_PLATFORM
+const branch = global.process.env.HAIKU_RELEASE_BRANCH
+const version = global.process.env.HAIKU_RELEASE_VERSION
+const environment = global.process.env.HAIKU_RELEASE_ENVIRONMENT
+
+const region = deploy.deployer[environment].region
+const key = deploy.deployer[environment].key
+const secret = deploy.deployer[environment].secret
+const bucket = deploy.deployer[environment].bucket
+const distribution = deploy.deployer[environment].distribution
+
+const s3 = initializeAWSService('S3', region, key, secret)
+const cloudFront = initializeAWSService('CloudFront', region, key, secret)
+
+const latestKey = `releases/${environment}-${branch}-${platform}-latest.zip`
+
+const syndicate = (patchKey) => {
+  // Deploy the patch update to catch in-app users.
+  s3.copyObject({Bucket: bucket, CopySource: `/${bucket}/${patchKey}`, Key: patchKey.replace('-pending', '')})
+    .promise()
+    .then(() => {
+      // Deploy the Inkstone update to catch new users.
+      s3.copyObject({Bucket: bucket, CopySource: `/${bucket}/${patchKey}`, Key: latestKey})
+        .promise()
+        .then(() => {
+          cloudFront.createInvalidation({
+            DistributionId: distribution,
+            InvalidationBatch: {
+              CallerReference: Date.now().toString(),
+              Paths: {
+                Quantity: 1,
+                Items: [`/${latestKey}`]
+              }
+            }
+          })
+            .promise()
+            .then(() => {
+              log.hat('Syndication complete!')
+            })
+            .catch(() => {
+              log.err('Unable to create CloudFront invalidation!')
+              global.process.exit(1)
+            })
+        })
+        .catch(() => {
+          log.err(`Unable to syndicate latest key (${latestKey})`)
+          global.process.exit(1)
+        })
+    })
+    .catch(() => {
+      log.err(`Unable to syndicate patch key (${patchKey})`)
+      global.process.exit(1)
+    })
+}
+
+const maybeSyndicate = (data) => {
+  const potentialPatches = data.Contents.filter((key) =>
+    path.basename(key.Key).startsWith(`Haiku-${version}-${platform}`))
+  if (potentialPatches.length === 0) {
+    log.err('Unable to find pending patch key!')
+    global.process.exit(1)
+  }
+
+  if (potentialPatches.length > 1) {
+    log.err(`Found too many potential patches:\n${potentialPatches.map((obj) => obj.Key).join('\n')}`)
+    global.process.exit(1)
+  }
+
+  const patchKey = potentialPatches[0].Key
+  if (!patchKey.endsWith('-pending.zip')) {
+    log.err(`Aborting attempt to release already released patch: ${patchKey}`)
+    global.process.exit(1)
+  }
+
+  log.log(`Found patch key: ${patchKey}`)
+
+  log.warn(`WARNING: about to syndicate ${patchKey} and ${latestKey}!`)
+
+  if (argv['non-interactive']) {
+    syndicate(patchKey)
+    return
+  }
+
+  inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'continue',
+      message: 'Continue',
+      default: false
+    }
+  ]).then((answers) => {
+    if (!answers.continue) {
+      log.log('Aborting publish by user request')
+      global.process.exit(0)
+    }
+
+    syndicate(patchKey)
+  })
+}
+
+s3.listObjects({Bucket: bucket, Prefix: `releases/${environment}/${branch}/${platform}`})
+  .promise()
+  .then(maybeSyndicate)
+  .catch(() => {
+    log.err('Unable to list candidate patch releases')
+    global.process.exit(1)
+  })

--- a/scripts/distro-syndicate.js
+++ b/scripts/distro-syndicate.js
@@ -25,14 +25,20 @@ const latestKey = `releases/${environment}-${branch}-${platform}-latest.zip`
 
 const syndicate = (patchKey) => {
   // Make a backup of our latest in case we need to roll back.
+  //  e.g. /haiku-electron-releases-production/releases/production-master-mac-latest.zip - copy to ->
+  //       /haiku-electron-releases-production/releases/production-master-mac-previous.zip
   s3.copyObject({Bucket: bucket, CopySource: `/${bucket}/${latestKey}`, Key: latestKey.replace('-latest', '-previous')})
     .promise()
     .then(() => {
       // Deploy the patch update to catch in-app users.
+      //  e.g. /haiku-electron-releases-production/releases/releases/production/master/mac/12345/1.2.3/Haiku-1.2.3-mac-pending.zip - copy to ->
+      //       /haiku-electron-releases-production/releases/releases/production/master/mac/12345/1.2.3/Haiku-1.2.3-mac.zip
       s3.copyObject({Bucket: bucket, CopySource: `/${bucket}/${patchKey}`, Key: patchKey.replace('-pending', '')})
         .promise()
         .then(() => {
           // Deploy the Inkstone update to catch new users.
+          //  e.g. /haiku-electron-releases-production/releases/releases/production/master/mac/12345/1.2.3/Haiku-1.2.3-mac-pending.zip - copy to ->
+          //       /haiku-electron-releases-production/releases/production-master-mac-latest.zip
           s3.copyObject({Bucket: bucket, CopySource: `/${bucket}/${patchKey}`, Key: latestKey})
             .promise()
             .then(() => {

--- a/scripts/distro-upload.js
+++ b/scripts/distro-upload.js
@@ -26,8 +26,7 @@ uploadRelease(region, objkey, secret, bucket, RELEASES_FOLDER, platform, environ
   var slackMessage = `
 Distro ready (${version} ${environment})
 Download link: ${urls.download}
-Latest link: ${urls.latest}
-_To syndicate to users via auto-update, sign in to S3 and remove "-pending" from the file path (https://haiku-production.signin.aws.amazon.com/console)_
+_Syndicate with :jenkins:._
   `.trim()
 
   slackShout({ shout: config.shout }, slackMessage, () => {

--- a/scripts/helpers/slackShout.js
+++ b/scripts/helpers/slackShout.js
@@ -9,7 +9,7 @@ module.exports = function shout (options, text, cb) {
       token: deploy.slack.legacy,
       channel: 'releases',
       username: 'Haiku Distro',
-      icon_emoji: ':robot_face:'
+      icon_emoji: ':jenkins:'
     }, function (err) {
       if (err) log.err(err)
       return cb()

--- a/scripts/helpers/uploadRelease.js
+++ b/scripts/helpers/uploadRelease.js
@@ -13,7 +13,6 @@ function uploadRelease (region, key, secret, bucket, folder, platform, environme
   var countdown = (Math.pow(10, 13) - Date.now()) + '' // Reverse timestamp for ordering
 
   var target = path.join(folder, environment, branch, platform, countdown, version)
-  var latest = path.join(folder, [environment, branch, platform].join('-'))
 
   return fs.readdir(source, function (err, entries) {
     if (err) return cb(err)
@@ -38,30 +37,12 @@ function uploadRelease (region, key, secret, bucket, folder, platform, environme
 
       console.log('Uploading ' + build + ' as object ' + key + ' to bucket ' + bucket + '...')
 
-      return uploadObjectToS3(s3, key, stream, bucket, 'public-read', function (err) {
-        if (err) return next(err)
-
-        // The 'latest' upload variant doesn't include the -pending label since it is
-        // not used to determine syndication behavior on auto-update
-        key = [latest, 'latest' + path.extname(entry)].join('-')
-
-        // Upload with a 'pending' label so squirrel server knows not to include this in
-        // the list of candidates. This gives us an opportunity to test before syndication.
-        // The idea is that we manually remove the pending flag on S3 when we're ready.
-        key = key.replace(/.zip$/, '-pending.zip')
-
-        stream = fs.createReadStream(build)
-
-        console.log('Uploading ' + build + ' as object ' + key + ' to bucket ' + bucket + '...')
-
-        return uploadObjectToS3(s3, key, stream, bucket, 'public-read', next)
-      })
+      return uploadObjectToS3(s3, key, stream, bucket, 'public-read', next)
     }, (err) => {
       if (err) return cb(err)
 
       var urls = {
         download: `https://s3.amazonaws.com/${bucket}/${folder}/${environment}/${branch}/${platform}/${countdown}/${version}/Haiku-${version}-${platform}-pending.zip`,
-        latest: `https://s3.amazonaws.com/${bucket}/${folder}/${environment}-${branch}-${platform}-latest-pending.zip`
       }
 
       return cb(null, {


### PR DESCRIPTION
OK to merge.

Short review.

[Asana task](https://app.asana.com/0/480796620059175/515878783187361/f)

Changes in this PR:

- [x] Add a cache-busting syndication script (no more logging into S3!)
- [x] Simplify distro upload (we don't need to upload the same file stream to S3 twice—and then we don't need to check if their checksums match when we do auto-distro). It suffices to copy the version-specific `-pending.zip` file to the places it needs to go.

Notes for the reviewer:

- Worth reading through carefully to look out for any gotchas.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
