### PR TITLE
feat: add a toast when the user presses cmd+s

### DIFF
--- a/packages/haiku-creator/src/TopMenu.js
+++ b/packages/haiku-creator/src/TopMenu.js
@@ -81,6 +81,14 @@ export default class TopMenu extends EventEmitter {
         click: () => {
           this.emit('global-menu:save')
         }
+      },
+      {
+        label: 'Reveal in finder',
+        enabled: isProjectOpen,
+        accelerator: 'CmdOrCtrl+S',
+        click: () => {
+          this.emit('global-menu:show-project-location-toast')
+        }
       }
     ]
 

--- a/packages/haiku-creator/src/TopMenu.js
+++ b/packages/haiku-creator/src/TopMenu.js
@@ -83,7 +83,7 @@ export default class TopMenu extends EventEmitter {
         }
       },
       {
-        label: 'Reveal in finder',
+        label: 'Save',
         enabled: isProjectOpen,
         accelerator: 'CmdOrCtrl+S',
         click: () => {

--- a/packages/haiku-creator/src/electron.js
+++ b/packages/haiku-creator/src/electron.js
@@ -144,6 +144,7 @@ function createWindow () {
     'open-text-editor',
     'redo',
     'save',
+    'show-project-location-toast',
     'start-tour',
     'undo',
     'zoom-in',

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -7,6 +7,7 @@ import Palette from 'haiku-ui-common/lib/Palette'
 import { ThreeBounce } from 'better-react-spinkit'
 import Color from 'color'
 import { BTN_STYLES } from '../styles/btnShared'
+import { DASH_STYLES } from '../styles/dashShared'
 import CopyToClipboard from 'react-copy-to-clipboard'
 import ToolSelector from './ToolSelector'
 import Toggle from './Toggle'
@@ -250,6 +251,26 @@ class StageTitleBar extends React.Component {
         })
       }
     }, 1000)
+
+    ipcRenderer.on('global-menu:show-project-location-toast', () => {
+      this.props.createNotice({
+        type: 'info',
+        title: 'Notice',
+        message: (
+          <p>
+            Snapshot saved —{' '}
+            <span
+              style={DASH_STYLES.link}
+              onClick={() => {
+                shell.showItemInFolder(this.props.folder)
+              }}
+            >
+              View in Finder
+            </span>
+          </p>
+        )
+      })
+    })
 
     ipcRenderer.on('global-menu:save', () => {
       this.handleSaveSnapshotClick()

--- a/packages/haiku-creator/src/react/components/notifications/Toast.js
+++ b/packages/haiku-creator/src/react/components/notifications/Toast.js
@@ -75,7 +75,6 @@ const STYLES = {
     fontSize: '12px',
     marginTop: '8px',
     color: Palette.ROCK,
-    pointerEvents: 'none',
     width: '190px'
   }
 }

--- a/packages/haiku-creator/src/react/styles/dashShared.js
+++ b/packages/haiku-creator/src/react/styles/dashShared.js
@@ -324,5 +324,11 @@ export const DASH_STYLES = {
   projToDelete: {
     color: Palette.LIGHT_BLUE,
     fontStyle: 'italic'
+  },
+  link: {
+    color: Palette.LIGHTEST_PINK,
+    textDecoration: 'underline',
+    cursor: 'pointer',
+    display: 'inline-block'
   }
 }


### PR DESCRIPTION
OK to merge.

Short review.

Asana task link: https://app.asana.com/0/480796620059175/525679033255930

Changes in this PR:

- [x] Add a toast with a link to the project folder when the user tries to save a project.

Notes for the reviewer:

- This also adds an option to the top menu: `Project > Reveal in finder` (we need this in order for the shortcut to work)

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [x] Ran the automated tests and linted the code
- [ ] Wrote an automated test covering new functionality
