### PR TITLE
fix: smarter compound path handling for Lottie.

### DIFF
--- a/packages/haiku-common/src/types/index.ts
+++ b/packages/haiku-common/src/types/index.ts
@@ -9,6 +9,23 @@ export type ContextualSize = {
   z: number;
 };
 
+export type CubicCurve = {
+  type: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  x: number;
+  y: number;
+};
+
+export type PathPoint = {
+  moveTo: boolean;
+  curve?: CubicCurve;
+  x: number;
+  y: number;
+};
+
 export type TemplateElement<T> = {
   elementName: string;
   attributes: TemplateElementAttributes;

--- a/packages/haiku-formats/test/exporters/bodymovin.test.ts
+++ b/packages/haiku-formats/test/exporters/bodymovin.test.ts
@@ -1,6 +1,5 @@
-import * as tape from 'tape';
-
 import {HaikuBytecode} from 'haiku-common/lib/types';
+import * as tape from 'tape';
 
 import {BodymovinExporter} from '../../lib/exporters/bodymovin/bodymovinExporter';
 import baseBytecode from './baseBytecode';
@@ -701,15 +700,20 @@ tape('BodymovinExporter', (test: tape.Test) => {
       test.deepEqual(shapes[1].it[0].ks.k.v, [[2, 2], [3, 3]], 'creates additional shapes from other closed segments');
     }
 
-    // Scope for testing compound shapes painted with the evenodd fill-rule.
+    // Scope for testing compound shapes that are not actually compound.
     {
       overrideShapeAttributes(bytecode, {
-        d: {0: {value: 'M0,0 L1,1 L0,0 Z M2,2 L3,3 L2,2 Z'}},
+        d: {0: {value: 'M0,0 L10,0 L10,10 L0,10 L0,0 Z M2,2 L8,2 L8,8 L2,8 L2,2 Z'}},
         'fill-rule': {0: {value: 'evenodd'}},
       });
 
       const {layers: [{shapes}]} = rawOutput(bytecode);
-      test.equal(shapes.length, 1, 'does not split compound shapes if they use the evenodd fill-rule');
+      test.equal(shapes.length, 1, 'does not create additional shapes out of contained paths');
+      test.deepEqual(
+        shapes[0].it[0].ks.k.v,
+        [[0, 0], [10, 0], [10, 10], [0, 10], [0, 0], [2, 2], [8, 2], [8, 8], [2, 8], [2, 2]],
+        'collates vertices from inner paths',
+      );
     }
 
     // Scope for testing cubic bezier support.


### PR DESCRIPTION
OK to merge.

Short review.

[Asana task](https://app.asana.com/0/506410768732346/506410768732337/f)

Changes in this PR:

- [x] Instead of using `fill-rule` as a random guess about how we should decompose compound paths, actually use some #math to make a better (but still slightly random) guess. At its core we use the [ray casting algorithm](https://en.wikipedia.org/wiki/Point_in_polygon#Ray_casting_algorithm) to determine if we think the next composed path we encounter is supposed to be inside or outside the "enclosure" formed by the last path we processed, treating it as a polygon instead of a path with curves. As usual, this is incomplete, but much better than what we were doing before, and seems to allow us to cover a good amount of text ligatures cast to shapes we've seen in the wild.

Notes for the reviewer:

- Still much more to do here but "unit tests pass".

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran the automated tests and linted the code
- [x] Wrote an automated test covering new functionality