### PR TITLE
fix: always write code/scene/react-dom.js

### DIFF
--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -826,13 +826,10 @@ class Project extends BaseModel {
 
     fse.outputFileSync(path.join(this.getFolder(), `code/${scenename}/dom.js`), DOM_JS)
     fse.outputFileSync(path.join(this.getFolder(), `code/${scenename}/dom-embed.js`), DOM_EMBED_JS)
+    fse.outputFileSync(path.join(this.getFolder(), `code/${scenename}/react-dom.js`), REACT_DOM_JS)
 
     if (!fse.existsSync(path.join(this.getFolder(), `code/${scenename}/dom-standalone.js`))) {
       fse.outputFileSync(path.join(this.getFolder(), `code/${scenename}/dom-standalone.js`), DOM_STANDALONE_JS)
-    }
-
-    if (!fse.existsSync(path.join(this.getFolder(), `code/${scenename}/react-dom.js`))) {
-      fse.outputFileSync(path.join(this.getFolder(), `code/${scenename}/react-dom.js`), REACT_DOM_JS)
     }
 
     return rootComponentId


### PR DESCRIPTION
OK to merge.

Short review.

Changes in this PR:

- [x] Always write `code/${scenename}/react-dom.js` on scene files bootstrap.

Notes for the reviewer:

- Broken on projects that predate core, now fixed!

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran the automated tests and linted the code