### PR TITLE
fix: short-circuit all timeline keyboard events on preview mode

### DIFF
--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -545,7 +545,8 @@ class Timeline extends React.Component {
   handleKeyDown (nativeEvent) {
     // Give the currently active expression input a chance to capture this event and short circuit us if so
     const willExprInputHandle = this.refs.expressionInput.willHandleExternalKeydownEvent(nativeEvent)
-    if (willExprInputHandle) {
+
+    if (willExprInputHandle || this.state.isPreviewModeActive) {
       return void (0)
     }
 


### PR DESCRIPTION
OK to merge.

Short review.

Changes in this PR:

- [x] short-circuit all timeline keyboard events on preview mode

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Ran the automated tests and linted the code
- [ ] Wrote an automated test covering new functionality
