### PR TITLE
fix: do not pan the stage when scrolling the actions editor

### DIFF
--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
@@ -238,6 +238,9 @@ class EventHandlerEditor extends React.PureComponent {
             style={STYLES.editorsWrapper}
             className='haiku-scroll'
             ref={(el) => { this.wrapper = el }}
+            onWheel={(wheelEvent) => {
+              wheelEvent.nativeEvent.stopImmediatePropagation()
+            }}
           >
             {this.renderEditors()}
           </div>


### PR DESCRIPTION
OK to merge.

Short review.

Asana task links:

- https://app.asana.com/0/539750334128224/521753482907507

Summary of changes:

- [x] Prevent the propagation of the `wheel` event when scrolling on the actions editor, preventing the stage from panning 

Notes for reviewers:

- Would be great if someone with a trackpad can double test this, as it works with mouse but we had trackpad/mouse discrepancies in the past.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran the automated tests and linted the code
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
