### PR TITLE
fix (this time for real): do not scroll glass when the actions editor is open

### DIFF
--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -435,8 +435,10 @@ export class Glass extends React.Component {
     )
 
     document.addEventListener('mousewheel', (evt) => {
-      // on mac, this is triggered by a two-finger pan
-      if (!this.getActiveComponent()) {
+      if (
+        !this.getActiveComponent() || // on mac, this is triggered by a two-finger pan
+        this.state.isEventHandlerEditorOpen
+      ) {
         return
       }
 


### PR DESCRIPTION
OK to merge.

Short review.

Asana task links:

- https://app.asana.com/0/539750334128224/521753482907507

Summary of changes:

- [x] Prevent glass from scrolling if the actions ui is open

Regressions to look for:

- Two finger panning on stage

Notes for reviewers:

- A different approach than #284 , this time we update the logic in glass instead of avoid propagating the error, I had to look at an alternative solution since the sole fact of binding the `onWheel` event on the container of the actions ui (without even touching the event) was causing panning issues.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran the automated tests and linted the code
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
