### PR TITLE
Don't hold admin accounts to normal project limit

### DIFF
--- a/packages/@haiku/cli/src/haiku-cli.ts
+++ b/packages/@haiku/cli/src/haiku-cli.ts
@@ -409,9 +409,13 @@ function doLogin(context: IContext, cb?: Function) {
     username = answers['username'];
     password = answers['password'];
 
-    inkstone.user.authenticate(username, password, (err, authResponse) => {
+    inkstone.user.authenticate(username, password, (err, authResponse, httpResponse) => {
       if (err !== undefined) {
-        context.writeLine(chalk.bold.red('Username or password incorrect.'));
+        if (httpResponse.statusCode === 403) {
+          context.writeLine(chalk.bold.yellow('You must verify your email address before logging in.'));
+        } else {
+          context.writeLine(chalk.bold.red('Username or password incorrect.'));
+        }
         if (context.flags.verbose) {
           context.writeLine(err);
         }

--- a/packages/@haiku/core/README.md
+++ b/packages/@haiku/core/README.md
@@ -46,7 +46,7 @@ Haiku Core is compatible with all major modern web browsers: Firefox, Chrome, Sa
   <img width="60%" src='docs/assets/lottie-and-mobile-logos.png' />
 </p>
 
-[Haiku for Mac](https://haiku.ai) supports exporting to Lottie for native rendering of animations on iOS and Android. Technical details on this are coming soon; for now, please read [our blog post on Lottie](https://medium.com/haiku-blog/lottie-without-after-effects-9c5a8e74c239) and stay tuned. (Note: Interactions and dynamic components aren't currently supported by Lottie.)
+[Haiku for Mac](https://haiku.ai) supports exporting to Lottie for native rendering of animations on iOS and Android. Check out [our blog post on Lottie](https://medium.com/haiku-blog/lottie-without-after-effects-9c5a8e74c239) or read more in [our docs.](https://docs.haiku.ai/embedding-and-using-haiku/lottie.html) (Note: Interactions and dynamic components aren't currently supported by Lottie.)
 
 <br>
 

--- a/packages/@haiku/sdk-inkstone/src/index.ts
+++ b/packages/@haiku/sdk-inkstone/src/index.ts
@@ -202,7 +202,7 @@ export namespace inkstone {
       const options: requestLib.UrlOptions & requestLib.CoreOptions = {
         url: inkstoneConfig.baseUrl + ENDPOINTS.RESET_PASSWORD,
         headers: baseHeaders,
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({email}),
       };
 
       request.post(options, (err, httpResponse, body) => {
@@ -235,7 +235,7 @@ export namespace inkstone {
       const options: requestLib.UrlOptions & requestLib.CoreOptions = {
         url: inkstoneConfig.baseUrl + ENDPOINTS.RESET_PASSWORD_CLAIM.replace(':UUID', resetPasswordUUID),
         headers: baseHeaders,
-        body: JSON.stringify({ password }),
+        body: JSON.stringify({password}),
       };
 
       request.post(options, (err, httpResponse, body) => {
@@ -334,11 +334,11 @@ export namespace inkstone {
           cb(undefined, invitePreset, httpResponse);
         } else {
           if (httpResponse.statusCode === 404) {
-            cb('invalid code', { Valid: Validity.INVALID }, httpResponse);
+            cb('invalid code', {Valid: Validity.INVALID}, httpResponse);
           } else if (httpResponse.statusCode === 410) {
-            cb('code already claimed', { Valid: Validity.ALREADY_CLAIMED }, httpResponse);
+            cb('code already claimed', {Valid: Validity.ALREADY_CLAIMED}, httpResponse);
           } else {
-            cb(safeError(err), { Valid: Validity.ERROR }, httpResponse);
+            cb(safeError(err), {Valid: Validity.ERROR}, httpResponse);
           }
         }
       });
@@ -414,7 +414,7 @@ export namespace inkstone {
         if (response && response.statusCode !== 200) {
           cb(err, undefined, undefined);
         } else {
-          cb(undefined, { snap, link: assembleSnapshotLinkFromSnapshot(snap.Snapshot) }, response);
+          cb(undefined, {snap, link: assembleSnapshotLinkFromSnapshot(snap.Snapshot)}, response);
         }
       });
     }
@@ -444,7 +444,7 @@ export namespace inkstone {
       const options: requestLib.UrlOptions & requestLib.CoreOptions = {
         url,
         headers: baseHeaders,
-        body: JSON.stringify({ secret_token: secretToken }),
+        body: JSON.stringify({secret_token: secretToken}),
       };
 
       request.post(options, (err, httpResponse, body) => {

--- a/packages/@haiku/sdk-inkstone/src/index.ts
+++ b/packages/@haiku/sdk-inkstone/src/index.ts
@@ -140,7 +140,7 @@ export namespace inkstone {
           const auth = body as Authentication;
           cb(undefined, auth, httpResponse);
         } else {
-          cb(err, undefined, httpResponse);
+          cb(safeError(err), undefined, httpResponse);
         }
       });
     }
@@ -159,7 +159,7 @@ export namespace inkstone {
           cb(undefined, response, httpResponse);
         } else {
           const response = body as string;
-          cb(response, undefined, httpResponse);
+          cb(safeError(err), undefined, httpResponse);
         }
       });
     }
@@ -179,7 +179,7 @@ export namespace inkstone {
           cb(undefined, response, httpResponse);
         } else {
           const response = body as string;
-          cb(response, undefined, httpResponse);
+          cb(safeError(err), undefined, httpResponse);
         }
       });
     }
@@ -193,7 +193,7 @@ export namespace inkstone {
         if (httpResponse && httpResponse.statusCode === 200) {
           cb(undefined, body, httpResponse);
         } else {
-          cb(err, undefined, httpResponse);
+          cb(safeError(err), undefined, httpResponse);
         }
       });
     }
@@ -224,7 +224,7 @@ export namespace inkstone {
         if (httpResponse && httpResponse.statusCode === 200) {
           cb(undefined, body, httpResponse);
         } else {
-          cb(err, undefined, httpResponse);
+          cb(safeError(err), undefined, httpResponse);
         }
       });
     }

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -43,7 +43,7 @@ var mixpanel = require('haiku-serialization/src/utils/Mixpanel')
 
 const electron = require('electron')
 const remote = electron.remote
-const {dialog} = remote
+const { dialog } = remote
 const ipcRenderer = electron.ipcRenderer
 const clipboard = electron.clipboard
 
@@ -211,7 +211,7 @@ export default class Creator extends React.Component {
       (event) => {
         if (this.state.projectModel) {
           this.state.projectModel.linkExternalAssetOnDrop(event, (error) => {
-            if (error) this.setState({error})
+            if (error) this.setState({ error })
             this.forceUpdate()
           })
         }
@@ -316,6 +316,20 @@ export default class Creator extends React.Component {
     }
   }
 
+  handleEnvoyUserReady () {
+    // kick off initial report
+    this.onActivityReport(true, true)
+
+    this.user.getUserDetails().then((details) => {
+      let deets = JSON.parse(details)
+      // update UI with whether this user is an admin
+      // alert("Admin " + details)
+      // alert("Admin " + JSON.parse(details))
+
+      // this.setState({isAdmin: deets.IsAdmin})
+    })
+  }
+
   componentDidMount () {
     this.props.websocket.on('broadcast', (message) => {
       switch (message.name) {
@@ -369,9 +383,9 @@ export default class Creator extends React.Component {
             extensions: [extension]
           }]
         },
-        (filename) => {
-          exporterChannel.save({format, filename})
-        })
+          (filename) => {
+            exporterChannel.save({ format, filename })
+          })
       })
     })
 
@@ -381,9 +395,7 @@ export default class Creator extends React.Component {
        */
       (user) => {
         this.user = user
-
-        // kick off initial report
-        this.onActivityReport(true, true)
+        this.handleEnvoyUserReady()
       }
     )
 
@@ -587,8 +599,8 @@ export default class Creator extends React.Component {
 
   setPreviewMode (interactionMode) {
     if (this.state.projectModel) {
-      this.state.projectModel.setInteractionMode(interactionMode, () => {})
-      this.setState({interactionMode})
+      this.state.projectModel.setInteractionMode(interactionMode, () => { })
+      this.setState({ interactionMode })
     }
   }
 
@@ -614,7 +626,7 @@ export default class Creator extends React.Component {
   }
 
   switchActiveNav (activeNav) {
-    this.setState({activeNav})
+    this.setState({ activeNav })
   }
 
   authenticateUser (username, password, cb) {
@@ -634,7 +646,7 @@ export default class Creator extends React.Component {
   }
 
   resendEmailConfirmation (username, password, cb) {
-    return this.props.websocket.request({ method: 'resendEmailConfirmation', params: [username] }, () => {})
+    return this.props.websocket.request({ method: 'resendEmailConfirmation', params: [username] }, () => { })
   }
 
   authenticationComplete () {
@@ -736,10 +748,10 @@ export default class Creator extends React.Component {
                 if (ac) {
                   // Even if we already have an active component set up and assigned in memory,
                   // we still need to notify Timeline/Stage since they have been completely recreated
-                  ac.setAsCurrentActiveComponent({ from: 'creator' }, () => {})
+                  ac.setAsCurrentActiveComponent({ from: 'creator' }, () => { })
                 } else {
                   // And if we don't have anything assigned, assume we're editing the main component
-                  this.state.projectModel.setCurrentActiveComponent('main', { from: 'creator' }, () => {})
+                  this.state.projectModel.setCurrentActiveComponent('main', { from: 'creator' }, () => { })
                 }
               })
             })
@@ -869,11 +881,11 @@ export default class Creator extends React.Component {
   }
 
   onTimelineMounted () {
-    this.setState({isTimelineReady: true})
+    this.setState({ isTimelineReady: true })
   }
 
   onTimelineUnmounted () {
-    this.setState({isTimelineReady: false})
+    this.setState({ isTimelineReady: false })
   }
 
   onNavigateToDashboard () {
@@ -906,7 +918,7 @@ export default class Creator extends React.Component {
           transitionName='toast'
           transitionEnterTimeout={500}
           transitionLeaveTimeout={300}>
-          <div style={{position: 'absolute', right: 0, top: 0, width: 300}}>
+          <div style={{ position: 'absolute', right: 0, top: 0, width: 300 }}>
             {lodash.map(this.state.notices, this.renderNotifications)}
           </div>
         </ReactCSSTransitionGroup>
@@ -932,7 +944,7 @@ export default class Creator extends React.Component {
   }
 
   clearAuth () {
-    this.setState({readyForAuth: true, isUserAuthenticated: false, username: ''})
+    this.setState({ readyForAuth: true, isUserAuthenticated: false, username: '' })
   }
 
   setProjectLaunchStatus ({ launchingProject, newProjectLoading }) {
@@ -1037,7 +1049,7 @@ export default class Creator extends React.Component {
             transitionName='toast'
             transitionEnterTimeout={500}
             transitionLeaveTimeout={300}>
-            <div style={{position: 'absolute', right: 0, top: 0, width: 300}}>
+            <div style={{ position: 'absolute', right: 0, top: 0, width: 300 }}>
               {lodash.map(this.state.notices, this.renderNotifications)}
             </div>
           </ReactCSSTransitionGroup>
@@ -1062,12 +1074,12 @@ export default class Creator extends React.Component {
           projectsList={this.state.projectsList}
           envoyClient={this.envoyClient} />
         <div style={{ position: 'absolute', width: '100%', height: '100%', top: 0, left: 0 }}>
-          <div className='layout-box' style={{overflow: 'visible'}}>
+          <div className='layout-box' style={{ overflow: 'visible' }}>
             <ReactCSSTransitionGroup
               transitionName='toast'
               transitionEnterTimeout={500}
               transitionLeaveTimeout={300}>
-              <div style={{position: 'absolute', right: 0, top: 0, width: 300}}>
+              <div style={{ position: 'absolute', right: 0, top: 0, width: 300 }}>
                 {lodash.map(this.state.notices, this.renderNotifications)}
               </div>
             </ReactCSSTransitionGroup>
@@ -1115,9 +1127,9 @@ export default class Creator extends React.Component {
                         removeNotice={this.removeNotice}
                         folder={this.state.projectFolder}
                         websocket={this.props.websocket} />
-                      }
+                    }
                   </SideBar>
-                  <div style={{position: 'relative', width: '100%', height: '100%'}}>
+                  <div style={{ position: 'relative', width: '100%', height: '100%' }}>
                     <Stage
                       ref='stage'
                       folder={this.state.projectFolder}
@@ -1139,7 +1151,7 @@ export default class Creator extends React.Component {
                     />
                     {(this.state.assetDragging)
                       ? <div style={{ width: '100%', height: '100%', backgroundColor: 'white', opacity: 0.01, position: 'absolute', top: 0, left: 0 }} />
-                      : '' }
+                      : ''}
                   </div>
                 </SplitPane>
               </div>

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -88,6 +88,7 @@ export default class Creator extends React.Component {
       isUserAuthenticated: false,
       username: null,
       password: null,
+      isAdmin: false,
       notices: [],
       softwareVersion: pkg.version,
       didPlumbingNoticeCrash: false,
@@ -974,6 +975,7 @@ export default class Creator extends React.Component {
             username={this.state.username}
             softwareVersion={this.state.softwareVersion}
             organizationName={this.state.organizationName}
+            isAdmin={this.state.isAdmin}
             loadProjects={this.loadProjects}
             launchProject={this.launchProject}
             createNotice={this.createNotice}

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -320,13 +320,12 @@ export default class Creator extends React.Component {
     // kick off initial report
     this.onActivityReport(true, true)
 
-    this.user.getUserDetails().then((details) => {
-      let deets = JSON.parse(details)
-      // update UI with whether this user is an admin
-      // alert("Admin " + details)
-      // alert("Admin " + JSON.parse(details))
-
-      // this.setState({isAdmin: deets.IsAdmin})
+    //check admin status
+    this.user.getUserDetails().then((stringData) => {
+      let userInfo = JSON.parse(stringData)
+      if(userInfo && userInfo.IsAdmin){
+        this.setState({isAdmin: userInfo.IsAdmin})
+      }
     })
   }
 

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -320,10 +320,10 @@ export default class Creator extends React.Component {
     // kick off initial report
     this.onActivityReport(true, true)
 
-    //check admin status
+    // check admin status
     this.user.getUserDetails().then((stringData) => {
       let userInfo = JSON.parse(stringData)
-      if(userInfo && userInfo.IsAdmin){
+      if (userInfo && userInfo.IsAdmin) {
         this.setState({isAdmin: userInfo.IsAdmin})
       }
     })

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -15,11 +15,10 @@ const HARDCODED_PROJECTS_LIMIT = 15
 
 const STYLES = {
   adminButton: {
-    //TODO: make this a bit more subdued? 
-    background: 'linear-gradient(180deg, rgb(247,183,89), rgb(229,116,89) 50%, rgb(213,53,89))',
+    // TODO: make this a bit more subdued?
+    background: 'linear-gradient(180deg, rgb(247,183,89), rgb(229,116,89) 50%, rgb(213,53,89))'
   }
 }
-
 
 class ProjectBrowser extends React.Component {
   constructor (props) {

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -13,6 +13,14 @@ import Popover from 'react-popover'
 
 const HARDCODED_PROJECTS_LIMIT = 15
 
+const STYLES = {
+  adminButton: {
+    //TODO: make this a bit more subdued? 
+    background: 'linear-gradient(180deg, rgb(247,183,89), rgb(229,116,89) 50%, rgb(213,53,89))',
+  }
+}
+
+
 class ProjectBrowser extends React.Component {
   constructor (props) {
     super(props)
@@ -458,7 +466,7 @@ class ProjectBrowser extends React.Component {
               id='haiku-button-show-account-popover'
               key='user'
               onClick={this.openPopover}
-              style={[BTN_STYLES.btnIcon, BTN_STYLES.btnIconHovered]}>
+              style={[BTN_STYLES.btnIcon, BTN_STYLES.btnIconHovered, this.props.isAdmin && STYLES.adminButton]}>
               <UserIconSVG color={Palette.SUNSTONE} />
             </button>
           </Popover>

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -153,7 +153,7 @@ class ProjectBrowser extends React.Component {
           projectsList.splice(index, 1)
           this.setState({
             projectsList,
-            atProjectMax: !this.props.isAdmin &&  projectsList.length >= HARDCODED_PROJECTS_LIMIT
+            atProjectMax: !this.props.isAdmin && projectsList.length >= HARDCODED_PROJECTS_LIMIT
           })
         }, Math.min(200, Date.now() - deleteStart))
       })

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -84,7 +84,7 @@ class ProjectBrowser extends React.Component {
       this.setState({
         projectsList,
         areProjectsLoading: false,
-        atProjectMax: projectsList.length >= HARDCODED_PROJECTS_LIMIT
+        atProjectMax: !this.props.isAdmin && projectsList.length >= HARDCODED_PROJECTS_LIMIT
       })
     })
   }
@@ -151,7 +151,10 @@ class ProjectBrowser extends React.Component {
         // the project.
         setTimeout(() => {
           projectsList.splice(index, 1)
-          this.setState({ projectsList, atProjectMax: projectsList.length >= HARDCODED_PROJECTS_LIMIT })
+          this.setState({
+            projectsList,
+            atProjectMax: !this.props.isAdmin &&  projectsList.length >= HARDCODED_PROJECTS_LIMIT
+          })
         }, Math.min(200, Date.now() - deleteStart))
       })
     })

--- a/packages/haiku-glass/test/projects/simple/code/main/dom-embed.js
+++ b/packages/haiku-glass/test/projects/simple/code/main/dom-embed.js
@@ -1,13 +1,17 @@
 var code = require('./code')
-var adapter = window.HaikuPlayer && window.HaikuPlayer['2.3.78']
+var adapter = window.HaikuCore && window.HaikuCore['3.0.28']
+if (!adapter) {
+  // See if we can find the legacy player module if HaikuCore isn't present
+  adapter = window.HaikuPlayer && window.HaikuPlayer['3.0.28']
+}
 if (adapter) {
   module.exports = adapter(code)
 } else  {
   function safety () {
     console.error(
-      '[haiku player] player version 2.3.78 seems to be missing. ' +
-      'index.embed.js expects it at window.HaikuPlayer["2.3.78"], but we cannot find it. ' +
-      'you may need to add a <script src="path/to/HaikuPlayer.js"></script> to fix this.'
+      '[haiku core] core version 3.0.28 seems to be missing. ' +
+      'index.embed.js expects it at window.HaikuCore["3.0.28"], but we cannot find it. ' +
+      'you may need to add a <script src="path/to/HaikuCore.js"></script> to fix this.'
     )
     return code
   }

--- a/packages/haiku-glass/test/projects/simple/code/main/dom.js
+++ b/packages/haiku-glass/test/projects/simple/code/main/dom.js
@@ -1,2 +1,2 @@
-var HaikuCreation = require('@haiku/core/dom')
-module.exports = HaikuCreation(require('./code.js'))
+var HaikuDOMAdapter = require('@haiku/core/dom')
+module.exports = HaikuDOMAdapter(require('./code'))

--- a/packages/haiku-sdk-creator/src/bll/User.ts
+++ b/packages/haiku-sdk-creator/src/bll/User.ts
@@ -9,6 +9,7 @@ export interface User {
   setConfig: MaybeAsync<(key: string, value: string) => void>;
   getConfig: MaybeAsync<(key: string) => string>;
   getAuthToken: MaybeAsync<() => string>;
+  getUserDetails: MaybeAsync<() => MaybeAsync<inkstone.user.User>>;
 }
 
 export const USER_CHANNEL = 'user';

--- a/packages/haiku-sdk-creator/src/bll/User.ts
+++ b/packages/haiku-sdk-creator/src/bll/User.ts
@@ -37,4 +37,12 @@ export class UserHandler implements User {
     return sdkClient.config.getUserId();
   }
 
+  getUserDetails(): Promise<inkstone.user.User> {
+    return new Promise<inkstone.user.User>((resolve) => {
+      inkstone.user.getDetails(this.getAuthToken(), (err, user, response) => {
+        resolve(user);
+      });
+    });
+  }
+
 }

--- a/packages/haiku-sdk-creator/src/envoy/EnvoyServer.ts
+++ b/packages/haiku-sdk-creator/src/envoy/EnvoyServer.ts
@@ -170,16 +170,34 @@ export default class EnvoyServer {
         const method = handler.instance[data.method];
         if (method && typeof method === 'function') {
           const returnValue = method.apply(handler.instance, data.params);
-          const response = <Datagram> {
-            channel: data.channel,
-            data: returnValue,
-            id: data.id,
-            intent: DatagramIntent.RESPONSE,
 
-          };
-          // TODO: could reply directly to the client that requested instead of broadcasting to all
-          //       would require identifying the client (via datagram) & then tracking clientId in future datagrams
-          this.broadcast(response);
+          if (returnValue && returnValue.then) {
+            //assume this is a promise, and unwrap it before sending response
+            returnValue.then((unwrapped) => {
+              const unwrappedString = JSON.stringify(unwrapped);
+              const response = <Datagram>{
+                channel: data.channel,
+                data: unwrappedString,
+                id: data.id,
+                intent: DatagramIntent.RESPONSE,
+              };
+              // TODO: could reply directly to the client that requested instead of broadcasting to all
+              //       would require identifying the client (via datagram) & then tracking clientId in future datagrams
+              this.broadcast(response);
+            });
+
+          } else {
+            const response = <Datagram>{
+              channel: data.channel,
+              data: returnValue,
+              id: data.id,
+              intent: DatagramIntent.RESPONSE,
+
+            };
+            // TODO: could reply directly to the client that requested instead of broadcasting to all
+            //       would require identifying the client (via datagram) & then tracking clientId in future datagrams
+            this.broadcast(response);
+          }
 
         } else {
           this.logger.warn('Not Found', `Method ${method} not found at ${data.channel}`);
@@ -189,7 +207,7 @@ export default class EnvoyServer {
       const handler = this.handlerRegistry.get(data.channel);
       if (handler) {
         const schema = this.discoverSchemaOfHandlerPrototype(handler);
-        const response = <Datagram> {
+        const response = <Datagram>{
           channel: data.channel,
           data: JSON.stringify(schema),
           id: data.id,
@@ -236,7 +254,7 @@ export default class EnvoyServer {
    * populates into a schema object.
    */
   private discoverSchemaOfHandlerPrototype(handlerTuple: HandlerTuple): Schema {
-    const ret = <Schema> {};
+    const ret = <Schema>{};
     const proto = handlerTuple.proto;
     const instance = handlerTuple.instance;
     Object.getOwnPropertyNames(proto).forEach((name) => {

--- a/packages/haiku-sdk-creator/src/envoy/EnvoyServer.ts
+++ b/packages/haiku-sdk-creator/src/envoy/EnvoyServer.ts
@@ -174,10 +174,10 @@ export default class EnvoyServer {
           if (returnValue && returnValue.then) {
             //assume this is a promise, and unwrap it before sending response
             returnValue.then((unwrapped) => {
-              const unwrappedString = JSON.stringify(unwrapped);
+              // const unwrappedString = JSON.stringify(unwrapped);
               const response = <Datagram>{
                 channel: data.channel,
-                data: unwrappedString,
+                data: unwrapped,
                 id: data.id,
                 intent: DatagramIntent.RESPONSE,
               };

--- a/packages/haiku-timeline/test/projects/complex/code/bubtonkillingsworth/dom-embed.js
+++ b/packages/haiku-timeline/test/projects/complex/code/bubtonkillingsworth/dom-embed.js
@@ -1,13 +1,17 @@
 var code = require('./code')
-var adapter = window.HaikuPlayer && window.HaikuPlayer['2.3.78']
+var adapter = window.HaikuCore && window.HaikuCore['3.0.28']
+if (!adapter) {
+  // See if we can find the legacy player module if HaikuCore isn't present
+  adapter = window.HaikuPlayer && window.HaikuPlayer['3.0.28']
+}
 if (adapter) {
   module.exports = adapter(code)
 } else  {
   function safety () {
     console.error(
-      '[haiku player] player version 2.3.78 seems to be missing. ' +
-      'index.embed.js expects it at window.HaikuPlayer["2.3.78"], but we cannot find it. ' +
-      'you may need to add a <script src="path/to/HaikuPlayer.js"></script> to fix this.'
+      '[haiku core] core version 3.0.28 seems to be missing. ' +
+      'index.embed.js expects it at window.HaikuCore["3.0.28"], but we cannot find it. ' +
+      'you may need to add a <script src="path/to/HaikuCore.js"></script> to fix this.'
     )
     return code
   }

--- a/packages/haiku-timeline/test/projects/complex/code/main/dom-embed.js
+++ b/packages/haiku-timeline/test/projects/complex/code/main/dom-embed.js
@@ -1,13 +1,17 @@
 var code = require('./code')
-var adapter = window.HaikuPlayer && window.HaikuPlayer['2.3.78']
+var adapter = window.HaikuCore && window.HaikuCore['3.0.28']
+if (!adapter) {
+  // See if we can find the legacy player module if HaikuCore isn't present
+  adapter = window.HaikuPlayer && window.HaikuPlayer['3.0.28']
+}
 if (adapter) {
   module.exports = adapter(code)
 } else  {
   function safety () {
     console.error(
-      '[haiku player] player version 2.3.78 seems to be missing. ' +
-      'index.embed.js expects it at window.HaikuPlayer["2.3.78"], but we cannot find it. ' +
-      'you may need to add a <script src="path/to/HaikuPlayer.js"></script> to fix this.'
+      '[haiku core] core version 3.0.28 seems to be missing. ' +
+      'index.embed.js expects it at window.HaikuCore["3.0.28"], but we cannot find it. ' +
+      'you may need to add a <script src="path/to/HaikuCore.js"></script> to fix this.'
     )
     return code
   }

--- a/packages/haiku-timeline/test/projects/complex/code/main/dom.js
+++ b/packages/haiku-timeline/test/projects/complex/code/main/dom.js
@@ -1,2 +1,2 @@
-var HaikuCreation = require('@haiku/core/dom')
-module.exports = HaikuCreation(require('./code.js'))
+var HaikuDOMAdapter = require('@haiku/core/dom')
+module.exports = HaikuDOMAdapter(require('./code'))


### PR DESCRIPTION
Ready to merge.

Short review.
UI support for not holding an admin account to the standard 15 project limit. Zack is working on the backend piece. 

Update from Zack:  piggy-backed on this PR for a grab-bag of other tasks:

 - did some polish work on the CLI, including adding an `init` command so we can `haiku init && yarn add @haiku/some-project`
 - hooked up pulling "isAdmin" status from Inkstone (incl. SDK work,) plus a little UI tweak to show a badge of shininess when you're an admin
 - built support for async functions inside Envoy handlers (i.e. functions that need to return values from callbacks or promises — this wasn't really possible before, seriously limiting the utility of Envoy handlers)
 - updated some of the docs in Haiku Core's readme

This also required some inkstone work, which is already done & deployed



Asana task links:
https://app.asana.com/0/539750334128224/546269516770377
- …



Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Ran the automated tests and linted the code
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
