### PR TITLE
Feat: vue adapter

### DIFF
--- a/packages/@haiku/core/demo/projects/AndroidFiltersV2/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/AndroidFiltersV2/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/cardmenu/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/cardmenu/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/chinese-food/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/chinese-food/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/clickable-square-2/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/clickable-square-2/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/clickable-square/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/clickable-square/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/comet-rotation/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/comet-rotation/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/component-instance-multi/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/component-instance-multi/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/component-instance/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/component-instance/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/controlflow-placeholder-keys/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/controlflow-placeholder-keys/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/controlflow-placeholder-opacity/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/controlflow-placeholder-opacity/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/controlflow-placeholder-with-haiku-opacity/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/controlflow-placeholder-with-haiku-opacity/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/controlflow-placeholder-with-haiku/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/controlflow-placeholder-with-haiku/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/controlflow-placeholder/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/controlflow-placeholder/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/controlflow-repeat-1/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/controlflow-repeat-1/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/crazy-paths/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/crazy-paths/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/drop-shadow/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/drop-shadow/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/el-resizing-contain/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/el-resizing-contain/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/el-resizing-cover/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/el-resizing-cover/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/events-internal/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/events-internal/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/events/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/events/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/expr-bad1/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/expr-bad1/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/expr1/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/expr1/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/filter-instances/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/filter-instances/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/gradients-and-masks/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/gradients-and-masks/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/hearts-beating/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/hearts-beating/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/hearts-rejoicing/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/hearts-rejoicing/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/heartstry4/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/heartstry4/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/hello-world-strobe/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/hello-world-strobe/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/hello-world/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/hello-world/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/injectables-builtins/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/injectables-builtins/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/injectables-component/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/injectables-component/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/injectables-element/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/injectables-element/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/injectables-helpers/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/injectables-helpers/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/injectables-player/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/injectables-player/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/injectables-root/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/injectables-root/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/injectables-states/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/injectables-states/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/injectables-tree-parent/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/injectables-tree-parent/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/injectables-user/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/injectables-user/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/injectables-window/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/injectables-window/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/inline-image/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/inline-image/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/morph-loop-in-react-dom/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/morph-loop-in-react-dom/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/morph/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/morph/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/moto7/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/moto7/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/mountainsillo/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/mountainsillo/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/move/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/move/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/overflow-hidden/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/overflow-hidden/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/overflow-scroll/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/overflow-scroll/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/overflow-visible/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/overflow-visible/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/perf-nesting/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/perf-nesting/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/perf-thumbdial/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/perf-thumbdial/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/primitives-2/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/primitives-2/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/primitives/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/primitives/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/react-bare-1/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/react-bare-1/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/react-bare-2/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/react-bare-2/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/react-remount/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/react-remount/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/react-render-via-state/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/react-render-via-state/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/react-router-dom/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/react-router-dom/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/react-states-and-such-1/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/react-states-and-such-1/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/rings3000/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/rings3000/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/sign-up-button-loop/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/sign-up-button-loop/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/sign-up-button/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/sign-up-button/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/simple-sect-one/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/simple-sect-one/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/sparrow-sez-rerender/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/sparrow-sez-rerender/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/sparrow-sez/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/sparrow-sez/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/stage-delete-element/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/stage-delete-element/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/stein/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/stein/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/timed-skeleton/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/timed-skeleton/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/ttt1/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/ttt1/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/user-mouse-pos-offset/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/user-mouse-pos-offset/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/projects/wowie/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/wowie/code/main/vue-dom.js
@@ -1,0 +1,4 @@
+var HaikuVueAdapter = require('@haiku/core/dom/vue')
+var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+module.exports = HaikuVueComponent

--- a/packages/@haiku/core/demo/server.js
+++ b/packages/@haiku/core/demo/server.js
@@ -75,11 +75,12 @@ app.get('/demos/:demo', (req, res) => {
 
   const dom = path.join(PROJECTS_DIRECTORY, demo, 'code', 'main', 'dom.js');
   const reactDom = path.join(PROJECTS_DIRECTORY, demo, 'code', 'main', 'react-dom.js');
-  if (!fse.existsSync(dom) || !fse.existsSync(reactDom)) {
+  const vueDom = path.join(PROJECTS_DIRECTORY, demo, 'code', 'main', 'vue-dom.js');
+  if (!fse.existsSync(dom) || !fse.existsSync(reactDom) || !fse.existsSync(vueDom)) {
     return res.status(404).send('Demo not found!');
   }
 
-  const compiler = getSimpleCompiler({dom, reactDom}, demo);
+  const compiler = getSimpleCompiler({dom, reactDom, vueDom}, demo);
 
   try {
     compiler.run((err, stats) => {

--- a/packages/@haiku/core/demo/templates/demo.html.handlebars
+++ b/packages/@haiku/core/demo/templates/demo.html.handlebars
@@ -15,6 +15,8 @@
   </style>
   <script src="/webpack/{{demo}}.dom.js"></script>
   <script src="/webpack/{{demo}}.reactDom.js"></script>
+  <script src="/webpack/{{demo}}.vueDom.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.5.13/vue.js"></script>
 </head>
 <body>
   <div class="container">
@@ -25,18 +27,27 @@
     <p>{{{note}}}</p>
 
     <div class="row">
-      <div class="col-md-6">
+      <div class="col-md-4">
         <h2>vanilla</h2>
         {{{before}}}
         <div class="mount" id="dom-mount"></div>
         {{{after}}}
       </div>
-      <div class="col-md-6">
+      <div class="col-md-4">
         <h2>react</h2>
         {{{before}}}
         <div class="mount" id="react-dom-mount"></div>
         {{{after}}}
       </div>
+      <div class="col-md-4">
+        <h2>vue</h2>
+        {{{before}}}
+        <div class="mount">
+          <div id="vue-dom-mount"></div>
+        </div>
+        {{{after}}}
+      </div>
+     </div>
     </div>
   </div>
 
@@ -47,6 +58,14 @@
     reactDom.mount
       ? reactDom.mount(reactDomMount, reactDom.React, reactDom.ReactDOM)
       : reactDom.ReactDOM.render(reactDom.React.createElement(reactDom), reactDomMount);
+
+    new Vue({
+      el: '#vue-dom-mount',
+      template: `<{{demo}}></{{demo}}>`,
+      components: {
+        '{{demo}}': vueDom
+      }
+    });
   </script>
 </body>
 </html>

--- a/packages/@haiku/core/dom/vue/index.js
+++ b/packages/@haiku/core/dom/vue/index.js
@@ -1,0 +1,5 @@
+/**
+ * Copyright (c) Haiku 2016-2018. All rights reserved.
+ */
+
+module.exports = require('./../../lib/adapters/vue-dom').default

--- a/packages/@haiku/core/src/adapters/react-dom/HaikuReactDOMAdapter.ts
+++ b/packages/@haiku/core/src/adapters/react-dom/HaikuReactDOMAdapter.ts
@@ -5,6 +5,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import EventsDict from './EventsDict';
+import {randomString} from '../../helpers/StringUtils';
 
 const DEFAULT_HOST_ELEMENT_TAG_NAME = 'div';
 
@@ -305,20 +306,6 @@ export default function HaikuReactDOMAdapter(haikuComponentFactory, optionalRawB
   }
 
   return HaikuReactComponentInternal;
-}
-
-/**
- * Quick-and-dirty way to generate unique DOM-friendly ids on the fly...
- */
-
-const ALPHABET = 'abcdefghijklmnopqrstuvwxyz';
-
-function randomString(len) {
-  let str = '';
-  while (str.length < len) {
-    str += ALPHABET[Math.floor(Math.random() * ALPHABET.length)];
-  }
-  return str;
 }
 
 function visit(el, visitor) {

--- a/packages/@haiku/core/src/adapters/vue-dom/HaikuVueDOMAdapter.ts
+++ b/packages/@haiku/core/src/adapters/vue-dom/HaikuVueDOMAdapter.ts
@@ -15,9 +15,9 @@ export default function HaikuVueDOMAdapter(haikuComponentFactory): HaikuVueCompo
       eventHandlers: Object,
       timelines: Object,
       vanities: Object,
-      placeholder: Object
+      placeholder: Object,
     },
-    mounted: function() {
+    mounted() {
       this.haiku = haikuComponentFactory(this.$el, {
         ref: this.$el,
         options: this.$props.haikuOptions,
@@ -27,35 +27,35 @@ export default function HaikuVueDOMAdapter(haikuComponentFactory): HaikuVueCompo
         vanities: this.$props.vanities,
         placeholder: this.$props.placeholder,
         onHaikuComponentWillInitialize: (component) => {
-          this.$emit('haikuComponentWillInitialize', component)
+          this.$emit('haikuComponentWillInitialize', component);
         },
         onHaikuComponentDidMount: (component) => {
-          this.$emit('haikuComponentDidMount', component)
+          this.$emit('haikuComponentDidMount', component);
         },
         onHaikuComponentWillMount: (component) => {
-          this.$emit('haikuComponentWillMount', component)
+          this.$emit('haikuComponentWillMount', component);
         },
         onHaikuComponentDidInitialize: (component) => {
-          this.$emit('haikuComponentDidInitialize', component)
+          this.$emit('haikuComponentDidInitialize', component);
         },
         onHaikuComponentWillUnmount: (component) => {
-          this.$emit('haikuComponentWillUnmount', component)
-        }
-      })
+          this.$emit('haikuComponentWillUnmount', component);
+        },
+      });
     },
-    updated: function() {
+    updated() {
       this.haiku.assignConfig({
         options: this.$props.haikuOptions,
-        states: this.$props.haikuStates
-      })
+        states: this.$props.haikuStates,
+      });
     },
-    destroyed: function() {
-      this.haiku.callUnmount()
+    destroyed() {
+      this.haiku.callUnmount();
     },
-    render: function(createElement) {
+    render(createElement) {
       return createElement('div', {
         attrs: {
-          id: 'haiku-vueroot-' + randomString(24)
+          id: 'haiku-vueroot-' + randomString(24),
         },
         style: {
           position: 'relative',
@@ -64,9 +64,9 @@ export default function HaikuVueDOMAdapter(haikuComponentFactory): HaikuVueCompo
           border: 0,
           width: '100%',
           height: '100%',
-          transform: 'matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)'
-        }
-      })
-    }
-  }
+          transform: 'matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)',
+        },
+      });
+    },
+  };
 }

--- a/packages/@haiku/core/src/adapters/vue-dom/HaikuVueDOMAdapter.ts
+++ b/packages/@haiku/core/src/adapters/vue-dom/HaikuVueDOMAdapter.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Haiku 2016-2018. All rights reserved.
+ */
+
+import {randomString} from '../../helpers/StringUtils';
+
+export interface HaikuVueComponent {}
+
+// tslint:disable-next-line:function-name
+export default function HaikuVueDOMAdapter(haikuComponentFactory): HaikuVueComponent {
+  return {
+    props: {
+      haikuOptions: Object,
+      haikuStates: Object,
+      eventHandlers: Object,
+      timelines: Object,
+      vanities: Object,
+      placeholder: Object
+    },
+    mounted: function() {
+      this.haiku = haikuComponentFactory(this.$el, {
+        ref: this.$el,
+        options: this.$props.haikuOptions,
+        states: this.$props.haikuStates,
+        eventHandlers: this.$props.eventHandlers,
+        timelines: this.$props.timelines,
+        vanities: this.$props.vanities,
+        placeholder: this.$props.placeholder,
+        onHaikuComponentWillInitialize: (component) => {
+          this.$emit('haikuComponentWillInitialize', component)
+        },
+        onHaikuComponentDidMount: (component) => {
+          this.$emit('haikuComponentDidMount', component)
+        },
+        onHaikuComponentWillMount: (component) => {
+          this.$emit('haikuComponentWillMount', component)
+        },
+        onHaikuComponentDidInitialize: (component) => {
+          this.$emit('haikuComponentDidInitialize', component)
+        },
+        onHaikuComponentWillUnmount: (component) => {
+          this.$emit('haikuComponentWillUnmount', component)
+        }
+      })
+    },
+    updated: function() {
+      this.haiku.assignConfig({
+        options: this.$props.haikuOptions,
+        states: this.$props.haikuStates
+      })
+    },
+    destroyed: function() {
+      this.haiku.callUnmount()
+    },
+    render: function(createElement) {
+      return createElement('div', {
+        attrs: {
+          id: 'haiku-vueroot-' + randomString(24)
+        },
+        style: {
+          position: 'relative',
+          margin: 0,
+          padding: 0,
+          border: 0,
+          width: '100%',
+          height: '100%',
+          transform: 'matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)'
+        }
+      })
+    }
+  }
+}

--- a/packages/@haiku/core/src/adapters/vue-dom/HaikuVueDOMAdapter.ts
+++ b/packages/@haiku/core/src/adapters/vue-dom/HaikuVueDOMAdapter.ts
@@ -47,6 +47,10 @@ export default function HaikuVueDOMAdapter(haikuComponentFactory): HaikuVueCompo
       this.haiku.assignConfig({
         options: this.$props.haikuOptions,
         states: this.$props.haikuStates,
+        eventHandlers: this.$props.eventHandlers,
+        timelines: this.$props.timelines,
+        vanities: this.$props.vanities,
+        placeholder: this.$props.placeholder,
       });
     },
     destroyed() {

--- a/packages/@haiku/core/src/adapters/vue-dom/index.ts
+++ b/packages/@haiku/core/src/adapters/vue-dom/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) Haiku 2016-2018. All rights reserved.
+ */
+
+import HaikuVueDOMAdapter from './HaikuVueDOMAdapter';
+
+export default HaikuVueDOMAdapter;

--- a/packages/@haiku/core/src/helpers/StringUtils.ts
+++ b/packages/@haiku/core/src/helpers/StringUtils.ts
@@ -1,0 +1,13 @@
+/**
+ * Quick-and-dirty way to generate unique DOM-friendly ids on the fly...
+ */
+
+export const ALPHABET = 'abcdefghijklmnopqrstuvwxyz';
+
+export function randomString(len) {
+  let str = '';
+  while (str.length < len) {
+    str += ALPHABET[Math.floor(Math.random() * ALPHABET.length)];
+  }
+  return str;
+}

--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -1049,3 +1049,10 @@ const REACT_DOM_JS = dedent`
   if (HaikuReactComponent.default) HaikuReactComponent = HaikuReactComponent.default
   module.exports = HaikuReactComponent
 `.trim()
+
+const VUE_DOM_JS = dedent`
+  var HaikuVueAdapter = require('@haiku/core/dom/vue')
+  var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
+  if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
+  module.exports = HaikuVueComponent
+`.trim()

--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -848,6 +848,7 @@ class Project extends BaseModel {
     fse.outputFileSync(path.join(this.getFolder(), `code/${scenename}/dom.js`), DOM_JS)
     fse.outputFileSync(path.join(this.getFolder(), `code/${scenename}/dom-embed.js`), DOM_EMBED_JS)
     fse.outputFileSync(path.join(this.getFolder(), `code/${scenename}/react-dom.js`), REACT_DOM_JS)
+    fse.outputFileSync(path.join(this.getFolder(), `code/${scenename}/vue-dom.js`), VUE_DOM_JS)
 
     if (!fse.existsSync(path.join(this.getFolder(), `code/${scenename}/dom-standalone.js`))) {
       fse.outputFileSync(path.join(this.getFolder(), `code/${scenename}/dom-standalone.js`), DOM_STANDALONE_JS)


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- We want to have a Vue.js adapter for HN launch 🎉 

Summary of work (include Asana links if any):

TL;DR: Implement barebones of vue adapter. (https://app.asana.com/0/539750334128224/548855170473422)

### The adapter

The adapter is a simple vue-component wrapper that handles all the logic to instantiate the element in DOM via the `core` API, while providing an idiomatic API on top of it, most features are implemented except for placeholders, which are going to be revisited soon.

Due to the nature of vue components (they are plain JS objects), we don't need to include Vue as a peer dependency of `core`, but may be worth discussing if we want to do it for any other reason.

**Full-example usage:**

_note: all props are optional, but are included in the example for the purposes of demonstration_

```js
import MyComponent from '@haiku/haiku-slug/vue'

new Vue({
  el: '#vue-dom-mount',
  template: `
    <my-component
      haikuOptions=""
      haikuStates=""
      eventHandlers=""
      timelines=""
      vanities=""
      @haikuComponentWillInitialize=""
      @haikuComponentDidMount=""
      @haikuComponentWillMount=""
      @haikuComponentDidInitialize=""
      @haikuComponentWillUnmount =""
    >
    </my-component>
`,
  components: {
    MyComponent
  }
})
```

Regressions to look for:

- Not aware of possible regressions, `core` code is untouched.

Notes for reviewers:

- Should we include Vue as a pair-dependency?
- For now, all demos with special functionality on the React side will only render the component on the Vue side, I will especial-case every demo later.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
