### PR TITLE
fix: allow splitpane to be resized

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1147,9 +1147,9 @@ export default class Creator extends React.Component {
                 {lodash.map(this.state.notices, this.renderNotifications)}
               </div>
             </ReactCSSTransitionGroup>
-            <SplitPane allowResize={false} onDragFinished={this.handlePaneResize.bind(this)} split='horizontal' minSize={300} defaultSize={this.props.height * 0.62}>
+            <SplitPane onDragFinished={this.handlePaneResize.bind(this)} split='horizontal' minSize={300} defaultSize={this.props.height * 0.62}>
               <div>
-                <SplitPane allowResize={false} onDragFinished={this.handlePaneResize.bind(this)} split='vertical' minSize={300} defaultSize={300}>
+                <SplitPane onDragFinished={this.handlePaneResize.bind(this)} split='vertical' minSize={300} defaultSize={300}>
                   <SideBar
                     doShowBackToDashboardButton={this.state.doShowBackToDashboardButton}
                     projectModel={this.state.projectModel}


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- I accidentally included this two parameters in #104 as I disabled it to test something else, I reviewed #104 for any other leftovers and everything seems to be in place, my apologies.

Summary of work (include Asana links if any):

- [x] Timeline panel can't be resized: https://app.asana.com/0/539750334128224/556802698503594

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
