### PR TITLE
fix: for various races affecting publish UI

### DIFF
--- a/packages/haiku-plumbing/src/MasterGitProject.js
+++ b/packages/haiku-plumbing/src/MasterGitProject.js
@@ -386,7 +386,10 @@ export default class MasterGitProject extends EventEmitter {
         // The main master process and component need to handle this too since the
         // bytecode contains the version which we use to render in the right-click menu
         this.emit('semver-bumped', nextTag, () => {
-          return cb(null, nextTag)
+          return this.fetchFolderState('semver-bumped', {}, (err) => {
+            if (err) return cb(err)
+            return cb(null, nextTag)
+          })
         })
       })
     })
@@ -1255,7 +1258,6 @@ export default class MasterGitProject extends EventEmitter {
         ]
 
         const teardownSteps = [
-          'bumpSemverAppropriately',
           'commitEverything',
           'makeTag',
           'saveSnapshot'


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- Fix various races encountered while testing publish UI leading to unstable Git sha and incorrect bytecode being published.

Summary of work (include Asana links if any):

- [x] In `Master.js`, move `bumpSemverAppropriately` out of `saveProject` and into its own routine that gets called first. This ensures that that bytecode isn't updated with the new version _after_ a tag is created, which was happening with intermittent regularity on projects where bytecode flushes were slow and Lottie export was fast (e.g. bytecode with large images, painstakingly processed by Haiku.app but just skipped by Lottie export).
- [x] Ensure there are no pending bytecode flushes before continuing on to Lottie export. This ensures that bytecode metadata is actually written to disk before we try to start committing stuff, in case Lottie is very fast as in bullet above. _[STILL BROKEN: making a change on stage and quickly hitting publish (before at least 500ms have passed) results in false "no publish necessary" behavior. I figured this is okay to leave broken and ticket for later.]_
- [x] Commit changes *after* populating project content during save, vs. before.

Taken together, these changes should make it so the commit SHA we produce during `this._git.commitProjectIfChanged('Updated metadata', cb)` stays the same from after we click the **Publish** button to after the Publish modal is closed and bytecode mutations are possible within the app.

Regressions to look for:

- Anything related to publishing never actually finishing. Tested carefully on several projects but worth another look.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed