### PR TITLE
Fixes for various publish UI races and edge cases

### DIFF
--- a/packages/haiku-ui-common/src/react/ShareModal/EmbedCategory.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/EmbedCategory.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import * as assign from 'lodash.assign';
-import {SHARE_OPTIONS} from './ShareModalOptions';
 import {EmbedOption} from './EmbedOption';
 
 const STYLES = {
@@ -30,18 +28,21 @@ export class EmbedCategory extends React.PureComponent {
     onOptionClicked: React.PropTypes.func,
     isSnapshotSaveInProgress: React.PropTypes.bool,
     snapshotSyndicated: React.PropTypes.bool,
+    snapshotPublished: React.PropTypes.bool,
   };
 
   renderCategoryOptions (options: Object) {
     return Object.entries(options).map(([entry, {disabled, template}]) => (
       <EmbedOption
         key={entry}
+        category={this.props.category}
         entry={entry}
         disabled={disabled}
         template={template}
         onClick={this.props.onOptionClicked}
         isSnapshotSaveInProgress={this.props.isSnapshotSaveInProgress}
         snapshotSyndicated={this.props.snapshotSyndicated}
+        snapshotPublished={this.props.snapshotPublished}
       />
     ));
   }

--- a/packages/haiku-ui-common/src/react/ShareModal/EmbedList.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/EmbedList.tsx
@@ -39,6 +39,7 @@ export class EmbedList extends React.PureComponent {
     onOptionClicked: React.PropTypes.func,
     isSnapshotSaveInProgress: React.PropTypes.bool,
     snapshotSyndicated: React.PropTypes.bool,
+    snapshotPublished: React.PropTypes.bool,
   };
 
   renderShareOptions () {
@@ -50,6 +51,7 @@ export class EmbedList extends React.PureComponent {
         onOptionClicked={this.props.onOptionClicked}
         isSnapshotSaveInProgress={this.props.isSnapshotSaveInProgress}
         snapshotSyndicated={this.props.snapshotSyndicated}
+        snapshotPublished={this.props.snapshotPublished}
       />
     ));
   }

--- a/packages/haiku-ui-common/src/react/ShareModal/LinkHolster.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/LinkHolster.tsx
@@ -30,6 +30,9 @@ const STYLES = {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
   } as React.CSSProperties,
+  linkDisabled: {
+    cursor: 'not-allowed',
+  } as React.CSSProperties,
   linkCopyBtn: {
     height: '100%',
     padding: '0 8px',
@@ -87,7 +90,7 @@ export class LinkHolster extends React.PureComponent {
     } = this.props;
 
     if (this.props.isSnapshotSaveInProgress) {
-      return <span style={STYLES.link}>New share link being generated</span>;
+      return <span style={{...STYLES.link, ...STYLES.linkDisabled}}>New share link being generated</span>;
     }
 
     if (this.state.copied) {

--- a/packages/haiku-ui-common/src/react/ShareModal/ShareModalOptions.ts
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareModalOptions.ts
@@ -1,5 +1,11 @@
+export const enum ShareCategory {
+  Web = 'Web',
+  Mobile = 'Mobile',
+  Other = 'Other',
+}
+
 export const SHARE_OPTIONS = {
-  Web: {
+  [ShareCategory.Web]: {
     'Vanilla JS': {
       disabled: false,
       template: 'VanillaJS',
@@ -21,7 +27,7 @@ export const SHARE_OPTIONS = {
       template: 'Embed',
     },
   },
-  Mobile: {
+  [ShareCategory.Mobile]: {
     iOS: {
       disabled: false,
       template: 'Lottie',
@@ -35,7 +41,7 @@ export const SHARE_OPTIONS = {
       template: 'Lottie',
     },
   },
-  Other: {
+  [ShareCategory.Other]: {
     GIF: {
       disabled: false,
       template: 'Gif',

--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -26,6 +26,7 @@ export class ShareModal extends React.Component {
     isSnapshotSaveInProgress: React.PropTypes.bool,
     isProjectInfoFetchInProgress: React.PropTypes.bool,
     snapshotSyndicated: React.PropTypes.bool,
+    snapshotPublished: React.PropTypes.bool,
     semverVersion: React.PropTypes.string,
     userName: React.PropTypes.string,
     organizationName: React.PropTypes.string,
@@ -72,6 +73,7 @@ export class ShareModal extends React.Component {
       isProjectInfoFetchInProgress,
       isSnapshotSaveInProgress,
       snapshotSyndicated,
+      snapshotPublished,
       userName,
       organizationName,
       sha,
@@ -98,6 +100,7 @@ export class ShareModal extends React.Component {
             <EmbedList
               isSnapshotSaveInProgress={isSnapshotSaveInProgress}
               snapshotSyndicated={snapshotSyndicated}
+              snapshotPublished={snapshotPublished}
               onOptionClicked={(selectedEntry) => {
                 this.showDetails(selectedEntry);
               }}


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- Fix various races and edge cases that could cause a bad user experience in the new publish UI.

Summary of work (include Asana links if any):

- [x] Switch to two-minute wait for GIF to appear with a slightly shorter interval (2500ms).
- [x] Use the `not-allowed` cursor when hovering over buttons that can't be clicked yet in the publish modal.
- [x] Gate mobile links with the "published" flag in Inkstone, which tells us the `lottie.json` files we link directly to in the app will actually exist when we click on them. (Note: I kept the web column attached to the weaker "snapshot exists" condition, even though it's technically *not* sufficient without the "published" flag for some and the "npm_published" flag for others. Rationale being that you can't hit this potential race *from our app*, and by the time you get around to following the instructions you'll probably have dodged it. The `lottie.json` link going to a 403 was the main thing I wanted to avoid.)
- [x] Use more realistic countdown times for the three stages of publish (link available, mobile stuff available, GIF available).
- [x] Treat snapshot info errors as actual errors—show an error message, close the share modal, encourage user to try again or contact us if it still doesn't work.
- [x] If "GIF available" or "mobile available" checks time out, pass this info down to the loading indicators so we can just gray out the buttons instead of making users think something is still happening.
- [x] Actually zero and increment the `syndicationChecks` counter in the appropriate place, so that timeouts can ever occur. (I think this got lost in some recent revisions, possibly from today.)
- [x] Strengthen the `clearSyndicationChecks()` work by exiting early if the share modal has been closed between requesting and receiving the share URL.

Regressions to look for:

- Not expecting regressions proper because a lot of these races already exist, but be on the lookout for weirdness when you make a bunch of changes, publish, abort publish modal, quickly make more changes, then publish again.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)