### PR TITLE
fix: use react-popover to show previews on library items

### DIFF
--- a/packages/haiku-creator/public/stylesheets/global.css
+++ b/packages/haiku-creator/public/stylesheets/global.css
@@ -184,16 +184,6 @@ button {
   transition: -webkit-transform 0ms ease-in!important;
 }
 
-/* Set the default color for the tip and the body */
-.Popover-body {
-  border-radius: 5px;
-  background-color: rgb(21, 32, 34);
-}
-
-.Popover-tipShape {
-  fill: rgb(21, 32, 34);
-}
-
 /* Basic form resets */
 input,
 label,

--- a/packages/haiku-creator/src/react/components/library/AssetItem.js
+++ b/packages/haiku-creator/src/react/components/library/AssetItem.js
@@ -7,6 +7,7 @@ import { Draggable } from 'react-drag-and-drop'
 import AssetList from './AssetList'
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
 import Palette from 'haiku-ui-common/lib/Palette'
+import Popover from 'react-popover'
 import {
   CollapseChevronRightSVG,
   CollapseChevronDownSVG,
@@ -101,7 +102,7 @@ const STYLES = {
     alignItems: 'center',
     justifyContent: 'center',
     pointerEvents: 'none',
-    transform: 'translateX(-10px)',
+    transform: 'translateY(50%)',
     transition: 'transform 270ms ease',
     shown: {
       opacity: 1,
@@ -284,14 +285,15 @@ class AssetItem extends React.Component {
           onMouseOut={() => {
             this.setState({isHovered: false})
           }}>
-          <img style={STYLES.cardImage} src={`file://${imageSrc}`} />
-          <img
-            style={[
-              STYLES.cardPreview,
-              this.state.isHovered && STYLES.cardPreview.shown,
-              this.state.isDragging && {display: 'none'}
-            ]}
-            src={`file://${imageSrc}`} />
+          <Popover
+            isOpen={this.state.isHovered && !this.state.isDragging}
+            style={STYLES.cardPreview}
+            preferPlace={'right'}
+            body={<img src={`file://${imageSrc}`} style={{width: '170px', height: '170px'}} />}
+            tipSize={0.01}
+          >
+            <img style={STYLES.cardImage} src={`file://${imageSrc}`} />
+          </Popover>
         </span>
       )
     }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of work (include Asana links if any):

- [x] fix floating previews constrained to library pane/clipped by stage https://app.asana.com/0/539750334128224/551384917648541

![2018-02-13 18_25_54](https://user-images.githubusercontent.com/4419992/36174537-5bf74ba8-10eb-11e8-9a85-7ae333de6697.gif)


Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
