### PR TITLE
feat: Add ability to duplicate a project.

### DIFF
--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -188,8 +188,9 @@ class ProjectBrowser extends React.Component {
     const duplicateNameBase = `${this.state.projectsList[projToDuplicateIndex].projectName}Copy`
     let recordedNewProjectName = duplicateNameBase
     let iteration = 1
-    while (this.state.projectsList.find((project) => project.projectName === recordedNewProjectName) !== undefined) {
+    while (this.doesProjectNameExist(recordedNewProjectName) !== undefined) {
       recordedNewProjectName = `${duplicateNameBase}${iteration}`
+      iteration++
     }
     this.setState({
       projToDuplicateIndex,
@@ -268,6 +269,11 @@ class ProjectBrowser extends React.Component {
     })
   }
 
+  doesProjectNameExist (projectName) {
+    const equivalentNameMatcher = new RegExp(`^${projectName}$`, 'i')
+    return this.state.projectsList.find((project) => equivalentNameMatcher.test(project.projectName)) !== undefined
+  }
+
   handleNewProjectInputChange (event) {
     const rawValue = event.target.value || ''
 
@@ -277,8 +283,7 @@ class ProjectBrowser extends React.Component {
       .slice(0, 32) // Keep the overall name length short
 
     // Check for any projects with the exact same name.
-    const equivalentNameMatcher = new RegExp(`^${recordedNewProjectName}$`, 'i')
-    const newProjectError = this.state.projectsList.find((project) => equivalentNameMatcher.test(project.projectName))
+    const newProjectError = this.doesProjectNameExist(recordedNewProjectName)
       ? 'A project with that name already exists'
       : null
 

--- a/packages/haiku-creator/src/react/components/ProjectLoader.js
+++ b/packages/haiku-creator/src/react/components/ProjectLoader.js
@@ -120,7 +120,7 @@ class ProjectLoader extends React.Component {
       <div style={STYLES.fullScreenCenterWrap}>
         <div style={STYLES.contentHolster}>
           <div style={STYLES.reticulator}>
-            {reticulations[this.state.retic]}
+            {reticulations[this.state.retic]}…
           </div>
         </div>
         <div style={STYLES.tip}>

--- a/packages/haiku-creator/src/react/components/ProjectThumbnail.js
+++ b/packages/haiku-creator/src/react/components/ProjectThumbnail.js
@@ -71,16 +71,17 @@ class ProjectThumbnail extends React.Component {
           >
             OPEN
           </span>
-          <span
-            key='delete'
-            onClick={this.props.showDeleteModal}
+          {this.props.projectExistsLocally && !this.props.atProjectMax && <span
+            key='duplicate'
+            onClick={this.props.showDuplicateProjectModal}
             style={[
               DASH_STYLES.menuOption,
+              DASH_STYLES.opt2,
               !this.state.isMenuActive && DASH_STYLES.gone
             ]}
           >
-            DELETE
-          </span>
+            DUPLICATE
+          </span>}
           {this.props.projectExistsLocally && <span
             key='reveal'
             onClick={() => shell.showItemInFolder(this.props.projectPath)}
@@ -92,6 +93,17 @@ class ProjectThumbnail extends React.Component {
           >
             REVEAL IN FINDER
           </span>}
+          <span
+            key='delete'
+            onClick={this.props.showDeleteModal}
+            style={[
+              DASH_STYLES.menuOption,
+              DASH_STYLES.opt2,
+              !this.state.isMenuActive && DASH_STYLES.gone
+            ]}
+          >
+            DELETE
+          </span>
         </div>
         <div style={DASH_STYLES.titleStrip}>
           <span style={DASH_STYLES.title}>

--- a/packages/haiku-creator/src/react/styles/dashShared.js
+++ b/packages/haiku-creator/src/react/styles/dashShared.js
@@ -328,7 +328,9 @@ export const DASH_STYLES = {
     marginBottom: 42
   },
   newProjectError: {
-
+    display: 'block',
+    float: 'left',
+    marginTop: 2
   },
   projToDelete: {
     color: Palette.LIGHT_BLUE,

--- a/packages/haiku-creator/src/react/styles/dashShared.js
+++ b/packages/haiku-creator/src/react/styles/dashShared.js
@@ -330,7 +330,7 @@ export const DASH_STYLES = {
   newProjectError: {
     display: 'block',
     float: 'left',
-    marginTop: 2
+    marginTop: 4
   },
   projToDelete: {
     color: Palette.LIGHT_BLUE,

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -947,6 +947,30 @@ export default class Plumbing extends StateObject {
     })
   }
 
+  duplicateProject (destinationProject, sourceProject, cb) {
+    if (!sourceProject.projectExistsLocally) {
+      logger.info(`[plumbing] source project did not exist during duplicate: ${sourceProject.projectName}`)
+      // Unable to proceed; there is nothing from the source project that we could possibly copy.
+      return cb()
+    }
+
+    if (destinationProject.projectExistsLocally) {
+      // We don't actually need to return early here—but we should warn in logs in case something else bad happens
+      // as a result.
+      logger.warn(`[plumbing] source project existed locally during duplicate: ${destinationProject.projectName}`)
+    }
+
+    // Duplicate project folder content from source to destination.
+    ProjectFolder.duplicateProject(destinationProject, sourceProject, (err) => {
+      // Note: we don't pass errors forward to Creator here. It wouldn't know what to do with it.
+      if (err) {
+        logger.warn(`[plumbing] error during project duplication: ${err}`)
+      }
+
+      cb()
+    })
+  }
+
   deleteProject (name, path, cb) {
     logger.info('[plumbing] deleting project', name)
     const authToken = sdkClient.config.getAuthToken()

--- a/packages/haiku-plumbing/src/ProjectFolder.js
+++ b/packages/haiku-plumbing/src/ProjectFolder.js
@@ -474,3 +474,33 @@ export function semverBumpPackageJson (projectPath, maybeVersionToBumpTo, cb) {
     return cb(exception)
   }
 }
+
+export function duplicateProject (destinationProject, sourceProject, cb) {
+  try {
+    const scenes = fse.readdirSync(path.join(sourceProject.projectPath, 'code'))
+    scenes.forEach((sceneName) => {
+      const destinationScenePath = path.join(destinationProject.projectPath, 'code', sceneName)
+      fse.mkdirpSync(destinationScenePath)
+
+      const bytecode = fse.readFileSync(path.join(sourceProject.projectPath, 'code', sceneName, 'code.js'))
+        .toString()
+        .replace(`${sourceProject.projectName}.sketch`, `${destinationProject.projectName}.sketch`)
+      fse.outputFileSync(path.join(destinationScenePath, 'code.js'), bytecode)
+    })
+
+    const designAssets = fse.readdirSync(path.join(sourceProject.projectPath, 'designs'))
+    designAssets.forEach((designAssetName) => {
+      const destinationDesignAsset = designAssetName.startsWith(`${sourceProject.projectName}.sketch`)
+        ? designAssetName.replace(`${sourceProject.projectName}.sketch`, `${destinationProject.projectName}.sketch`)
+        : designAssetName
+      fse.copySync(
+        path.join(sourceProject.projectPath, 'designs', designAssetName),
+        path.join(destinationProject.projectPath, 'designs', destinationDesignAsset)
+      )
+    })
+
+    cb()
+  } catch (err) {
+    return cb(err)
+  }
+}

--- a/packages/haiku-plumbing/test/plumbing/04_Plumbing.test.js
+++ b/packages/haiku-plumbing/test/plumbing/04_Plumbing.test.js
@@ -4,13 +4,14 @@ const fse = require('haiku-fs-extra')
 const cp = require('child_process')
 const path = require('path')
 const lodash = require('lodash')
+const {randomString} = require('@haiku/core/lib/helpers/StringUtils')
 const TestHelpers = require('./../TestHelpers')
+
 tape('Plumbing', (t) => {
-  t.plan(22)
   TestHelpers.launch((plumbing, teardown) => {
-    const projectName = 'TestProject' + Date.now()
-    const getFolder = () => plumbing.masters[0].folder
-    return async.series([
+    const projectName = 'TestProject' + randomString(9)
+    const duplicateProjectName = `${projectName}Copy`
+    return async.waterfall([
       (cb) => {
         return plumbing.authenticateUser('matthew+matthew@haiku.ai', 'supersecure', (err, resp) => {
           t.error(err, 'no auth err')
@@ -18,7 +19,7 @@ tape('Plumbing', (t) => {
         })
       },
       (cb) => {
-        return plumbing.listProjects((err, projectsList) => {
+        return plumbing.listProjects((err) => {
           t.error(err, 'no err listing initially')
           return cb()
         })
@@ -38,62 +39,115 @@ tape('Plumbing', (t) => {
           t.error(err, 'no err listing after create')
           const foundProj = lodash.find(projectsList, { projectName })
           t.ok(foundProj, 'proj was listed after creation')
-          return cb()
+          return cb(null, foundProj)
         })
       },
-      (cb) => {
+      (project, cb) => {
         // Mimicking what happens in Creator
-        const projectOptions = { skipContentCreation: true, projectName }
-        return plumbing.initializeProject(projectName, projectOptions, 'matthew+matthew@haiku.ai', 'supersecure', cb)
+        const projectOptions = Object.assign(
+          {
+            skipContentCreation: true
+          },
+          project
+        )
+        return plumbing.initializeProject(
+          projectName,
+          projectOptions,
+          'matthew+matthew@haiku.ai',
+          'supersecure',
+          () => cb(null, project)
+        )
       },
-      (cb) => {
-        return plumbing.startProject(projectName, getFolder(), cb)
+      (project, cb) => {
+        return plumbing.startProject(projectName, project.projectPath, () => cb(null, project))
       },
-      (cb) => {
+      (project, cb) => {
         // First save should push it all
         const saveOptions = {} // ?
-        return plumbing.saveProject(getFolder(), projectName, 'matthew+matthew@haiku.ai', 'supersecure', saveOptions, (err, shareInfo) => {
+        return plumbing.saveProject(project.projectPath, projectName, 'matthew+matthew@haiku.ai', 'supersecure', saveOptions, (err, shareInfo) => {
           t.error(err, 'no err saving')
           t.ok(shareInfo, 'share info present')
-          const localsha = cp.execSync(`git rev-parse --verify HEAD`, { cwd: getFolder() }).toString().trim()
+          const localsha = cp.execSync(`git rev-parse --verify HEAD`, { cwd: project.projectPath }).toString().trim()
           t.equal(localsha, shareInfo && shareInfo.sha, 'local sha is share info sha')
           t.ok(shareInfo && shareInfo.shareLink, 'share link present')
           t.ok(shareInfo && shareInfo.projectUid, 'share project uid present')
-          const pkg = fse.readJsonSync(path.join(getFolder(), 'package.json'))
+          const pkg = fse.readJsonSync(path.join(project.projectPath, 'package.json'))
           t.equal(pkg.version, '0.0.1', 'semver is 0.0.1')
           initialShareInfo = shareInfo
-          return cb()
+          return cb(null, project)
         })
       },
-      (cb) => {
+      (project, cb) => {
         // Second save should return right away with previous share link
         const saveOptions = {} // ?
-        return plumbing.saveProject(getFolder(), projectName, 'matthew+matthew@haiku.ai', 'supersecure', saveOptions, (err, shareInfo) => {
+        return plumbing.saveProject(project.projectPath, projectName, 'matthew+matthew@haiku.ai', 'supersecure', saveOptions, (err, shareInfo) => {
           t.error(err, 'no err saving again')
           t.equal(initialShareInfo && initialShareInfo.sha, shareInfo && shareInfo.sha, 'new sha same as initial save because no change')
-          return cb()
+          return cb(null, project)
         })
       },
-      (cb) => {
+      (project, cb) => {
         // Third save, with a change, should push it all
-        fse.outputFileSync(path.join(getFolder(), 'test.txt'), '123')
-        return plumbing.saveProject(getFolder(), projectName, 'matthew+matthew@haiku.ai', 'supersecure', {}, (err, shareInfo) => {
+        fse.outputFileSync(path.join(project.projectPath, 'test.txt'), '123')
+        return plumbing.saveProject(project.projectPath, projectName, 'matthew+matthew@haiku.ai', 'supersecure', {}, (err, shareInfo) => {
           t.error(err, 'no err on save after file addition')
           t.ok(shareInfo, 'new share info present')
           t.ok(shareInfo && shareInfo.sha, 'share info sha present')
-          const localsha = cp.execSync(`git rev-parse --verify HEAD`, { cwd: getFolder() }).toString().trim()
+          const localsha = cp.execSync(`git rev-parse --verify HEAD`, { cwd: project.projectPath }).toString().trim()
           t.equal(localsha, shareInfo && shareInfo.sha, 'local sha matches')
-          const pkgjson = fse.readJsonSync(path.join(getFolder(), 'package.json'))
+          const pkgjson = fse.readJsonSync(path.join(project.projectPath, 'package.json'))
           t.equal(pkgjson.version, '0.0.2', 'version was bumped')
-          return cb()
+          return cb(null, project)
         })
       },
-      (cb) => {
+      (project, cb) => {
+        // Make a duplicate and verify it has the expected contents.
+        return plumbing.createProject(duplicateProjectName, (err, duplicateProject) => {
+          t.error(err, 'no err creating')
+          if (!duplicateProject) {
+            throw new Error('the test account has reached the max number projects')
+          }
+          t.equal(duplicateProject.projectName, duplicateProjectName, 'proj obj has good format')
+          project.projectExistsLocally = true
+          plumbing.duplicateProject(duplicateProject, project, () => {
+            t.equal(
+              fse.readFileSync(path.join(project.projectPath, 'code', 'main', 'code.js')).toString(),
+              fse.readFileSync(path.join(duplicateProject.projectPath, 'code', 'main', 'code.js')).toString(),
+              'duplicated project has the same bytecode'
+            )
+            t.ok(
+              fse.existsSync(path.join(duplicateProject.projectPath, 'designs', `${duplicateProjectName}.sketch`)),
+              'duplicated project has renamed default Sketch file'
+            )
+            return cb(null, project, duplicateProject)
+          })
+        })
+      },
+      (project, duplicateProject, cb) => {
         // Clean up after ourselves
-        return plumbing.deleteProject(projectName, cb)
+        return plumbing.deleteProject(
+          projectName,
+          project.projectPath,
+          () => plumbing.deleteProject(
+            // Clean up our duplicate too!
+            duplicateProjectName,
+            duplicateProject.projectPath,
+            () => cb(null, project)
+          )
+        )
+      },
+      (project, cb) => {
+        // We should have backed up the project contents when we deleted them locally.
+        t.ok(fse.existsSync(`${project.projectPath}.bak`), 'a .bak-suffixed backup copy was made')
+        return cb(null, project)
+      },
+      (project, cb) => {
+        // We should have backed up the project contents when we deleted them locally.
+        plumbing.teardownMaster(project.projectPath, () => cb(null, project))
       }
     ], (err) => {
       teardown()
+      t.end()
     })
   })
 })


### PR DESCRIPTION
OK to merge.

Medium review.

Purpose of changes:

- Adds ability to duplicate projects inside the app ([Asana task](https://app.asana.com/0/539750334128224/558122386005711/f)).

Summary of work (include Asana links if any):

- [x] Fork the existing "new project" modal to support creating an automatically-named new project. Try chain: `OriginalNameCopy` -> `OriginalName1` -> `OriginalName2` -> …
- [x] Change a common reason project creation fails (duplicate name) to notify the user before they start to create the project, not after (https://cl.ly/1k0w3P3c323n). @taylorpoe, please check design!
- [x] Implement naive project duplication in Plumbing with these rules: copy bytecode and designs, but change the filename of `<originalProjectName>.sketch`, as well as any pointers to it in bytecode, to resolve to `<newProjectName>.sketch`. This should preempt likely issues of confusion with users who have that Sketch file open at the time of duplication, although isn't going to do anything for other Sketch files with a non-default name. I thought this was a good compromise between doing nothing and a holistic solution, which might be overkill. Thoughts/concerns about the resultant UX are welcome!
- [x] Get one of the Plumbing tests to pass (but not its leaked handles 😢)….

Regressions to look for:

- Some light refactoring of project creation was performed, so in addition to testing the duplication functionality, you should also spend some time confirming everything is normal with project creation.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [x] Wrote an automated test covering new functionality