### PR TITLE
fix: allow devtools to be toggled without having a project open

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -161,6 +161,8 @@ export default class Creator extends React.Component {
       combokeys.bind('command+option+i', lodash.debounce(() => {
         if (this.state.projectModel) {
           this.state.projectModel.toggleDevTools()
+        } else {
+          this.toggleDevTools()
         }
       }, 500, { leading: true }))
     }


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

This is something that has been bothering me for a while and I finally decided to do something about it 👐 . It comes really helpful to be able to open the devtools without having a project open when developing screens like the login page or the dashboard

Summary of work (include Asana links if any):

- [x] Allow devtools to be toggled without having a project open

Completed checkin tasks:

- [ ] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [ ] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
