### PR TITLE
V0 proxy support

### DIFF
--- a/_config.js.handlebars
+++ b/_config.js.handlebars
@@ -15,6 +15,7 @@ var env = {
   HAIKU_RELEASE_ENVIRONMENT: '{{appenv}}', // just a tag, really - use to push to a url that won't trigger an update to users on the mainline
   HAIKU_RELEASE_BRANCH: '{{branch}}', // just a tag, really
   HAIKU_PLUMBING_VERSION: '{{branch}}', // plumbing branch
+  HAIKU_PLUMBING_HOST: 'loopback.haiku.ai',
   HAIKU_SKIP_AUTOUPDATE: null, // '1' to skip the auto-update hook
   HAIKU_AUTOUPDATE_SERVER: 'http://squirrel.haiku.ai:3002',
   NO_REMOTE_DEBUG: '1', // prevent debugger from crashing the app

--- a/packages/haiku-common/src/proxies/index.ts
+++ b/packages/haiku-common/src/proxies/index.ts
@@ -11,5 +11,5 @@ export const enum ProxyType {
  * Canonical method to detect if a proxy string provided by electron
  */
 export const isProxied = (proxyString: string) => {
-  return proxyString !== ProxyType.Direct
+  return proxyString !== ProxyType.Direct;
 };

--- a/packages/haiku-common/src/proxies/index.ts
+++ b/packages/haiku-common/src/proxies/index.ts
@@ -11,5 +11,5 @@ export const enum ProxyType {
  * Canonical method to detect if a proxy string provided by electron
  */
 export const isProxied = (proxyString: string) => {
-  return proxyString === ProxyType.Direct
+  return proxyString !== ProxyType.Direct
 };

--- a/packages/haiku-common/src/proxies/index.ts
+++ b/packages/haiku-common/src/proxies/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Proxy Type.
+ * @enum {string}
+ */
+export const enum ProxyType {
+  Proxyed = 'PROXY',
+  Direct = 'DIRECT',
+}
+
+/**
+ * Canonical method to detect if a proxy string provided by electron
+ */
+export const isProxied = (proxyString: string) => {
+  return proxyString === ProxyType.Direct
+};

--- a/packages/haiku-common/src/proxies/index.ts
+++ b/packages/haiku-common/src/proxies/index.ts
@@ -3,7 +3,7 @@
  * @enum {string}
  */
 export const enum ProxyType {
-  Proxyed = 'PROXY',
+  Proxied = 'PROXY',
   Direct = 'DIRECT',
 }
 

--- a/packages/haiku-creator/src/dom.js
+++ b/packages/haiku-creator/src/dom.js
@@ -38,7 +38,6 @@ export default function dom (modus, haiku) {
       )
     : new MockWebsocket()
 
-
   websocket.on('close', () => {
     const currentWindow = remote.getCurrentWindow()
     if (currentWindow) {

--- a/packages/haiku-creator/src/dom.js
+++ b/packages/haiku-creator/src/dom.js
@@ -27,9 +27,17 @@ export default function dom (modus, haiku) {
 
   window.addEventListener('resize', lodash.debounce(resizeHandler, 64))
 
-  const websocket = (haiku.plumbing)
-    ? new Websocket(_fixPlumbingUrl(haiku.plumbing.url), haiku.folder, 'commander', 'creator', null, haiku.socket.token)
+  const websocket = haiku.plumbing && !haiku.proxy.active
+    ? new Websocket(
+        _fixPlumbingUrl(haiku.plumbing.url),
+        haiku.folder,
+        'commander',
+        'creator',
+        null,
+        haiku.socket.token
+      )
     : new MockWebsocket()
+
 
   websocket.on('close', () => {
     const currentWindow = remote.getCurrentWindow()

--- a/packages/haiku-creator/src/electron.js
+++ b/packages/haiku-creator/src/electron.js
@@ -47,7 +47,7 @@ if (!haiku.plumbing.url) {
     throw new Error(`Oops! You must define a HAIKU_PLUMBING_PORT env var!`)
   }
 
-  haiku.plumbing.url = `http://${global.process.env.HAIKU_PLUMBING_HOST || '0.0.0.0'}:${global.process.env.HAIKU_PLUMBING_PORT}/?token=${process.env.HAIKU_WS_SECURITY_TOKEN}`
+  haiku.plumbing.url = `http://${global.process.env.HAIKU_PLUMBING_HOST || 'loopback.haiku.ai'}:${global.process.env.HAIKU_PLUMBING_PORT}/?token=${process.env.HAIKU_WS_SECURITY_TOKEN}`
 }
 
 function different (a, b) {

--- a/packages/haiku-creator/src/electron.js
+++ b/packages/haiku-creator/src/electron.js
@@ -48,7 +48,7 @@ if (!haiku.plumbing.url) {
     throw new Error(`Oops! You must define a HAIKU_PLUMBING_PORT env var!`)
   }
 
-  haiku.plumbing.url = `http://${global.process.env.HAIKU_PLUMBING_HOST || 'loopback.haiku.ai'}:${global.process.env.HAIKU_PLUMBING_PORT}/?token=${process.env.HAIKU_WS_SECURITY_TOKEN}`
+  haiku.plumbing.url = `http://${global.process.env.HAIKU_PLUMBING_HOST || '0.0.0.0'}:${global.process.env.HAIKU_PLUMBING_PORT}/?token=${process.env.HAIKU_WS_SECURITY_TOKEN}`
 }
 
 function different (a, b) {

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -23,6 +23,7 @@ import Tour from './components/Tour/Tour'
 import AutoUpdater from './components/AutoUpdater'
 import ProjectLoader from './components/ProjectLoader'
 import OfflineModePage from './components/OfflineModePage'
+import ProxyHelpScreen from './components/ProxyHelpScreen'
 import EnvoyClient from 'haiku-sdk-creator/lib/envoy/EnvoyClient'
 import { EXPORTER_CHANNEL, ExporterFormat } from 'haiku-sdk-creator/lib/exporter'
 // Note that `User` is imported below for type discovery
@@ -947,6 +948,10 @@ export default class Creator extends React.Component {
   }
 
   renderStartupDefaultScreen () {
+    if (this.props.haiku.proxy.active) {
+      return <ProxyHelpScreen />
+    }
+
     return (
       <div style={{ position: 'absolute', width: '100%', height: '100%' }}>
         <ReactCSSTransitionGroup

--- a/packages/haiku-creator/src/react/components/ProxyHelpScreen.js
+++ b/packages/haiku-creator/src/react/components/ProxyHelpScreen.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Palette from 'haiku-ui-common/lib/Palette'
-import {ModalWrapper, ModalHeader, ModalFooter} from 'haiku-ui-common/lib/react/Modal'
+import {ModalWrapper, ModalHeader} from 'haiku-ui-common/lib/react/Modal'
 
 const STYLES = {
   wrapper: {
@@ -12,14 +12,15 @@ const STYLES = {
   },
   modalWrapper: {
     maxWidth: '600px',
-    transform: 'translateY(60%)'
+    top: '50%',
+    transform: 'translateY(-50%)'
   },
   modalBody: {
-    padding: '20px',
+    padding: '20px'
   },
   listItem: {
-    marginBottom: '8px',
-  },
+    marginBottom: '8px'
+  }
 }
 
 const HELP_STEPS = [
@@ -33,14 +34,14 @@ const HELP_STEPS = [
 ]
 
 class ProxyHelpScreen extends React.PureComponent {
-  render() {
+  render () {
     return (
       <div style={STYLES.wrapper}>
-      <ModalWrapper style={STYLES.modalWrapper}>
-        <ModalHeader>
-          <h2>Please adjust your proxy or firewall settings</h2>
-        </ModalHeader>
-        <div style={STYLES.modalBody}>
+        <ModalWrapper style={STYLES.modalWrapper}>
+          <ModalHeader>
+            <h2>Please adjust your proxy or firewall settings</h2>
+          </ModalHeader>
+          <div style={STYLES.modalBody}>
           Proxies and firewalls can sometimes interfere with your connection to
           Haiku. If you’re struggling to connect, here are a few steps that can resolve the problem:
           <ul>
@@ -56,7 +57,7 @@ class ProxyHelpScreen extends React.PureComponent {
           confusing: please contact your trusted IT professional for additional
           assistance.
         </div>
-      </ModalWrapper>
+        </ModalWrapper>
       </div>
     )
   }

--- a/packages/haiku-creator/src/react/components/ProxyHelpScreen.js
+++ b/packages/haiku-creator/src/react/components/ProxyHelpScreen.js
@@ -1,0 +1,87 @@
+import React from 'react'
+import Palette from 'haiku-ui-common/lib/Palette'
+import {ModalWrapper, ModalHeader, ModalFooter} from 'haiku-ui-common/lib/react/Modal'
+
+const STYLES = {
+  wrapper: {
+    fontSize: '14px',
+    width: '100%',
+    height: '100%',
+    position: 'absolute',
+    backgroundColor: Palette.GRAY
+  },
+  modalWrapper: {
+    maxWidth: '600px',
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translateY(-50%) translateX(-50%)'
+  },
+  modalBody: {
+    padding: '20px',
+  },
+  list: {
+    // listStyle: 'none',
+    // paddingLeft: 0,
+  },
+  listItem: {
+    marginBottom: '8px',
+  },
+  number: {
+    verticalAlign: 'middle',
+    backgroundColor: Palette.LIGHT_PINK,
+    width: '20px',
+    textAlign: 'center',
+    height: '20px',
+    verticalAlign: 'top',
+    borderRadius: '13px',
+    backgroundClip: 'padding-box',
+    color: Palette.SUNSTONE,
+    display: 'inline-block',
+    fontWeight: '700',
+    marginRight: '10px',
+    fontSize: '14px'
+  }
+}
+
+const HELP_STEPS = [
+  `Whitelist (allow) *.haiku.ai`,
+  `Check if your proxy is running SSL decryption. If it is, the proxy
+  must either support WebSockets, or you’ll need to exempt
+  *.haiku.ai from SSL decryption.`,
+  `If you’re running Haiku on a Mac, head to your computer’s System
+  Preferences, then Network, Advanced, and under Proxies, check that
+  Auto Proxy Discovery is disabled.`
+]
+
+class ProxyHelpScreen extends React.PureComponent {
+  render() {
+    return (
+      <div style={STYLES.wrapper}>
+      <ModalWrapper style={STYLES.modalWrapper}>
+        <ModalHeader>
+          <h2>Please adjust your proxy or firewall settings</h2>
+        </ModalHeader>
+        <div style={STYLES.modalBody}>
+          Proxies and firewalls can sometimes interfere with your connection to
+          Haiku. If you’re struggling to connect, here are a few steps that can resolve the problem:
+          <ul style={STYLES.list}>
+            {HELP_STEPS.map((step, idx) => {
+              return (
+                <li key={idx} style={STYLES.listItem}>
+                  {step}
+                </li>
+              )
+            })}
+          </ul>
+          If you did not configure your network security, this might sound a bit
+          confusing: please contact your trusted IT professional for additional
+          assistance.
+        </div>
+      </ModalWrapper>
+      </div>
+    )
+  }
+}
+
+export default ProxyHelpScreen

--- a/packages/haiku-creator/src/react/components/ProxyHelpScreen.js
+++ b/packages/haiku-creator/src/react/components/ProxyHelpScreen.js
@@ -20,28 +20,9 @@ const STYLES = {
   modalBody: {
     padding: '20px',
   },
-  list: {
-    // listStyle: 'none',
-    // paddingLeft: 0,
-  },
   listItem: {
     marginBottom: '8px',
   },
-  number: {
-    verticalAlign: 'middle',
-    backgroundColor: Palette.LIGHT_PINK,
-    width: '20px',
-    textAlign: 'center',
-    height: '20px',
-    verticalAlign: 'top',
-    borderRadius: '13px',
-    backgroundClip: 'padding-box',
-    color: Palette.SUNSTONE,
-    display: 'inline-block',
-    fontWeight: '700',
-    marginRight: '10px',
-    fontSize: '14px'
-  }
 }
 
 const HELP_STEPS = [
@@ -65,7 +46,7 @@ class ProxyHelpScreen extends React.PureComponent {
         <div style={STYLES.modalBody}>
           Proxies and firewalls can sometimes interfere with your connection to
           Haiku. If you’re struggling to connect, here are a few steps that can resolve the problem:
-          <ul style={STYLES.list}>
+          <ul>
             {HELP_STEPS.map((step, idx) => {
               return (
                 <li key={idx} style={STYLES.listItem}>

--- a/packages/haiku-creator/src/react/components/ProxyHelpScreen.js
+++ b/packages/haiku-creator/src/react/components/ProxyHelpScreen.js
@@ -12,10 +12,7 @@ const STYLES = {
   },
   modalWrapper: {
     maxWidth: '600px',
-    position: 'absolute',
-    top: '50%',
-    left: '50%',
-    transform: 'translateY(-50%) translateX(-50%)'
+    transform: 'translateY(60%)'
   },
   modalBody: {
     padding: '20px',

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -109,8 +109,8 @@ const WAIT_DELAY = 10 * 1000
 
 const HAIKU_DEFAULTS = {
   socket: {
-    port: process.env.HAIKU_CONTROL_PORT,
-    host: process.env.HAIKU_CONTROL_HOST || '0.0.0.0'
+    port: process.env.HAIKU_PLUMBING_PORT,
+    host: process.env.HAIKU_PLUMBING_HOST || '0.0.0.0'
   }
 }
 

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -110,7 +110,7 @@ const WAIT_DELAY = 10 * 1000
 const HAIKU_DEFAULTS = {
   socket: {
     port: process.env.HAIKU_CONTROL_PORT,
-    host: process.env.HAIKU_CONTROL_HOST || '0.0.0.0'
+    host: process.env.HAIKU_CONTROL_HOST || 'loopback.haiku.ai'
   }
 }
 
@@ -1290,7 +1290,7 @@ function getPort (host, cb) {
 }
 
 Plumbing.prototype.launchControlServer = function launchControlServer (socketInfo, cb) {
-  const host = (socketInfo && socketInfo.host) || '0.0.0.0'
+  const host = (socketInfo && socketInfo.host) || 'loopback.haiku.ai'
 
   if (socketInfo && socketInfo.port) {
     logger.info(`[plumbing] plumbing websocket server listening on specified port ${socketInfo.port}...`)

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -110,7 +110,7 @@ const WAIT_DELAY = 10 * 1000
 const HAIKU_DEFAULTS = {
   socket: {
     port: process.env.HAIKU_CONTROL_PORT,
-    host: process.env.HAIKU_CONTROL_HOST || 'loopback.haiku.ai'
+    host: process.env.HAIKU_CONTROL_HOST || '0.0.0.0'
   }
 }
 
@@ -1290,7 +1290,7 @@ function getPort (host, cb) {
 }
 
 Plumbing.prototype.launchControlServer = function launchControlServer (socketInfo, cb) {
-  const host = (socketInfo && socketInfo.host) || 'loopback.haiku.ai'
+  const host = (socketInfo && socketInfo.host) || '0.0.0.0'
 
   if (socketInfo && socketInfo.port) {
     logger.info(`[plumbing] plumbing websocket server listening on specified port ${socketInfo.port}...`)

--- a/packages/haiku-sdk-creator/src/envoy/index.ts
+++ b/packages/haiku-sdk-creator/src/envoy/index.ts
@@ -32,7 +32,7 @@ export interface EnvoyOptions {
 }
 
 export const DEFAULT_ENVOY_OPTIONS: EnvoyOptions = {
-  host: '0.0.0.0',
+  host: 'loopback.haiku.ai',
   logger: console,
   mock: false, // In mock mode, clients don't try to connect to the server
   path: '/',

--- a/packages/haiku-sdk-creator/src/envoy/index.ts
+++ b/packages/haiku-sdk-creator/src/envoy/index.ts
@@ -32,7 +32,7 @@ export interface EnvoyOptions {
 }
 
 export const DEFAULT_ENVOY_OPTIONS: EnvoyOptions = {
-  host: '0.0.0.0',
+  host: global.process.env.HAIKU_PLUMBING_HOST || '0.0.0.0',
   logger: console,
   mock: false, // In mock mode, clients don't try to connect to the server
   path: '/',

--- a/packages/haiku-sdk-creator/src/envoy/index.ts
+++ b/packages/haiku-sdk-creator/src/envoy/index.ts
@@ -32,7 +32,7 @@ export interface EnvoyOptions {
 }
 
 export const DEFAULT_ENVOY_OPTIONS: EnvoyOptions = {
-  host: 'loopback.haiku.ai',
+  host: '0.0.0.0',
   logger: console,
   mock: false, // In mock mode, clients don't try to connect to the server
   path: '/',

--- a/packages/haiku-sdk-creator/src/utils/findOpenPort.ts
+++ b/packages/haiku-sdk-creator/src/utils/findOpenPort.ts
@@ -1,7 +1,7 @@
 import * as net from 'net';
 
 const DEFAULT_PORT_SEARCH_START = 45032;
-const DEFAULT_HOST = '0.0.0.0';
+const DEFAULT_HOST = global.process.env.HAIKU_PLUMBING_HOST || '0.0.0.0';
 const ADDRESS_IN_USE_CODE = 'EADDRINUSE';
 
 /**

--- a/packages/haiku-sdk-creator/src/utils/findOpenPort.ts
+++ b/packages/haiku-sdk-creator/src/utils/findOpenPort.ts
@@ -1,7 +1,7 @@
 import * as net from 'net';
 
 const DEFAULT_PORT_SEARCH_START = 45032;
-const DEFAULT_HOST = 'loopback.haiku.ai';
+const DEFAULT_HOST = '0.0.0.0';
 const ADDRESS_IN_USE_CODE = 'EADDRINUSE';
 
 /**

--- a/packages/haiku-sdk-creator/src/utils/findOpenPort.ts
+++ b/packages/haiku-sdk-creator/src/utils/findOpenPort.ts
@@ -1,7 +1,7 @@
 import * as net from 'net';
 
 const DEFAULT_PORT_SEARCH_START = 45032;
-const DEFAULT_HOST = '0.0.0.0';
+const DEFAULT_HOST = 'loopback.haiku.ai';
 const ADDRESS_IN_USE_CODE = 'EADDRINUSE';
 
 /**

--- a/packages/haiku-ui-common/src/react/Modal/ModalWrapper.tsx
+++ b/packages/haiku-ui-common/src/react/Modal/ModalWrapper.tsx
@@ -3,6 +3,7 @@ import Palette from './../../Palette';
 
 const STYLES = {
   backgroundColor: Palette.COAL,
+  boxShadow: 'rgba(21, 32, 34, 0.9) 0px 12px 60px 0px',
   borderRadius: '6px',
   zIndex: 9001,
   cursor: 'auto',

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -178,7 +178,7 @@ function setup () {
   global.process.env.HAIKU_AUTOUPDATE_SERVER = 'http://localhost:3002'
 
   if (inputs.devChoice === 'everything') {
-    global.process.env.HAIKU_PLUMBING_URL = 'http://0.0.0.0:1024'
+    global.process.env.HAIKU_PLUMBING_URL = 'http://loopback.haiku.ai:1024'
     if (inputs.folderChoice === 'blank') {
       fse.removeSync(blankProject)
       fse.mkdirpSync(blankProject)

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -178,7 +178,7 @@ function setup () {
   global.process.env.HAIKU_AUTOUPDATE_SERVER = 'http://localhost:3002'
 
   if (inputs.devChoice === 'everything') {
-    global.process.env.HAIKU_PLUMBING_URL = 'http://loopback.haiku.ai:1024'
+    global.process.env.HAIKU_PLUMBING_URL = 'http://0.0.0.0:1024'
     if (inputs.folderChoice === 'blank') {
       fse.removeSync(blankProject)
       fse.mkdirpSync(blankProject)


### PR DESCRIPTION
OK to merge.

Medium review.


Summary of work (include Asana links if any):

- [x] Detect if the user is using proxies, and if so display a message instead of crashing the app: https://app.asana.com/0/539750334128224/548822693280685
- [x] Use `loopback.haiku.ai` as our new host for websocket communications

Regressions to look for:

- Should we expect any kind of regression due to our host change?

Notes for reviewers:

If you want to emulate the crash / test this, you will need to configure your network to use a proxy, you can either fetch a free proxy from the internet or set up your local proxy. I have been using [squidman](http://squidman.net/squidman/) for the latter with great success.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [x] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
