### PR TITLE
tweak: switch to grown-up squirrel URL

### DIFF
--- a/_config.js.handlebars
+++ b/_config.js.handlebars
@@ -16,7 +16,7 @@ var env = {
   HAIKU_RELEASE_BRANCH: '{{branch}}', // just a tag, really
   HAIKU_PLUMBING_VERSION: '{{branch}}', // plumbing branch
   HAIKU_SKIP_AUTOUPDATE: null, // '1' to skip the auto-update hook
-  HAIKU_AUTOUPDATE_SERVER: 'http://squirrel.haiku.ai:3002',
+  HAIKU_AUTOUPDATE_SERVER: 'https://squirrel.haiku.ai',
   NO_REMOTE_DEBUG: '1', // prevent debugger from crashing the app
 }
 


### PR DESCRIPTION
OK to merge.

Review so short I can't believe I PR'ed this.

Purpose of changes:

- Switch to load-balanced, secure squirrel domain for autoupdate check.

Summary of work (include Asana links if any):

- [x] Change URL from HTTP on port 3002 to HTTPs on port 443.

Regressions to look for:

- None.