### PR TITLE
 Cosmetic Tweaks to Publish and Actions Modals

### DIFF
--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/EditorActions.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/EditorActions.js
@@ -31,7 +31,7 @@ class EditorActions extends React.PureComponent {
           style={{...STYLES.button, ...STYLES.doneButton}}
           title={this.props.title}
         >
-          Done
+          Save
         </button>
       </div>
     )

--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/Snippets.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/Snippets.js
@@ -23,8 +23,9 @@ const STYLES = {
     height: '18px',
     textAlign: 'center',
     cursor: 'pointer',
-    fontSize: '20px',
-    lineHeight: '18px'
+    fontSize: '18px',
+    lineHeight: '18px',
+    paddingLeft: '1px',
   }
 }
 

--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
@@ -23,6 +23,7 @@ const STYLES = {
     height: '255px',
     width: '100%',
     paddingRight: '18px',
+    paddingLeft: '18px',
     paddingTop: '23px'
   }
 }

--- a/packages/haiku-ui-common/src/LoadingTopBar.tsx
+++ b/packages/haiku-ui-common/src/LoadingTopBar.tsx
@@ -8,7 +8,7 @@ const STYLES = {
     top: '0',
     left: '0',
     height: '3px',
-    backgroundColor: Palette.PINK,
+    backgroundColor: Palette.LIGHT_PINK,
   },
 };
 

--- a/packages/haiku-ui-common/src/react/ShareModal/EmbedCategory.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/EmbedCategory.tsx
@@ -16,6 +16,7 @@ const STYLES = {
   categoryTitle: {
     fontSize: '16px',
     textTransform: 'uppercase',
+    marginBottom: 6
   },
 };
 

--- a/packages/haiku-ui-common/src/react/ShareModal/EmbedList.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/EmbedList.tsx
@@ -15,21 +15,23 @@ const STYLES = {
     textTransform: 'uppercase',
     fontSize: '14px',
     marginBottom: '0',
-  },
+    fontWeight: 400
+  } as React.CSSProperties,
   circle: {
     display: 'inline-block',
     border: '1px solid currentColor',
     borderRadius: '50%',
-    width: '1.3em',
-    height: '1.3em',
+    width: '1.1em',
+    height: '1.2em',
     verticalAlign: 'middle',
     marginLeft: '5px',
     color: Palette.DARK_ROCK,
     fontSize: '0.7em',
     cursor: 'pointer',
     textAlign: 'center',
-    lineHeight: '1.3em',
-  },
+    lineHeight: '1.2em',
+    marginTop: '-2px',
+  } as React.CSSProperties,
 };
 
 export class EmbedList extends React.PureComponent {

--- a/packages/haiku-ui-common/src/react/ShareModal/EmbedOption.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/EmbedOption.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as assign from 'lodash.assign';
 import Palette from '../../Palette';
 import {LoadingTopBar} from '../../LoadingTopBar';
-import {Tooltip} from '../Tooltip';
+import {TooltipBasic} from '../TooltipBasic';
 import {SHARED_STYLES} from '../../SharedStyles';
 import {ShareCategory} from './ShareModalOptions';
 
@@ -17,7 +17,7 @@ const STYLES = {
     disabled: {
       backgroundColor: 'transparent',
       color: Palette.BLACK,
-      cursor: 'not-allowed',
+      cursor: 'auto',
       border: `1px solid ${Palette.DARKEST_COAL}`,
     },
     loading: {
@@ -48,6 +48,7 @@ export class EmbedOption extends React.PureComponent {
     speed: '2s',
     done: false,
     abandoned: false,
+    showTooltip: false
   };
 
   get tooltipText() {
@@ -144,33 +145,39 @@ export class EmbedOption extends React.PureComponent {
     const effectivelyDisabled = disabled || this.state.abandoned;
 
     return (
-      <li>
-        <Tooltip content={this.tooltipText} place="above">
-          <button
-            style={assign(
-              {},
-              {
-                ...SHARED_STYLES.btn,
-                ...STYLES.entry,
-                ...(!this.state.done && STYLES.entry.loading),
-                ...(effectivelyDisabled && STYLES.entry.disabled),
-              },
-            )}
-            disabled={effectivelyDisabled || !this.state.done}
-            onClick={() => {
-              onClick({entry, template});
-            }}
-          >
-            {!effectivelyDisabled && (
-              <LoadingTopBar
-                progress={this.state.progress}
-                speed={this.state.speed}
-                done={this.state.done}
-              />
-            )}
-            {entry}
-          </button>
-        </Tooltip>
+      <li style={{position: 'relative'}}>
+        <button
+          style={assign(
+            {},
+            {
+              ...SHARED_STYLES.btn,
+              ...STYLES.entry,
+              ...(!this.state.done && STYLES.entry.loading),
+              ...(effectivelyDisabled && STYLES.entry.disabled),
+            },
+          )}
+          disabled={!this.state.done}
+          onMouseOver={() => {
+            if (effectivelyDisabled) this.setState({showTooltip: true})
+          }}onMouseOut={() => {
+            if (effectivelyDisabled) this.setState({showTooltip: false})
+          }}
+          onClick={() => {
+            if (!effectivelyDisabled) onClick({entry, template});
+          }}
+        >
+          {!effectivelyDisabled && (
+            <LoadingTopBar
+              progress={this.state.progress}
+              speed={this.state.speed}
+              done={this.state.done}
+            />
+          )}
+          {entry}
+        </button>
+        {this.state.showTooltip &&
+          <TooltipBasic>{this.tooltipText}</TooltipBasic>
+        }
       </li>
     );
   }

--- a/packages/haiku-ui-common/src/react/ShareModal/EmbedOption.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/EmbedOption.tsx
@@ -17,11 +17,12 @@ const STYLES = {
     disabled: {
       backgroundColor: 'transparent',
       color: Palette.BLACK,
+      cursor: 'not-allowed',
       border: `1px solid ${Palette.DARKEST_COAL}`,
     },
     loading: {
       opacity: 0.7,
-      cursor: 'not-allowed',
+      cursor: 'wait',
     },
   },
 };
@@ -151,8 +152,8 @@ export class EmbedOption extends React.PureComponent {
               {
                 ...SHARED_STYLES.btn,
                 ...STYLES.entry,
-                ...(effectivelyDisabled && STYLES.entry.disabled),
                 ...(!this.state.done && STYLES.entry.loading),
+                ...(effectivelyDisabled && STYLES.entry.disabled),
               },
             )}
             disabled={effectivelyDisabled || !this.state.done}

--- a/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
@@ -18,6 +18,8 @@ const STYLES = {
     fontSize: '10px',
     margin: '0',
     fontStyle: 'italic',
+    lineHeight: '1.2em',
+    paddingRight: 33,
   } as React.CSSProperties,
   label: {
     textTransform: 'uppercase',

--- a/packages/haiku-ui-common/src/react/ShareModal/ShareModalOptions.ts
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareModalOptions.ts
@@ -18,13 +18,13 @@ export const SHARE_OPTIONS = {
       disabled: false,
       template: 'VueHaiku',
     },
-    Angular: {
-      disabled: true,
-      template: '',
-    },
     'HTML + CDN': {
       disabled: false,
       template: 'Embed',
+    },
+    Angular: {
+      disabled: true,
+      template: '',
     },
   },
   [ShareCategory.Mobile]: {

--- a/packages/haiku-ui-common/src/react/ShareModal/ShareModalOptions.ts
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareModalOptions.ts
@@ -10,6 +10,10 @@ export const SHARE_OPTIONS = {
       disabled: false,
       template: 'VanillaJS',
     },
+    'HTML + CDN': {
+      disabled: false,
+      template: 'Embed',
+    },
     React: {
       disabled: false,
       template: 'ReactHaiku',
@@ -17,10 +21,6 @@ export const SHARE_OPTIONS = {
     Vue: {
       disabled: false,
       template: 'VueHaiku',
-    },
-    'HTML + CDN': {
-      disabled: false,
-      template: 'Embed',
     },
     Angular: {
       disabled: true,

--- a/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/PublishStyles.ts
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/PublishStyles.ts
@@ -51,6 +51,7 @@ export const PUBLISH_SHARED = {
   inlineLink: {
     color: Color(Palette.ROCK).fade(0.2),
     fontWeight: 'bold',
+    cursor: 'pointer',
     textDecoration: 'underline',
     ':hover': {
       color: Color(Palette.ROCK).fade(0.3),

--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -10,7 +10,11 @@ const STYLES = {
   wrapper: {
     width: 500,
     overflow: 'hidden',
-  },
+    left: 'calc(50% + 150px)',
+    transform: 'translateX(-50%)',
+    top: 110,
+    margin: 0
+  }
 };
 
 export class ShareModal extends React.Component {

--- a/packages/haiku-ui-common/src/react/TooltipBasic.tsx
+++ b/packages/haiku-ui-common/src/react/TooltipBasic.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import Palette from '../Palette';
+
+const STYLES = {
+  tooltip: {
+    position: 'absolute',
+    bottom: '-17px',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    borderRadius: '3px',
+    width: '100%',
+    textAlign: 'center',
+    backgroundColor: Palette.DARKEST_COAL,
+    boxShadow: '0 2px 7px 0 rgba(0,0,0,.3)'
+  } as React.CSSProperties,
+  tip: {
+    position: 'absolute',
+    top: -4,
+    left: '50%',
+    transform: 'translateX(-50%)',
+    width: 0,
+    height: 0,
+    borderLeft: '5px solid transparent',
+    borderRight: '5px solid transparent',
+    borderBottom: '5px solid' + Palette.DARKEST_COAL,
+  } as React.CSSProperties,
+};
+
+export class TooltipBasic extends React.PureComponent {
+  render () {
+    return (
+      <div style={STYLES.tooltip}>
+        <span style={STYLES.tip} />
+        {this.props.children}
+      </div>
+    );
+  }
+}

--- a/scripts/helpers/uploadRelease.js
+++ b/scripts/helpers/uploadRelease.js
@@ -42,7 +42,7 @@ function uploadRelease (region, key, secret, bucket, folder, platform, environme
       if (err) return cb(err)
 
       var urls = {
-        download: `https://s3.amazonaws.com/${bucket}/${folder}/${environment}/${branch}/${platform}/${countdown}/${version}/Haiku-${version}-${platform}-pending.zip`,
+        download: `https://s3.amazonaws.com/${bucket}/${folder}/${environment}/${branch}/${platform}/${countdown}/${version}/Haiku-${version}-${platform}-pending.zip`
       }
 
       return cb(null, {

--- a/scripts/internal/create-user.js
+++ b/scripts/internal/create-user.js
@@ -11,7 +11,7 @@ cp.execSync([
   `--verbose`,
   `-X POST`,
   `https://inkstonestaging.haiku.ai/v0/user`,
-  `--data '{"OrganizationName": "${organization}", "Email": "${email}", "Password" : "${password}"}'`,
+  `--data '{"OrganizationName": "${organization}", "Email": "${email}", "Password" : "${password}"}'`
 ].join(' '))
 
 log.log(JSON.stringify({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2114,10 +2114,6 @@ body-parser@1.18.2:
     raw-body "2.3.2"
     type-is "~1.6.15"
 
-bodymovin@4.11.1:
-  version "4.11.1"
-  resolved "https://registry.yarnpkg.com/bodymovin/-/bodymovin-4.11.1.tgz#c59a88fc25b025cf680603d22a0ae9e59fa4315e"
-
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
@@ -7329,6 +7325,10 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+lottie-web@5.1.7:
+  version "5.1.7"
+  resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.1.7.tgz#5a4c9163209af12333637282b02032782fbfc530"
 
 loud-rejection@^1.0.0:
   version "1.6.0"


### PR DESCRIPTION
OK to merge.

Cosmetic tweaks to the Publish modal.
Of note, I had to make a simple `<TooltipBasic />`,  as the existing `<Popover/>`-based `<Tooltip />`  seems to have some problems. Does it work correctly on the Tour? (The only other place it is used.)

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [ ] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
