### PR TITLE
feat: allow negative and out-of-container values for mouse/touch events

### DIFF
--- a/packages/@haiku/core/src/renderers/dom/HaikuDOMRenderer.ts
+++ b/packages/@haiku/core/src/renderers/dom/HaikuDOMRenderer.ts
@@ -132,6 +132,9 @@ HaikuDOMRenderer.prototype.initialize = function initialize(domMountElement) {
   // MOUSE
   // -----
 
+  const doc = domMountElement.ownerDocument;
+  const win = doc.defaultView || doc.parentWindow;
+
   domMountElement.addEventListener('mousedown', (mouseEvent) => {
     ++user.mouse.down;
     ++user.mouse.buttons[mouseEvent.button];
@@ -145,17 +148,20 @@ HaikuDOMRenderer.prototype.initialize = function initialize(domMountElement) {
     setMouches();
   });
 
-  domMountElement.addEventListener('mousemove', (mouseEvent) => {
+  // NOTE: if there are perf or interop issues that arise from
+  //       attaching event listeners directly to host window,
+  //       could expose a haikuOption for reverting to "attach to mount" behavior
+  win.addEventListener('mousemove', (mouseEvent) => {
     setMouse(mouseEvent);
     setMouches();
   });
 
-  domMountElement.addEventListener('mouseenter', (mouseEvent) => {
+  win.addEventListener('mouseenter', (mouseEvent) => {
     clearMouse();
     clearMouch();
   });
 
-  domMountElement.addEventListener('mouseleave', (mouseEvent) => {
+  win.addEventListener('mouseleave', (mouseEvent) => {
     clearMouse();
     clearMouch();
   });
@@ -171,8 +177,6 @@ HaikuDOMRenderer.prototype.initialize = function initialize(domMountElement) {
     },
   );
 
-  const doc = domMountElement.ownerDocument;
-  const win = doc.defaultView || doc.parentWindow;
 
   // KEYS
   // ----
@@ -228,7 +232,7 @@ HaikuDOMRenderer.prototype.initialize = function initialize(domMountElement) {
 
   // TOUCHES
   // -------
-  domMountElement.addEventListener(
+  win.addEventListener(
     'touchstart',
     (touchEvent) => {
       setTouches(touchEvent);
@@ -239,12 +243,12 @@ HaikuDOMRenderer.prototype.initialize = function initialize(domMountElement) {
     },
   );
 
-  domMountElement.addEventListener('touchend', (touchEvent) => {
+  win.addEventListener('touchend', (touchEvent) => {
     clearTouch();
     clearMouch();
   });
 
-  domMountElement.addEventListener(
+  win.addEventListener(
     'touchmove',
     (touchEvent) => {
       setTouches(touchEvent);
@@ -255,12 +259,12 @@ HaikuDOMRenderer.prototype.initialize = function initialize(domMountElement) {
     },
   );
 
-  domMountElement.addEventListener('touchenter', (touchEvent) => {
+  win.addEventListener('touchenter', (touchEvent) => {
     clearTouch();
     clearMouch();
   });
 
-  domMountElement.addEventListener('touchleave', (touchEvent) => {
+  win.addEventListener('touchleave', (touchEvent) => {
     clearTouch();
     clearMouch();
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2114,10 +2114,6 @@ body-parser@1.18.2:
     raw-body "2.3.2"
     type-is "~1.6.15"
 
-bodymovin@4.11.1:
-  version "4.11.1"
-  resolved "https://registry.yarnpkg.com/bodymovin/-/bodymovin-4.11.1.tgz#c59a88fc25b025cf680603d22a0ae9e59fa4315e"
-
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
@@ -7329,6 +7325,10 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+lottie-web@5.1.7:
+  version "5.1.7"
+  resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.1.7.tgz#5a4c9163209af12333637282b02032782fbfc530"
 
 loud-rejection@^1.0.0:
   version "1.6.0"


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- Enables out-of-container values for e.g. $user.mouse.x (mouse & touch events)
- see https://cl.ly/2j35380Z080f

Notes for reviewers:

- It's kind-of a breaking change, but not really (supports superset of old behavior.)  Also: attaches directly to host window, increasing exposure to interop issues.  Worth it IMO — we need to be able to break out of our container..

Completed checkin tasks:

- [ x] Did manual testing of interrelated functionality
- [ x] Ran `$ yarn lint-all` and fixed all formatting issues
- [ x] Ran `$ yarn test` for core
