### PR TITLE
fix: cast all SVG text font declarations to a default sans-serif chain.

### DIFF
--- a/packages/haiku-serialization/src/svg/getSvgOptimizer.js
+++ b/packages/haiku-serialization/src/svg/getSvgOptimizer.js
@@ -16,7 +16,23 @@ module.exports = () => {
         'removeUselessStrokeAndFill',
         'removeNonInheritableGroupAttrs',
         'moveElemsAttrsToGroup',
-        'collapseGroups'
+        'collapseGroups',
+        {
+          haikuClean: {
+            type: 'perItem',
+            /**
+             * Custom svgo plugin for cleaning Haiku instantiated components.
+             * @param item
+             * @see {@link https://github.com/svg/svgo/blob/master/docs/how-it-works/en.md}
+             */
+            fn: (item) => {
+              // Clobber font-family on any/all nodes that try to declare it so users don't get their hopes up.
+              if (item.hasAttr('font-family')) {
+                item.attr('font-family').value = 'Helvetica, Arial, sans-serif'
+              }
+            }
+          }
+        }
       ]
     })
   }

--- a/packages/haiku-serialization/test/bll/08_File.test.js
+++ b/packages/haiku-serialization/test/bll/08_File.test.js
@@ -1,0 +1,40 @@
+const tape = require('tape')
+const path = require('path')
+const fse = require('haiku-fs-extra')
+const Project = require('./../../src/bll/Project')
+const Element = require('./../../src/bll/Element')
+
+const TEXT_SVG = `<svg><text font-family="DontKnowDontCare" font-size="12">Hello friend.</text></svg>`
+
+tape('File.readMana', (t) => {
+  t.plan(3)
+  const folder = path.join(__dirname, '..', 'fixtures', 'projects', 'file-readmana-01')
+  fse.removeSync(folder)
+  const websocket = { on: () => {}, send: () => {}, action: () => {}, connect: () => {} }
+  const platform = {}
+  const userconfig = {}
+  const fileOptions = { doWriteToDisk: true, skipDiffLogging: true }
+  const envoyOptions = { mock: true }
+  return Project.setup(folder, 'test', websocket, platform, userconfig, fileOptions, envoyOptions, (err, project) => {
+    return project.setCurrentActiveComponent('main', { from: 'test' }, (err) => {
+      if (err) throw err
+      fse.outputFileSync(path.join(folder, 'designs/Text.svg'), TEXT_SVG)
+      const ac0 = project.getCurrentActiveComponent()
+      return ac0.instantiateComponent('designs/Text.svg', {}, { from: 'test' }, (err, info, mana) => {
+        if (err) throw err
+        const timelineProperties = ac0
+          .fetchActiveBytecodeFile()
+          .getReifiedBytecode()
+          .timelines.Default[`haiku:${mana.children[0].attributes['haiku-id']}`]
+        t.deepEqual(timelineProperties.content, {0: {value: 'Hello friend.'}}, 'svg text content is transcluded')
+        t.deepEqual(timelineProperties['font-size'], {0: {value: '12'}}, 'most svg text attributes are parsed')
+        t.deepEqual(
+          timelineProperties['font-family'],
+          {0: {value: 'Helvetica, Arial, sans-serif'}},
+          'svg font-family is clobbered with a default sans-serif chain'
+        )
+        fse.removeSync(folder)
+      })
+    })
+  })
+})


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- During component instantiation, clobber `font-family` on any/all nodes that try to declare it so users don't get their hopes up.

Summary of work (include Asana links if any):

- [x] Fix [bug](https://app.asana.com/0/548868462189817/563374658146405/f), write test.

Regressions to look for:

- Any issues instantiating components in the app.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [x] Wrote an automated test covering new functionality
