### PR TITLE
fix: for "keyframes should still listen to expressions while paused()"

### DIFF
--- a/packages/@haiku/core/src/HaikuTimeline.ts
+++ b/packages/@haiku/core/src/HaikuTimeline.ts
@@ -29,7 +29,6 @@ export default function HaikuTimeline(component, name, descriptor, options) {
   this._localExplicitlySetTime = null; // Only set this to a number if time is 'controlled'
   this._maxExplicitlyDefinedTime = getTimelineMaxTime(descriptor);
 
-  this._isActive = false;
   this._isPlaying = false;
 }
 
@@ -91,7 +90,7 @@ HaikuTimeline.prototype._doUpdateWithGlobalClockTime = function _doUpdateWithGlo
     this._updateInternalProperties(globalClockTime);
   }
 
-  if (this.isActive() && this.isPlaying()) {
+  if (this.isPlaying()) {
     this._shout('tick');
   }
 
@@ -229,14 +228,6 @@ HaikuTimeline.prototype.isPlaying = function isPlaying() {
 };
 
 /**
- * @method isActive
- * @description Returns T/F if the timeline is active
- */
-HaikuTimeline.prototype.isActive = function isActive() {
-  return !!this._isActive;
-};
-
-/**
  * @method isFrozen
  * @description Returns T/F if the timeline is frozen
  */
@@ -250,7 +241,7 @@ HaikuTimeline.prototype.isFrozen = function isFrozen() {
  * If this timeline is set to loop, it is never "finished".
  */
 HaikuTimeline.prototype.isFinished = function () {
-  if (this.options.loop) {
+  if (this.options.loop || this._isTimeControlled()) {
     return false;
   }
   return ~~this.getElapsedTime() > this.getMaxTime();
@@ -297,7 +288,6 @@ HaikuTimeline.prototype.start = function start(
   descriptor,
 ) {
   this._localElapsedTime = 0;
-  this._isActive = true;
   this._isPlaying = true;
   this._globalClockTime = maybeGlobalClockTime || 0;
   this._maxExplicitlyDefinedTime = getTimelineMaxTime(descriptor);
@@ -308,7 +298,6 @@ HaikuTimeline.prototype.start = function start(
 };
 
 HaikuTimeline.prototype.stop = function stop(maybeGlobalClockTime, descriptor) {
-  this._isActive = false;
   this._isPlaying = false;
   this._maxExplicitlyDefinedTime = getTimelineMaxTime(descriptor);
 

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -360,7 +360,7 @@ class Timeline extends BaseModel {
 
         const timelineInstance = timelineInstances[timelineName]
 
-        if (timelineInstance.isActive()) {
+        if (timelineInstance.isPlaying()) {
           timelineInstance._controlTime(timelineTime, explicitTime)
         }
       }


### PR DESCRIPTION
OK to merge.

Medium review—should check demos.

Purpose of changes:

- Expressions should still work when an animation is paused.

Summary of work (include Asana links if any):

- [x] Alter the duplicative and slightly incorrect interplay of `HaikuTimeline#isActive` and `HaikuTimeline#isPlaying` by simply getting rid of the concept of `isActive()`.
- [x] Use `isPlaying` instead of `isActive` to decide if we should update the the timeline with the global clock time, but not to decide if we should consider the timeline "running".
- [x] Like with looping, never consider the timeline "finished" if it's being time controlled.

Regressions to look for:

- Anything playback weirdness in Glass after going through several loops in and out of preview mode, between various changes.

Notes for reviewers:

- Technically this is an API breaking change, but the API isn't documented yet, so I didn't think we needed to worry about this.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [x] ~~Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)~~ (somebody already did this)
