### PR TITLE
Cosmetic: Add placeholder labels to state inspector inputs

### DIFF
--- a/packages/haiku-creator/src/react/components/StateInspector/StateRow.js
+++ b/packages/haiku-creator/src/react/components/StateInspector/StateRow.js
@@ -299,7 +299,7 @@ class StateRow extends React.Component {
                 ref={(nameInput) => { this.nameInput = nameInput }}
                 style={[STYLES.pill, STYLES.input]}
                 defaultValue={this.props.stateName}
-                placeholder="STATE NAME"
+                placeholder='STATE NAME'
                 onKeyUp={(event) => this.handleChange(event, 'name')}
                 onKeyDown={(event) => this.handleTabSwitch(event, 'name')}
                 autoFocus />
@@ -309,7 +309,7 @@ class StateRow extends React.Component {
                 ref={(valueInput) => { this.valueInput = valueInput }}
                 style={[STYLES.pill, STYLES.input, STYLES.input2]}
                 defaultValue={this.getEditableStateValue()}
-                placeholder="STATE VALUE"
+                placeholder='STATE VALUE'
                 onKeyUp={(event) => this.handleChange(event, 'value')}
                 onKeyDown={(event) => this.handleTabSwitch(event, 'value')} />
               <span key={`${this.props.stateName}-menu`}

--- a/packages/haiku-creator/src/react/components/StateInspector/StateRow.js
+++ b/packages/haiku-creator/src/react/components/StateInspector/StateRow.js
@@ -299,6 +299,7 @@ class StateRow extends React.Component {
                 ref={(nameInput) => { this.nameInput = nameInput }}
                 style={[STYLES.pill, STYLES.input]}
                 defaultValue={this.props.stateName}
+                placeholder="STATE NAME"
                 onKeyUp={(event) => this.handleChange(event, 'name')}
                 onKeyDown={(event) => this.handleTabSwitch(event, 'name')}
                 autoFocus />
@@ -308,6 +309,7 @@ class StateRow extends React.Component {
                 ref={(valueInput) => { this.valueInput = valueInput }}
                 style={[STYLES.pill, STYLES.input, STYLES.input2]}
                 defaultValue={this.getEditableStateValue()}
+                placeholder="STATE VALUE"
                 onKeyUp={(event) => this.handleChange(event, 'value')}
                 onKeyDown={(event) => this.handleTabSwitch(event, 'value')} />
               <span key={`${this.props.stateName}-menu`}


### PR DESCRIPTION
OK to merge.

Very simple 2 line change that adds placeholder labels to state inputs when the user is adding a new state, so she has some indication of what's gone on.
![](https://d2ffutrenqvap3.cloudfront.net/items/1i1y1B2G2Q2V2D220E3n/Image%202018-02-20%20at%2012.56.09%20PM.png?v=39048299)

* [Asana task](https://app.asana.com/0/548868462189817/515027761708940)

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [ ] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
