### PR TITLE
Fix Mixpanel tracking

### DIFF
--- a/packages/@haiku/core/README.md
+++ b/packages/@haiku/core/README.md
@@ -174,6 +174,20 @@ Interactive:
 
 <br>
 
+## Tracking / Analytics
+
+By default, Haiku tracks usage of published components by transmitting metadata to Haiku's Mixpanel account when components are initialized on the page. We send only public information: your component's name, its Haiku account username, the software version it was built with, and its share identifier.
+
+To disable this, set the `mixpanel` option to falsy:
+
+    // ...
+    const factory = HaikuCore(definition);
+    const component = factory(document.getElementById("mount"), {
+      mixpanel: false // Or the string of your own Mixpanel API token
+    })
+
+<br>
+
 ## Bugs / Feature Requests / Troubleshooting
 
 Please use [GitHub Issues](https://github.com/HaikuTeam/core/issues).

--- a/packages/@haiku/core/src/HaikuContext.ts
+++ b/packages/@haiku/core/src/HaikuContext.ts
@@ -68,6 +68,7 @@ export default function HaikuContext(mount, renderer, platform, bytecode, config
   }
 
   this.component = new HaikuComponent(bytecode, this, this.config, null);
+
   this.clock = new HaikuClock(this._tickables, this.component, this.config.options.clock || {});
   // We need to start the loop even if we aren't autoplaying,
   // because we still need time to be calculated even if we don't 'tick'.
@@ -79,8 +80,10 @@ export default function HaikuContext(mount, renderer, platform, bytecode, config
     this._renderer.menuize(this._mount, this.component);
   }
 
-  // Don't set up mixpanel if we're running on localhost since we don't want test data to be tracked
-  // TODO: What other heuristics should we use to decide whether to use mixpanel or not?
+  // By default, Haiku tracks usage by transmitting component metadata to Mixpanel when initialized.
+  // Developers can disable this by setting the `mixpanel` option to a falsy value.
+  // To transmit metadata to your own Mixpanel account, set the `mixpanel` option to your Mixpanel API token.
+  // Don't set up Mixpanel if we're running on localhost since we don't want test data to be tracked
   if (
     this._mount &&
     this._platform &&

--- a/packages/@haiku/core/src/renderers/dom/createMixpanel.ts
+++ b/packages/@haiku/core/src/renderers/dom/createMixpanel.ts
@@ -32,7 +32,5 @@ export default function createMixpanel(domElement, mixpanelToken, component) {
     },
   };
 
-  component.on('haikuComponentDidInitialize', () => {
-    component.mixpanel.track('component:initialize');
-  });
+  component.mixpanel.track('component:initialize');
 }


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- Fix Mixpanel tracking when components are initialized

Summary of work (include Asana links if any):

- [x] https://app.asana.com/0/548868462189817/568420102336768
- [x] https://app.asana.com/0/548868462189817/561550461513856

Regressions to look for:

- Ensure we do get tracking for published components, but not when components are just run inside the app

Notes for reviewers:

- Please publish a component and then go into Mixpanel and verify the component:initialize event is present

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
