### PR TITLE
fix: wrap haikuOptions in quotes in the Vue.js example

### DIFF
--- a/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/VueHaiku.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/VueHaiku.tsx
@@ -21,7 +21,7 @@ export default class VueHaiku extends React.PureComponent {
 
           new Vue({
             el: '#vue-dom-mount',
-            template: \`<${projectName} haikuOptions={{loop: true}}></${projectName}>\`,
+            template: \`<${projectName} haikuOptions="{{loop: true}}"></${projectName}>\`,
             components: {
               ${projectName}
             }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of work (include Asana links if any):

- [x] wrap haikuOptions in quotes in the Vue.js example

Notes for reviewers:

I have decided to go with double quotes because is suggested in the [vue style guide](https://vuejs.org/v2/style-guide/#Quoted-attribute-values-strongly-recommended)

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
