### PR TITLE
Split panels

### DIFF
--- a/packages/haiku-creator/package.json
+++ b/packages/haiku-creator/package.json
@@ -58,7 +58,6 @@
     "react-motion": "0.4.7",
     "react-onclickoutside": "^6.4.0",
     "react-popover": "^0.4.18",
-    "react-split-pane": "0.1.57",
     "react-transition-group": "^2.2.1"
   },
   "devDependencies": {

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { StyleRoot } from 'radium'
-import SplitPane from 'react-split-pane'
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
 import lodash from 'lodash'
 import Combokeys from 'combokeys'
@@ -16,6 +15,7 @@ import ProjectBrowser from './components/ProjectBrowser'
 import SideBar from './components/SideBar'
 import Library from './components/library/Library'
 import StateInspector from './components/StateInspector/StateInspector'
+import SplitPanel from './components/SplitPanel'
 import Stage from './components/Stage'
 import Timeline from './components/Timeline'
 import Toast from './components/notifications/Toast'
@@ -611,10 +611,6 @@ export default class Creator extends React.Component {
     this.tourChannel.receiveWebviewCoordinates('creator', { top: 0, left: 0 })
   }
 
-  handlePaneResize () {
-    // this.layout.emit('resize')
-  }
-
   renderNotifications (content, i) {
     return (
       <Toast
@@ -1162,77 +1158,75 @@ export default class Creator extends React.Component {
                 {lodash.map(this.state.notices, this.renderNotifications)}
               </div>
             </ReactCSSTransitionGroup>
-            <SplitPane onDragFinished={this.handlePaneResize.bind(this)} split='horizontal' minSize={300} defaultSize={this.props.height * 0.62}>
-              <div>
-                <SplitPane onDragFinished={this.handlePaneResize.bind(this)} split='vertical' minSize={300} defaultSize={300}>
-                  <SideBar
-                    doShowBackToDashboardButton={this.state.doShowBackToDashboardButton}
-                    projectModel={this.state.projectModel}
-                    switchActiveNav={this.switchActiveNav.bind(this)}
-                    onNavigateToDashboard={this.onNavigateToDashboard}
-                    activeNav={this.state.activeNav}>
-                    {
-                      isPreviewMode(this.state.interactionMode) && (
-                        <div
-                          style={{
-                            opacity: 0.6,
-                            position: 'absolute',
-                            top: 34,
-                            left: 0,
-                            right: 0,
-                            bottom: 0,
-                            zIndex: 999999,
-                            backgroundColor: Palette.COAL
-                          }}
-                          onClick={() => { this.disablePreviewMode() }}
-                        />
-                      )
-                    }
-                    {this.state.activeNav === 'library'
-                      ? <Library
-                        projectModel={this.state.projectModel}
-                        layout={this.layout}
-                        folder={this.state.projectFolder}
-                        haiku={this.props.haiku}
-                        websocket={this.props.websocket}
-                        onDragEnd={this.onLibraryDragEnd.bind(this)}
-                        onDragStart={this.onLibraryDragStart.bind(this)}
-                        createNotice={this.createNotice}
-                        removeNotice={this.removeNotice} />
-                      : <StateInspector
-                        projectModel={this.state.projectModel}
-                        createNotice={this.createNotice}
-                        removeNotice={this.removeNotice}
-                        folder={this.state.projectFolder}
-                        websocket={this.props.websocket} />
-                    }
-                  </SideBar>
-                  <div style={{ position: 'relative', width: '100%', height: '100%' }}>
-                    <Stage
-                      ref='stage'
-                      folder={this.state.projectFolder}
+            <SplitPanel split='horizontal' minSize={300} defaultSize={this.props.height * 0.62}>
+              <SplitPanel split='vertical' minSize={300} defaultSize={300}>
+                <SideBar
+                  doShowBackToDashboardButton={this.state.doShowBackToDashboardButton}
+                  projectModel={this.state.projectModel}
+                  switchActiveNav={this.switchActiveNav.bind(this)}
+                  onNavigateToDashboard={this.onNavigateToDashboard}
+                  activeNav={this.state.activeNav}>
+                  {
+                    isPreviewMode(this.state.interactionMode) && (
+                      <div
+                        style={{
+                          opacity: 0.6,
+                          position: 'absolute',
+                          top: 34,
+                          left: 0,
+                          right: 0,
+                          bottom: 0,
+                          zIndex: 999999,
+                          backgroundColor: Palette.COAL
+                        }}
+                        onClick={() => { this.disablePreviewMode() }}
+                      />
+                    )
+                  }
+                  {this.state.activeNav === 'library'
+                    ? <Library
                       projectModel={this.state.projectModel}
-                      envoyClient={this.envoyClient}
+                      layout={this.layout}
+                      folder={this.state.projectFolder}
                       haiku={this.props.haiku}
                       websocket={this.props.websocket}
-                      project={this.state.projectObject}
+                      onDragEnd={this.onLibraryDragEnd.bind(this)}
+                      onDragStart={this.onLibraryDragStart.bind(this)}
+                      createNotice={this.createNotice}
+                      removeNotice={this.removeNotice} />
+                    : <StateInspector
+                      projectModel={this.state.projectModel}
                       createNotice={this.createNotice}
                       removeNotice={this.removeNotice}
-                      receiveProjectInfo={this.receiveProjectInfo}
-                      organizationName={this.state.organizationName}
-                      authToken={this.state.authToken}
-                      username={this.state.username}
-                      password={this.state.password}
-                      isTimelineReady={this.state.isTimelineReady}
-                      isPreviewMode={isPreviewMode(this.state.interactionMode)}
-                      onPreviewModeToggled={() => { this.togglePreviewMode() }}
-                    />
-                    {(this.state.assetDragging)
-                      ? <div style={{ width: '100%', height: '100%', backgroundColor: 'white', opacity: 0.01, position: 'absolute', top: 0, left: 0 }} />
-                      : ''}
-                  </div>
-                </SplitPane>
-              </div>
+                      folder={this.state.projectFolder}
+                      websocket={this.props.websocket} />
+                  }
+                </SideBar>
+                <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+                  <Stage
+                    ref='stage'
+                    folder={this.state.projectFolder}
+                    projectModel={this.state.projectModel}
+                    envoyClient={this.envoyClient}
+                    haiku={this.props.haiku}
+                    websocket={this.props.websocket}
+                    project={this.state.projectObject}
+                    createNotice={this.createNotice}
+                    removeNotice={this.removeNotice}
+                    receiveProjectInfo={this.receiveProjectInfo}
+                    organizationName={this.state.organizationName}
+                    authToken={this.state.authToken}
+                    username={this.state.username}
+                    password={this.state.password}
+                    isTimelineReady={this.state.isTimelineReady}
+                    isPreviewMode={isPreviewMode(this.state.interactionMode)}
+                    onPreviewModeToggled={() => { this.togglePreviewMode() }}
+                  />
+                  {(this.state.assetDragging)
+                    ? <div style={{ width: '100%', height: '100%', backgroundColor: 'white', opacity: 0.01, position: 'absolute', top: 0, left: 0 }} />
+                    : ''}
+                </div>
+              </SplitPanel>
               <Timeline
                 ref='timeline'
                 folder={this.state.projectFolder}
@@ -1243,7 +1237,7 @@ export default class Creator extends React.Component {
                 createNotice={this.createNotice}
                 removeNotice={this.removeNotice}
                 onReady={this.onTimelineMounted} />
-            </SplitPane>
+            </SplitPanel>
           </div>
         </div>
         {(this.state.doShowProjectLoader)

--- a/packages/haiku-creator/src/react/components/SplitPanel.js
+++ b/packages/haiku-creator/src/react/components/SplitPanel.js
@@ -1,0 +1,146 @@
+import React from 'react'
+import Radium from 'radium'
+import Draggable from 'react-draggable'
+
+const STYLE = {
+  wrapper: {
+    display: 'flex',
+    height: '100%',
+    outline: 'none',
+    overflow: 'hidden',
+    userSelect: 'text',
+    vertical: {
+      flexDirection: 'row',
+      left: 0,
+      right: 0
+    },
+    horizontal: {
+      bottom: 0,
+      flexDirection: 'column',
+      minHeight: '100%',
+      top: 0,
+      width: '100%'
+    }
+  },
+  resizer: {
+    position: 'absolute',
+    backgroundColor: 'rgb(21, 32, 34)',
+    opacity: '1',
+    zIndex: '5',
+    boxSizing: 'border-box',
+    backgroundClip: 'padding-box',
+    ':hover': {
+      transition: 'all 220ms ease'
+    }
+  },
+  pane: {
+    position: 'relative',
+    width: '100%',
+    height: '100%'
+  }
+}
+
+class SplitPanel extends React.PureComponent {
+  constructor (props) {
+    super()
+
+    this.state = {
+      minSize: props.minSize,
+      defaultSize: props.defaultSize
+    }
+  }
+
+  isVertical () {
+    return this.props.split === 'vertical'
+  }
+
+  resize (mouseEvent) {
+    const defaultSize = this.isVertical() ? mouseEvent.x : mouseEvent.y
+
+    this.setState({defaultSize})
+  }
+
+  render () {
+    const invisibleBorder = '5px solid rgba(255, 255, 255, 0)'
+    const visibleBorder = '5px solid rgba(0, 0, 0, 0.15)'
+
+    let axis
+    let paneStyle
+    let resizerStyle
+
+    if (this.isVertical()) {
+      axis = 'x'
+      paneStyle = {minWidth: this.state.minSize, width: this.state.defaultSize}
+      resizerStyle = {
+        width: '11px',
+        height: '100%',
+        cursor: 'col-resize',
+        borderRight: invisibleBorder,
+        borderLeft: invisibleBorder,
+        top: 0,
+        right: 0,
+        margin: '0 -6px',
+        ':hover': {
+          borderRight: visibleBorder,
+          borderLeft: visibleBorder
+        }
+      }
+    } else {
+      axis = 'y'
+      paneStyle = {
+        minHeight: this.state.minSize,
+        height: this.state.defaultSize
+      }
+      resizerStyle = {
+        height: '11px',
+        width: '100%',
+        cursor: 'row-resize',
+        borderTop: invisibleBorder,
+        borderBottom: invisibleBorder,
+        bottom: 0,
+        left: 0,
+        margin: '-6px 0',
+        ':hover': {
+          borderTop: visibleBorder,
+          borderBottom: visibleBorder
+        }
+      }
+    }
+
+    return (
+      <div style={{...STYLE.wrapper, ...STYLE.wrapper[this.props.split]}}>
+        <div style={{...STYLE.pane, ...paneStyle}}>
+          {this.props.children[0]}
+          <Draggable
+            axis={axis}
+            onStop={(mouseEvent) => {
+              this.resize(mouseEvent)
+            }}
+            position={{x: 0, y: 0}}
+          >
+            <span style={{...STYLE.resizer, ...resizerStyle}} />
+          </Draggable>
+        </div>
+        <div style={{
+          flexGrow: 2,
+          // FIXME: horrible hack to force reflow when resizing the panel, seems
+          // to be a chrome bug with this particular combo of flexbox + changing
+          // size
+          height: this.isVertical() ? '' : Math.random()
+        }}>
+          {this.props.children[1]}
+        </div>
+      </div>
+    )
+  }
+}
+
+SplitPanel.propTypes = {
+  split: React.PropTypes.string
+}
+
+SplitPanel.defaultProps = {
+  split: 'horizontal'
+}
+
+export default Radium(SplitPanel)

--- a/packages/haiku-creator/src/react/components/Stage.js
+++ b/packages/haiku-creator/src/react/components/Stage.js
@@ -9,7 +9,6 @@ import { Experiment, experimentIsEnabled } from 'haiku-common/lib/experiments'
 import { remote } from 'electron'
 
 const STAGE_BOX_STYLE = {
-  position: 'relative',
   overflow: 'hidden',
   padding: 0,
   margin: 0,

--- a/packages/haiku-creator/src/react/components/Timeline.js
+++ b/packages/haiku-creator/src/react/components/Timeline.js
@@ -129,7 +129,7 @@ export default class Timeline extends React.Component {
         onMouseOver={() => this.webview.focus()}
         onMouseOut={() => this.webview.blur()}
         ref={(element) => { this.mount = element }}
-        style={{ position: 'absolute', overflow: 'auto', width: '100%', height: '100%', backgroundColor: Palette.GRAY }}>
+        style={{ overflow: 'auto', width: '100%', height: '100%', backgroundColor: Palette.GRAY }}>
         {!this.state.finishedInjecting &&
         <div style={{
           position: 'absolute',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6094,7 +6094,7 @@ inline-style-prefix-all@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/inline-style-prefix-all/-/inline-style-prefix-all-2.0.2.tgz#44e23c00d3521a36041e07c9b1e81bf36770b08c"
 
-inline-style-prefixer@2.0.5, inline-style-prefixer@^2.0.4, inline-style-prefixer@^2.0.5:
+inline-style-prefixer@2.0.5, inline-style-prefixer@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz#c153c7e88fd84fef5c602e95a8168b2770671fe7"
   dependencies:
@@ -9623,13 +9623,6 @@ react-scroll-to-component@^1.0.1:
   dependencies:
     scroll-to "0.0.2"
 
-react-split-pane@0.1.57:
-  version "0.1.57"
-  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.57.tgz#7cc2d30841ae6a3e246ee613a9858012528d894f"
-  dependencies:
-    inline-style-prefixer "^2.0.4"
-    react-style-proptype "^1.4.0"
-
 react-split-pane@^0.1.74:
   version "0.1.74"
   resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.74.tgz#cf79fc98b51ab0763fdc778749b810a102b036ca"
@@ -9639,10 +9632,6 @@ react-split-pane@^0.1.74:
     inline-style-prefixer "^3.0.6"
     prop-types "^15.5.10"
     react-style-proptype "^3.0.0"
-
-react-style-proptype@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/react-style-proptype/-/react-style-proptype-1.4.0.tgz#d82c4093b73767e3efaacba013cea22a50e7b5ee"
 
 react-style-proptype@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
OK to merge.

Short review.

Summary of work (include Asana links if any):

- [x] Show a simple horizontal gray indicator that tracks mouseposition when dragging, then it only commits & resizes upon mouseup https://app.asana.com/0/548868462189817/505957877019451

Regressions to look for:

- Anything related to resizing or stage and timeline layouts

Notes:

We discussed showing a haiku while the stage is resizing, but honestly, the resize is so fast that the haiku just flashes away. We could add an artificial delay to show the haiku but feels like unnecessary. In any case, if @taylorpoe or @zackbrown feels like we should include it, it's a 0 effort task.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
