### PR TITLE
Proposal: format expressions code to avoid weirdness

### DIFF
--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
@@ -4,7 +4,7 @@ import ElementTitle from './ElementTitle'
 import CSSStyles from './CSSStyles'
 import Editor from './Editor'
 import EditorActions from './EditorActions'
-import HandlerManager from './HandlerManager'
+import HandlerManager from 'haiku-serialization/src/utils/HandlerManager'
 import {ModalWrapper, ModalHeader, ModalFooter} from 'haiku-ui-common/lib/react/Modal'
 import {EDITOR_WIDTH, EDITOR_HEIGHT, EVALUATOR_STATES} from './constants'
 

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -16,6 +16,7 @@ import ensureEq from 'haiku-ui-common/lib/helpers/ensureEq'
 import doesValueImplyExpression from 'haiku-ui-common/lib/helpers/doesValueImplyExpression'
 import humanizePropertyName from 'haiku-ui-common/lib/helpers/humanizePropertyName'
 import AutoCompleter from './AutoCompleter'
+import HandlerManager from 'haiku-serialization/src/utils/HandlerManager'
 
 const HaikuMode = require('./modes/haiku')
 
@@ -115,16 +116,18 @@ function getRenderableValueMultiline (valueDescriptor, skipFormatting) {
   // During editing, when we dynamically change the signature, formatting can
   // mess things up, giving us extra spaces, and also mess with the cursor
   // position resetting, so we return it as-is.
+
   if (skipFormatting) {
     return `function (${params}) {
 ${valueDescriptor.body}
 }`
   } else {
+    const body = HandlerManager.prettifyHandlerBody(valueDescriptor.body, {outdentBy: 0}) || valueDescriptor.body
     // We don't 'ensureRet' because in case of a multiline function, we can't be assured that
     // the user didn't return on a later line. However, we do a sanity check for the initial equal
     // sign in case the current case is converting from single to multi.
     return `function (${params}) {
-  ${eqToRet(valueDescriptor.body)}
+${eqToRet(body)}
 }`
   }
 }
@@ -461,8 +464,7 @@ export default class ExpressionInput extends React.Component {
       let cursor2 = this.codemirror.getCursor()
 
       // Update the editor contents
-      // We set 'skipFormatting' to true here so we don't get weird spacing issues
-      let renderable = getRenderableValueMultiline(officialValue, true)
+      let renderable = getRenderableValueMultiline(officialValue, false)
       this.setEditorValue(renderable)
 
       // Now put the cursor where it was originally
@@ -837,7 +839,7 @@ export default class ExpressionInput extends React.Component {
           lineNumbers: true,
           scrollbarStyle: 'native'
         })
-        renderable = getRenderableValueMultiline(this.state.editedValue)
+        renderable = getRenderableValueMultiline(this.state.editedValue, true)
         this.setEditorValue(renderable)
         break
 


### PR DESCRIPTION
OK to merge after discussion & rebasing (I'm lazy enough to wait for approval before rebasing).

Short review.

Purpose of changes:

- In multiline-expression land, every time you open the expression editor the code is messed up due to how our pipeline treats bytecode. In actions land, we _temporally_ solved this by formatting the code with prettier everytime the editor is open. This change reuses that logic in expressions.

Summary of work (include Asana links if any):

- [x] Move `HandlerManager` into `haiku-serialization`, we discussed this in the past, and maybe `utils` is still not the right place but at least is closer.
- [x] Abstract logic to prettify code into a class method of `HandlerManager` and use it to format expressions.

Regressions to look for:

- Expression multiline editing
- Actions editor formatting


Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
