### PR TITLE
fix: use correct import path for code samples in publish UI

### DIFF
--- a/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/ReactHaiku.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/ReactHaiku.tsx
@@ -19,7 +19,7 @@ export default class VanillaJS extends React.PureComponent {
       <NpmInstallable projectName={projectName} userName={userName} organizationName={organizationName}>
         <CodeBox>
           {dedent`
-          import ${projectName} from '@haiku/${organizationName.toLowerCase()}-${projectName}/react';
+          import ${projectName} from '@haiku/${organizationName.toLowerCase()}-${projectName.toLowerCase()}/react';
 
           /*...*/
 

--- a/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/VanillaJS.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/VanillaJS.tsx
@@ -19,7 +19,7 @@ export default class VanillaJS extends React.PureComponent {
       <NpmInstallable projectName={projectName} userName={userName} organizationName={organizationName}>
         <CodeBox>
           {dedent`
-          import ${projectName} from '@haiku/${organizationName.toLowerCase()}-${projectName}';
+          import ${projectName} from '@haiku/${organizationName.toLowerCase()}-${projectName.toLowerCase()}';
 
           const element = document.querySelector('.my-element');
           ${projectName}(element, {loop: true});

--- a/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/VueHaiku.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/VueHaiku.tsx
@@ -17,7 +17,7 @@ export default class VueHaiku extends React.PureComponent {
       <NpmInstallable projectName={projectName} userName={userName} organizationName={organizationName}>
         <CodeBox>
           {dedent`
-          import ${projectName} from '@haiku/${organizationName.toLowerCase()}-${projectName}/vue';
+          import ${projectName} from '@haiku/${organizationName.toLowerCase()}-${projectName.toLowerCase()}/vue';
 
           new Vue({
             el: '#vue-dom-mount',


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- Use correct import path for code samples in publish UI.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x ] Ran `$ yarn test-all` and all tests passed