### PR TITLE
Add ability to mark projects as "public to community" from publish UI

### DIFF
--- a/packages/@haiku/sdk-inkstone/src/index.ts
+++ b/packages/@haiku/sdk-inkstone/src/index.ts
@@ -9,6 +9,7 @@ const ENDPOINTS = {
   CHANGE_PASSWORD: 'v0/user/password',
   ORGANIZATION_LIST: 'v0/organization',
   PROJECT_LIST: 'v0/project',
+  PROJECT_UPDATE: 'v0/project',
   INVITE_PREFINERY_CHECK: 'v0/invite/check',
   INVITE_CHECK: 'v0/invite/:CODE',
   INVITE_CLAIM: 'v0/invite/claim',
@@ -16,6 +17,7 @@ const ENDPOINTS = {
   SNAPSHOT_SYNDICATED_BY_ID: 'v0/snapshot/:ID/syndicated',
   PROJECT_SNAPSHOT_BY_NAME_AND_SHA: 'v0/project/:NAME/snapshot/:SHA',
   PROJECT_GET_BY_NAME: 'v0/project/:NAME',
+  PROJECT_GET_BY_UNIQUE_ID: 'v0/project/:UNIQUE_ID',
   PROJECT_DELETE_BY_NAME: 'v0/project/:NAME',
   SUPPORT_UPLOAD_GET_PRESIGNED_URL: 'v0/support/upload/:UUID',
   UPDATES: 'v0/updates',
@@ -468,6 +470,7 @@ export namespace inkstone {
       GitRemoteUrl: string;
       GitRemoteName: string;
       GitRemoteArn: string;
+      IsPublic: boolean;
 
       // Current: GitLab-specific fields.
       RepositoryUrl: string;
@@ -488,6 +491,15 @@ export namespace inkstone {
       Name: string;
     }
 
+    export interface ProjectUpdateParams {
+      ID?: number;
+      UniqueId?: string;
+      // Name: string; // for renaming
+      // GitRemoteUrl: // for user-specified git remotes
+      MakePublic?: boolean;
+      MakePrivate?: boolean;
+    }
+
     export function create(authToken: string, params: ProjectCreateParams, cb: inkstone.Callback<Project>) {
       const options: requestLib.UrlOptions & requestLib.CoreOptions = {
         url: inkstoneConfig.baseUrl + ENDPOINTS.PROJECT_CREATE,
@@ -498,6 +510,26 @@ export namespace inkstone {
       };
 
       request.post(options, (err, httpResponse, body) => {
+        if (httpResponse && httpResponse.statusCode === 200) {
+          const project = body as Project;
+          cb(undefined, project, httpResponse);
+        } else {
+          cb(safeError(err), undefined, httpResponse);
+        }
+      });
+    }
+
+
+    export function update(authToken: string, params: ProjectUpdateParams, cb: inkstone.Callback<Project>) {
+      const options: requestLib.UrlOptions & requestLib.CoreOptions = {
+        url: inkstoneConfig.baseUrl + ENDPOINTS.PROJECT_CREATE,
+        headers: _.extend(baseHeaders, {
+          Authorization: `INKSTONE auth_token="${authToken}"`,
+        }),
+        json: params,
+      };
+
+      request.put(options, (err, httpResponse, body) => {
         if (httpResponse && httpResponse.statusCode === 200) {
           const project = body as Project;
           cb(undefined, project, httpResponse);
@@ -528,6 +560,25 @@ export namespace inkstone {
     export function getByName(authToken: string, name: string, cb: inkstone.Callback<ProjectAndCredentials>) {
       const options: requestLib.UrlOptions & requestLib.CoreOptions = {
         url: inkstoneConfig.baseUrl + ENDPOINTS.PROJECT_GET_BY_NAME.replace(':NAME', encodeURIComponent(name)),
+        headers: _.extend(baseHeaders, {
+          Authorization: `INKSTONE auth_token="${authToken}"`,
+        }),
+      };
+
+      request.get(options, (err, httpResponse, body) => {
+        if (httpResponse && httpResponse.statusCode === 200) {
+          const project = JSON.parse(body) as ProjectAndCredentials;
+          cb(undefined, project, httpResponse);
+        } else {
+          cb(safeError(err), undefined, httpResponse);
+        }
+      });
+    }
+
+    export function getByUniqueId(authToken: string, uniqueId: string, cb: inkstone.Callback<ProjectAndCredentials>) {
+      const options: requestLib.UrlOptions & requestLib.CoreOptions = {
+        url: inkstoneConfig.baseUrl +
+          ENDPOINTS.PROJECT_GET_BY_UNIQUE_ID.replace(':UNIQUE_ID', encodeURIComponent(uniqueId)),
         headers: _.extend(baseHeaders, {
           Authorization: `INKSTONE auth_token="${authToken}"`,
         }),

--- a/packages/@haiku/sdk-inkstone/src/index.ts
+++ b/packages/@haiku/sdk-inkstone/src/index.ts
@@ -522,7 +522,7 @@ export namespace inkstone {
 
     export function update(authToken: string, params: ProjectUpdateParams, cb: inkstone.Callback<Project>) {
       const options: requestLib.UrlOptions & requestLib.CoreOptions = {
-        url: inkstoneConfig.baseUrl + ENDPOINTS.PROJECT_CREATE,
+        url: inkstoneConfig.baseUrl + ENDPOINTS.PROJECT_UPDATE,
         headers: _.extend(baseHeaders, {
           Authorization: `INKSTONE auth_token="${authToken}"`,
         }),

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -29,6 +29,7 @@ import { EXPORTER_CHANNEL, ExporterFormat } from 'haiku-sdk-creator/lib/exporter
 // Note that `User` is imported below for type discovery
 // (which works even inside JS with supported editors, using jsdoc type annotations)
 import { USER_CHANNEL, User } from 'haiku-sdk-creator/lib/bll/User' // eslint-disable-line no-unused-vars
+import { PROJECT_CHANNEL } from 'haiku-sdk-creator/lib/bll/Project' // eslint-disable-line no-unused-vars
 import { GLASS_CHANNEL } from 'haiku-sdk-creator/lib/glass'
 import { InteractionMode, isPreviewMode } from '@haiku/core/lib/helpers/interactionModes'
 import Palette from 'haiku-ui-common/lib/Palette'
@@ -424,6 +425,13 @@ export default class Creator extends React.Component {
       (user) => {
         this.user = user
         this.handleEnvoyUserReady()
+      }
+    )
+
+    this.envoyClient.get(PROJECT_CHANNEL).then(
+      (project) => {
+        this.setState({envoyProject: project})
+        // this.handleEnvoyProjectReady()
       }
     )
 
@@ -1206,6 +1214,7 @@ export default class Creator extends React.Component {
                   <Stage
                     ref='stage'
                     folder={this.state.projectFolder}
+                    envoyProject={this.state.envoyProject}
                     projectModel={this.state.projectModel}
                     envoyClient={this.envoyClient}
                     haiku={this.props.haiku}

--- a/packages/haiku-creator/src/react/components/Stage.js
+++ b/packages/haiku-creator/src/react/components/Stage.js
@@ -159,6 +159,7 @@ export default class Stage extends React.Component {
           style={STAGE_BOX_STYLE}>
           <StageTitleBar
             folder={this.props.folder}
+            envoyProject={this.props.envoyProject}
             projectModel={this.props.projectModel}
             websocket={this.props.websocket}
             project={this.props.project}

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -574,6 +574,7 @@ class StageTitleBar extends React.Component {
 
         {experimentIsEnabled(Experiment.NewPublishUI) && this.state.showSharePopover && !this.props.isPreviewMode &&
           <ShareModal
+            envoyProject={this.props.envoyProject}
             project={this.props.project}
             snapshotSaveConfirmed={this.state.snapshotSaveConfirmed}
             isSnapshotSaveInProgress={this.state.isSnapshotSaveInProgress}

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -13,6 +13,7 @@ import EnvoyServer from 'haiku-sdk-creator/lib/envoy/EnvoyServer'
 import EnvoyLogger from 'haiku-sdk-creator/lib/envoy/EnvoyLogger'
 import { EXPORTER_CHANNEL, ExporterHandler } from 'haiku-sdk-creator/lib/exporter'
 import { USER_CHANNEL, UserHandler } from 'haiku-sdk-creator/lib/bll/User'
+import { PROJECT_CHANNEL, ProjectHandler } from 'haiku-sdk-creator/lib/bll/Project'
 import { GLASS_CHANNEL, GlassHandler } from 'haiku-sdk-creator/lib/glass'
 import { TimelineHandler } from 'haiku-sdk-creator/lib/timeline'
 import { TourHandler } from 'haiku-sdk-creator/lib/tour'
@@ -220,12 +221,14 @@ export default class Plumbing extends StateObject {
       const envoyExporterHandler = new ExporterHandler(this.envoyServer)
       const envoyGlassHandler = new GlassHandler(this.envoyServer)
       const envoyUserHandler = new UserHandler(this.envoyServer)
+      const envoyProjectHandler = new ProjectHandler(this.envoyServer)
 
       this.envoyServer.bindHandler('timeline', TimelineHandler, envoyTimelineHandler)
       this.envoyServer.bindHandler('tour', TourHandler, envoyTourHandler)
       this.envoyServer.bindHandler(EXPORTER_CHANNEL, ExporterHandler, envoyExporterHandler)
       this.envoyServer.bindHandler(USER_CHANNEL, UserHandler, envoyUserHandler)
       this.envoyServer.bindHandler(GLASS_CHANNEL, GlassHandler, envoyGlassHandler)
+      this.envoyServer.bindHandler(PROJECT_CHANNEL, ProjectHandler, envoyProjectHandler)
 
       logger.info('[plumbing] launching plumbing control server')
 

--- a/packages/haiku-sdk-creator/src/bll/Project.ts
+++ b/packages/haiku-sdk-creator/src/bll/Project.ts
@@ -1,0 +1,52 @@
+import { inkstone } from '@haiku/sdk-inkstone';
+import { client as sdkClient } from '@haiku/sdk-client';
+import { MaybeAsync } from '../envoy';
+
+import { Registry } from '../dal/Registry';
+
+export interface Project {
+  setIsPublic: (uniqueId:string, isPublic:boolean) => MaybeAsync<inkstone.project.Project>;
+  getProjectDetail: (uniqueId:string) => Promise<inkstone.project.Project>;
+}
+
+export const PROJECT_CHANNEL = 'project';
+
+export class ProjectHandler implements Project {
+
+  constructor() {
+    inkstone.setConfig({
+      baseUrl: process.env.HAIKU_API,
+    });
+  }
+
+  getProjectDetail(uniqueId: string) : Promise<inkstone.project.Project> {
+    return new Promise<inkstone.project.Project>((resolve, reject) => {
+      inkstone.project.getByUniqueId(sdkClient.config.getAuthToken(), uniqueId, (error, project) => {
+        if (!error) {
+          resolve(project.Project);
+        } else {
+          reject(error);
+        }
+      });
+    });
+  }
+
+  setIsPublic(uniqueId: string, isPublic: boolean) : Promise<inkstone.project.Project> {
+    return new Promise<inkstone.project.Project>((resolve, reject) => {
+      const params : inkstone.project.ProjectUpdateParams = {UniqueId: uniqueId};
+      if (isPublic) {
+        params.MakePublic = true;
+      } else {
+        params.MakePrivate = true;
+      }
+      inkstone.project.update(sdkClient.config.getAuthToken(), params, (error, project) => {
+        if (!error) {
+          resolve(project);
+        } else {
+          reject(error);
+        }
+      });
+    });
+  }
+
+}

--- a/packages/haiku-sdk-creator/src/bll/Project.ts
+++ b/packages/haiku-sdk-creator/src/bll/Project.ts
@@ -14,9 +14,11 @@ export const PROJECT_CHANNEL = 'project';
 export class ProjectHandler implements Project {
 
   constructor() {
-    inkstone.setConfig({
-      baseUrl: process.env.HAIKU_API,
-    });
+    if (process.env.HAIKU_API) {
+      inkstone.setConfig({
+        baseUrl: process.env.HAIKU_API,
+      });
+    }
   }
 
   getProjectDetail(uniqueId: string) : Promise<inkstone.project.Project> {

--- a/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as assign from 'lodash.assign';
 import Palette from '../../Palette';
 import {LinkHolster} from './LinkHolster';
 
@@ -19,12 +20,49 @@ const STYLES = {
     margin: '0',
     fontStyle: 'italic',
     lineHeight: '1.2em',
-    paddingRight: 33,
   } as React.CSSProperties,
+  infoSpecial: {
+    width: '120%',
+    float: 'right',
+    textAlign: 'right'
+  },
+  infoSpecial2: {
+    width: '62%',
+    float: 'right',
+    textAlign: 'right',
+    marginTop: 10
+  },
   label: {
     textTransform: 'uppercase',
     color: Palette.DARK_ROCK,
   },
+  toggle: {
+    display: 'inline-block',
+    float: 'right',
+    cursor: 'pointer',
+    width: 34,
+    height: 16,
+    backgroundColor: Palette.GRAY,
+    borderRadius: 16,
+    position: 'relative',
+    marginTop: 8,
+    marginLeft: 7
+  } as React.CSSProperties,
+  knob: {
+    display: 'inline-block',
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    width: 16,
+    height: 16,
+    borderRadius: 16,
+    backgroundColor: Palette.DARKER_ROCK,
+    transition: 'transform 220ms cubic-bezier(0.25, 0.1, 0.29, 1.45)'
+  } as React.CSSProperties,
+  knobActive: {
+    backgroundColor: Palette.LIGHTEST_PINK,
+    transform: 'translateX(-18px)'
+  }
 };
 
 export class ProjectShareDetails extends React.PureComponent {
@@ -44,6 +82,8 @@ export class ProjectShareDetails extends React.PureComponent {
       linkAddress,
       isSnapshotSaveInProgress,
       onHide,
+      isPublic,
+      togglePublic
     } = this.props;
 
     return (
@@ -68,7 +108,16 @@ export class ProjectShareDetails extends React.PureComponent {
             isSnapshotSaveInProgress={isSnapshotSaveInProgress}
             linkAddress={linkAddress}
           />
-          <p style={STYLES.info}>Anyone with the link can <strong>view and install</strong> your project.</p>
+          <p style={assign({}, {...STYLES.info, ...STYLES.infoSpecial})}>
+            Anyone with the link can <strong>view and install</strong> your project.
+          </p>
+
+          <span style={STYLES.toggle} onClick={togglePublic}>
+            <span style={assign({}, {...STYLES.knob, ...(isPublic && STYLES.knobActive)})}/>
+          </span>
+          <span style={assign({}, {...STYLES.info, ...STYLES.infoSpecial2})}>
+            Display on community profile
+          </span>
         </div>
       </div>
     );

--- a/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as assign from 'lodash.assign';
 import Palette from '../../Palette';
+import {TooltipBasic} from '../TooltipBasic';
 import {LinkHolster} from './LinkHolster';
 
 const STYLES = {
@@ -16,6 +17,7 @@ const STYLES = {
   },
   info: {
     color: Palette.PALE_GRAY,
+    cursor: 'default',
     fontSize: '10px',
     margin: '0',
     fontStyle: 'italic',
@@ -31,6 +33,8 @@ const STYLES = {
     float: 'right',
     textAlign: 'right',
     marginTop: 10,
+    position: 'relative',
+    userSelect: 'none'
   },
   label: {
     textTransform: 'uppercase',
@@ -84,6 +88,8 @@ export class ProjectShareDetails extends React.PureComponent {
       onHide,
       isPublic,
       togglePublic,
+      showTooltip,
+      toggleTooltip
     } = this.props;
 
     return (
@@ -115,8 +121,23 @@ export class ProjectShareDetails extends React.PureComponent {
           <span style={STYLES.toggle} onClick={togglePublic}>
             <span style={assign({}, {...STYLES.knob, ...(isPublic && STYLES.knobActive)})}/>
           </span>
-          <span style={assign({}, {...STYLES.info, ...STYLES.infoSpecial2})}>
+          <span
+            style={assign({}, {...STYLES.info, ...STYLES.infoSpecial2})}
+            onMouseEnter={toggleTooltip}
+            onMouseLeave={toggleTooltip}>
             Display on community profile
+            {showTooltip &&
+              <TooltipBasic light={true} top={17}>
+                {isPublic
+                  ? (<p style={{fontStyle: 'normal'}}>Project is visible on your public profile (coming soon),
+                    and may be selected to be featured on the Haiku Community.
+                    </p>)
+                  : (<p style={{fontStyle: 'normal'}}>Project is not visible on your public profile (coming soon),
+                    nor eligible to be featured on the Haiku Community.
+                    </p>)
+                 }
+              </TooltipBasic>
+            }
           </span>
         </div>
       </div>

--- a/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
@@ -62,10 +62,10 @@ const STYLES = {
   } as React.CSSProperties,
   toggleLabel: {
     width: 47,
-    display: 'inline-block'
+    display: 'inline-block',
   } as React.CSSProperties,
   toggleActive: {
-    backgroundColor: Color(Palette.LIGHTEST_PINK).fade(.5)
+    backgroundColor: Color(Palette.LIGHTEST_PINK).fade(.5),
   } as React.CSSProperties,
   knob: {
     display: 'inline-block',

--- a/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as assign from 'lodash.assign';
+import * as Color from 'color';
 import Palette from '../../Palette';
 import {LinkHolster} from './LinkHolster';
 
@@ -59,11 +60,18 @@ const STYLES = {
     marginTop: 10,
     marginLeft: 10,
   } as React.CSSProperties,
+  toggleLabel: {
+    width: 47,
+    display: 'inline-block'
+  } as React.CSSProperties,
+  toggleActive: {
+    backgroundColor: Color(Palette.LIGHTEST_PINK).fade(.5)
+  } as React.CSSProperties,
   knob: {
     display: 'inline-block',
     position: 'absolute',
     top: 0,
-    right: 0,
+    left: 0,
     width: 16,
     height: 16,
     borderRadius: 16,
@@ -72,7 +80,7 @@ const STYLES = {
   } as React.CSSProperties,
   knobActive: {
     backgroundColor: Palette.LIGHTEST_PINK,
-    transform: 'translateX(-18px)',
+    transform: 'translateX(18px)',
   },
   disabledToggle: {
     opacity: .5,
@@ -115,16 +123,18 @@ export class ProjectShareDetails extends React.PureComponent {
           ) : (
             <p style={{height: 16, ...STYLES.info}} />
           )}
-          
+
           <span
             style={assign({}, {...STYLES.info, ...STYLES.infoSpecial2})} >
-            <span id="public-private-label" style={this.props.isDisabled ? STYLES.disabledToggle : {}}>
+            <span
+              id="public-private-label"
+              style={this.props.isDisabled ? STYLES.disabledToggle : STYLES.toggleLabel}>
               {this.props.isPublic ? 'Public' : 'Private'}
             </span>
-            
-           
           </span>
-          <span style={STYLES.toggle} onClick={() => {!this.props.isDisabled && togglePublic();}}>
+          <span
+            style={assign({}, {...STYLES.toggle, ...(isPublic && STYLES.toggleActive)})}
+            onClick={() => {!this.props.isDisabled && togglePublic();}}>
               <span style={assign({}, {...STYLES.knob, ...(isPublic && STYLES.knobActive)})}/>
           </span>
         </div>

--- a/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
@@ -24,13 +24,13 @@ const STYLES = {
   infoSpecial: {
     width: '120%',
     float: 'right',
-    textAlign: 'right'
+    textAlign: 'right',
   },
   infoSpecial2: {
     width: '62%',
     float: 'right',
     textAlign: 'right',
-    marginTop: 10
+    marginTop: 10,
   },
   label: {
     textTransform: 'uppercase',
@@ -46,7 +46,7 @@ const STYLES = {
     borderRadius: 16,
     position: 'relative',
     marginTop: 8,
-    marginLeft: 7
+    marginLeft: 7,
   } as React.CSSProperties,
   knob: {
     display: 'inline-block',
@@ -57,12 +57,12 @@ const STYLES = {
     height: 16,
     borderRadius: 16,
     backgroundColor: Palette.DARKER_ROCK,
-    transition: 'transform 220ms cubic-bezier(0.25, 0.1, 0.29, 1.45)'
+    transition: 'transform 220ms cubic-bezier(0.25, 0.1, 0.29, 1.45)',
   } as React.CSSProperties,
   knobActive: {
     backgroundColor: Palette.LIGHTEST_PINK,
-    transform: 'translateX(-18px)'
-  }
+    transform: 'translateX(-18px)',
+  },
 };
 
 export class ProjectShareDetails extends React.PureComponent {
@@ -83,7 +83,7 @@ export class ProjectShareDetails extends React.PureComponent {
       isSnapshotSaveInProgress,
       onHide,
       isPublic,
-      togglePublic
+      togglePublic,
     } = this.props;
 
     return (

--- a/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
@@ -95,6 +95,8 @@ export class ProjectShareDetails extends React.PureComponent {
     projectName: React.PropTypes.string,
     linkAddress: React.PropTypes.string,
     isSnapshotSaveInProgress: React.PropTypes.bool,
+    isPublic: React.PropTypes.bool,
+    togglePublic: React.PropTypes.func,
   };
 
   render() {

--- a/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
@@ -34,7 +34,7 @@ const STYLES = {
     textAlign: 'right',
     marginTop: 10,
     position: 'relative',
-    userSelect: 'none'
+    userSelect: 'none',
   },
   label: {
     textTransform: 'uppercase',
@@ -89,7 +89,7 @@ export class ProjectShareDetails extends React.PureComponent {
       isPublic,
       togglePublic,
       showTooltip,
-      toggleTooltip
+      toggleTooltip,
     } = this.props;
 
     return (

--- a/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as assign from 'lodash.assign';
 import Palette from '../../Palette';
-import {TooltipBasic} from '../TooltipBasic';
 import {LinkHolster} from './LinkHolster';
 
 const STYLES = {
@@ -23,15 +22,23 @@ const STYLES = {
     fontStyle: 'italic',
     lineHeight: '1.2em',
   } as React.CSSProperties,
+  infoHeading: {
+    float: 'left',
+    textAlign: 'left',
+    width: '100%',
+    fontSize: '12px',
+    marginBottom: 4,
+    display: 'block',
+  },
   infoSpecial: {
     width: '120%',
-    float: 'right',
-    textAlign: 'right',
+    float: 'left',
+    textAlign: 'left',
   },
   infoSpecial2: {
-    width: '62%',
-    float: 'right',
-    textAlign: 'right',
+    float: 'left',
+    fontSize: 14,
+    textAlign: 'left',
     marginTop: 10,
     position: 'relative',
     userSelect: 'none',
@@ -42,15 +49,15 @@ const STYLES = {
   },
   toggle: {
     display: 'inline-block',
-    float: 'right',
+    float: 'left',
     cursor: 'pointer',
     width: 34,
     height: 16,
     backgroundColor: Palette.GRAY,
     borderRadius: 16,
     position: 'relative',
-    marginTop: 8,
-    marginLeft: 7,
+    marginTop: 10,
+    marginLeft: 10,
   } as React.CSSProperties,
   knob: {
     display: 'inline-block',
@@ -66,6 +73,9 @@ const STYLES = {
   knobActive: {
     backgroundColor: Palette.LIGHTEST_PINK,
     transform: 'translateX(-18px)',
+  },
+  disabledToggle: {
+    opacity: .5,
   },
 };
 
@@ -88,8 +98,6 @@ export class ProjectShareDetails extends React.PureComponent {
       onHide,
       isPublic,
       togglePublic,
-      showTooltip,
-      toggleTooltip,
     } = this.props;
 
     return (
@@ -107,38 +115,41 @@ export class ProjectShareDetails extends React.PureComponent {
           ) : (
             <p style={{height: 16, ...STYLES.info}} />
           )}
+          
+          <span
+            style={assign({}, {...STYLES.info, ...STYLES.infoSpecial2})} >
+            <span id="public-private-label" style={this.props.isDisabled ? STYLES.disabledToggle : {}}>
+              {this.props.isPublic ? 'Public' : 'Private'}
+            </span>
+            
+           
+          </span>
+          <span style={STYLES.toggle} onClick={() => {!this.props.isDisabled && togglePublic();}}>
+              <span style={assign({}, {...STYLES.knob, ...(isPublic && STYLES.knobActive)})}/>
+          </span>
         </div>
 
         <div style={{width: '50%'}}>
+          <p style={assign({}, {...STYLES.info, ...STYLES.infoHeading})}>
+            <strong>Shareable link:</strong>
+          </p>
           <LinkHolster
             isSnapshotSaveInProgress={isSnapshotSaveInProgress}
             linkAddress={linkAddress}
           />
-          <p style={assign({}, {...STYLES.info, ...STYLES.infoSpecial})}>
-            Anyone with the link can <strong>view and install</strong> your project.
-          </p>
-
-          <span style={STYLES.toggle} onClick={togglePublic}>
-            <span style={assign({}, {...STYLES.knob, ...(isPublic && STYLES.knobActive)})}/>
-          </span>
-          <span
-            style={assign({}, {...STYLES.info, ...STYLES.infoSpecial2})}
-            onMouseEnter={toggleTooltip}
-            onMouseLeave={toggleTooltip}>
-            Display on community profile
-            {showTooltip &&
-              <TooltipBasic light={true} top={17}>
-                {isPublic
-                  ? (<p style={{fontStyle: 'normal'}}>Project is visible on your public profile (coming soon),
-                    and may be selected to be featured on the Haiku Community.
-                    </p>)
-                  : (<p style={{fontStyle: 'normal'}}>Project is not visible on your public profile (coming soon),
-                    nor eligible to be featured on the Haiku Community.
-                    </p>)
-                 }
-              </TooltipBasic>
-            }
-          </span>
+          {
+            !this.props.isDisabled &&
+            <p style={assign({}, {...STYLES.info, ...STYLES.infoSpecial})}>
+              Anyone&nbsp;
+              {
+                !this.props.isPublic && <span>with the link&nbsp;</span>
+              }
+              <strong>can view and install</strong> your project&nbsp;
+              {
+                this.props.isPublic && <span><br />from your public profile</span> /*TODO: link to public profile */
+              }
+            </p>
+          }
         </div>
       </div>
     );

--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -49,8 +49,10 @@ export class ShareModal extends React.Component {
     this.state = {
       showDetail: false,
       isPublic: false,
+      showTooltip: false,
     };
     this.togglePublic = this.togglePublic.bind(this);
+    this.toggleTooltip = this.toggleTooltip.bind(this);
   }
 
   componentWillReceiveProps({error, isSnapshotSaveInProgress}) {
@@ -73,6 +75,10 @@ export class ShareModal extends React.Component {
 
   togglePublic () {
     this.setState({isPublic: !this.state.isPublic});
+  }
+
+  toggleTooltip () {
+    this.setState({showTooltip: !this.state.showTooltip});
   }
 
   render () {
@@ -103,6 +109,8 @@ export class ShareModal extends React.Component {
             isSnapshotSaveInProgress={isSnapshotSaveInProgress}
             isPublic={this.state.isPublic}
             togglePublic={this.togglePublic}
+            toggleTooltip={this.toggleTooltip}
+            showTooltip={this.state.showTooltip}
           />
         </ModalHeader>
 

--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -63,8 +63,6 @@ export class ShareModal extends React.Component<PropTypes, StateTypes> {
       showTooltip: false,
       isPublicKnown: false,
     };
-    this.togglePublic = this.togglePublic.bind(this);
-    this.toggleTooltip = this.toggleTooltip.bind(this);
   }
 
   componentWillReceiveProps(nextProps:PropTypes) {
@@ -115,10 +113,6 @@ export class ShareModal extends React.Component<PropTypes, StateTypes> {
     }
   }
 
-  toggleTooltip () {
-    this.setState({showTooltip: !this.state.showTooltip});
-  }
-
   render () {
     const {
       project,
@@ -147,9 +141,7 @@ export class ShareModal extends React.Component<PropTypes, StateTypes> {
             isProjectInfoFetchInProgress={isProjectInfoFetchInProgress}
             isSnapshotSaveInProgress={isSnapshotSaveInProgress}
             isPublic={this.state.isPublic}
-            togglePublic={this.togglePublic}
-            toggleTooltip={this.toggleTooltip}
-            showTooltip={this.state.showTooltip}
+            togglePublic={() => this.togglePublic()}
           />
         </ModalHeader>
 

--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -48,9 +48,9 @@ export class ShareModal extends React.Component {
 
     this.state = {
       showDetail: false,
-      isPublic: false
+      isPublic: false,
     };
-    this.togglePublic = this.togglePublic.bind(this)
+    this.togglePublic = this.togglePublic.bind(this);
   }
 
   componentWillReceiveProps({error, isSnapshotSaveInProgress}) {
@@ -72,7 +72,7 @@ export class ShareModal extends React.Component {
   }
 
   togglePublic () {
-    this.setState({isPublic: !this.state.isPublic})
+    this.setState({isPublic: !this.state.isPublic});
   }
 
   render () {

--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -48,7 +48,9 @@ export class ShareModal extends React.Component {
 
     this.state = {
       showDetail: false,
+      isPublic: false
     };
+    this.togglePublic = this.togglePublic.bind(this)
   }
 
   componentWillReceiveProps({error, isSnapshotSaveInProgress}) {
@@ -67,6 +69,10 @@ export class ShareModal extends React.Component {
 
   hideDetails () {
     this.setState({showDetail: false, selectedEntry: null});
+  }
+
+  togglePublic () {
+    this.setState({isPublic: !this.state.isPublic})
   }
 
   render () {
@@ -95,6 +101,8 @@ export class ShareModal extends React.Component {
             linkAddress={linkAddress}
             isProjectInfoFetchInProgress={isProjectInfoFetchInProgress}
             isSnapshotSaveInProgress={isSnapshotSaveInProgress}
+            isPublic={this.state.isPublic}
+            togglePublic={this.togglePublic}
           />
         </ModalHeader>
 

--- a/packages/haiku-ui-common/src/react/TooltipBasic.tsx
+++ b/packages/haiku-ui-common/src/react/TooltipBasic.tsx
@@ -38,7 +38,7 @@ const STYLES = {
     borderBottom: '5px solid ' + Palette.DARKEST_COAL,
   } as React.CSSProperties,
   light: {
-    backgroundColor: Palette.BLUE
+    backgroundColor: Palette.BLUE,
   } as React.CSSProperties,
   tipLight: {
     borderBottom: '5px solid ' + Palette.BLUE,
@@ -59,7 +59,7 @@ export class TooltipBasic extends React.PureComponent {
         assign({}, {
           ...STYLES.tooltip,
           ...(this.props.light && STYLES.light),
-          ...{top: this.props.top}
+          ...{top: this.props.top},
         })}>
         <span style={assign({}, {...STYLES.tip, ...(this.props.light && STYLES.tipLight)})} />
         {this.props.children}

--- a/packages/haiku-ui-common/src/react/TooltipBasic.tsx
+++ b/packages/haiku-ui-common/src/react/TooltipBasic.tsx
@@ -1,16 +1,29 @@
 import * as React from 'react';
 import Palette from '../Palette';
+import * as assign from 'lodash.assign';
+
+/*
+  This component is very rudimentary atm and needs to be fleshed out for
+  dynamic arrow positioning.
+
+  GOTCHA-warning: note that with the current implementation whatever element
+  this is included within must have position relative.
+
+*/
 
 const STYLES = {
   tooltip: {
     position: 'absolute',
-    bottom: '-17px',
+    zIndex: 2000,
     left: '50%',
+    top: 34,
     transform: 'translateX(-50%)',
     borderRadius: '3px',
     width: '100%',
+    padding: '0 4px',
     textAlign: 'center',
     backgroundColor: Palette.DARKEST_COAL,
+    borderColor: Palette.DARKEST_COAL,
     boxShadow: '0 2px 7px 0 rgba(0,0,0,.3)',
   } as React.CSSProperties,
   tip: {
@@ -22,15 +35,33 @@ const STYLES = {
     height: 0,
     borderLeft: '5px solid transparent',
     borderRight: '5px solid transparent',
-    borderBottom: '5px solid' + Palette.DARKEST_COAL,
+    borderBottom: '5px solid ' + Palette.DARKEST_COAL,
+  } as React.CSSProperties,
+  light: {
+    backgroundColor: Palette.BLUE
+  } as React.CSSProperties,
+  tipLight: {
+    borderBottom: '5px solid ' + Palette.BLUE,
   } as React.CSSProperties,
 };
 
 export class TooltipBasic extends React.PureComponent {
+  props;
+
+  static propTypes = {
+    light: React.PropTypes.bool,
+    top: React.PropTypes.number,
+  };
+
   render () {
     return (
-      <div style={STYLES.tooltip}>
-        <span style={STYLES.tip} />
+      <div style={
+        assign({}, {
+          ...STYLES.tooltip,
+          ...(this.props.light && STYLES.light),
+          ...{top: this.props.top}
+        })}>
+        <span style={assign({}, {...STYLES.tip, ...(this.props.light && STYLES.tipLight)})} />
         {this.props.children}
       </div>
     );


### PR DESCRIPTION
Do not merge. So far only the UI is created for this. We still need the following functionality (to be created by someone other than myself [that task here](https://app.asana.com/0/548868462189817/571204757867885)):
* Read if project has been set to 'public' previously. If not, then — when they open the publish UI, set the project to public. This way we can default to 'public' going forward (when this ui is in place) without backfilling older projects with a 'public' setting (seems invasive/undesired).
* When the setting in the UI is toggled, it needs to store the setting to the project, so that it can be remembered for next time. E.g. if I've set my project to private, next time I open the publish modal, it should still be private.


Short review.
![](https://d2ffutrenqvap3.cloudfront.net/items/462F462a1M2x0T371o2i/Image%202018-02-23%20at%205.09.00%20PM.png?v=a6cada12)
[The UI Task](https://app.asana.com/0/548868462189817/567843326852816)
Give the user the ability to change whether or they'd like their project to be visible on their public profile (user profiles coming soon). This will also allow us, as admin, to scope out which public, user projects are worth curating onto our public gallery.



Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [ ] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
