### PR TITLE
fix: layout on pub ui for long proj names

### DIFF
--- a/packages/haiku-creator/src/TopMenu.js
+++ b/packages/haiku-creator/src/TopMenu.js
@@ -226,6 +226,17 @@ export default class TopMenu extends EventEmitter {
         submenu: developerMenuItems
       },
       {
+        label: 'Community',
+        submenu: [
+          {
+            label: 'Haiku Community on Slack',
+            click: () => {
+              shell.openExternal('https://join.slack.com/t/haiku-community/shared_invite/enQtMjU0NzExMzQzMjIxLTA3NjgzZDYzYmNjYzcxNmUwY2NhMTE0YTE2OGVjZGE0MDhmNGIxOWUzOTk5OTI5MmQ0ZjA5MDAwNGY1Yjk1OTg')
+            }
+          }
+        ]
+      },
+      {
         label: 'Help',
         submenu: [
           {
@@ -252,13 +263,6 @@ export default class TopMenu extends EventEmitter {
             label: 'Privacy Policy',
             click: () => {
               shell.openExternal('https://www.haiku.ai/privacy-policy.html')
-            }
-          },
-          { type: 'separator' },
-          {
-            label: 'Haiku Community on Slack',
-            click: () => {
-              shell.openExternal('https://join.slack.com/t/haiku-community/shared_invite/enQtMjU0NzExMzQzMjIxLTA3NjgzZDYzYmNjYzcxNmUwY2NhMTE0YTE2OGVjZGE0MDhmNGIxOWUzOTk5OTI5MmQ0ZjA5MDAwNGY1Yjk1OTg')
             }
           }
         ]

--- a/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
@@ -14,7 +14,7 @@ const STYLES = {
     margin: '0',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
-  },
+  } as React.CSSProperties,
   info: {
     color: Palette.PALE_GRAY,
     fontSize: '10px',

--- a/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
@@ -12,6 +12,8 @@ const STYLES = {
     color: Palette.PALE_GRAY,
     fontSize: '18px',
     margin: '0',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
   info: {
     color: Palette.PALE_GRAY,
@@ -48,7 +50,7 @@ export class ProjectShareDetails extends React.PureComponent {
 
     return (
       <div style={STYLES.wrapper}>
-        <div>
+        <div style={{maxWidth: '50%'}}>
           <h2 style={STYLES.title}>{projectName}</h2>
           <p style={STYLES.info}>
             <span style={STYLES.label}>ID</span> {projectName}


### PR DESCRIPTION
OK to merge.

Fixes: Projects with long names break publish UI
https://app.asana.com/0/548868462189817/570991402187999

Graduates Slack out of "Help" and into its own "Community" heading in the top menu
https://app.asana.com/0/548868462189817/572720542800356

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [ ] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
