### PR TITLE
chore: use const enum for the color Palette

### DIFF
--- a/packages/haiku-ui-common/src/Palette.ts
+++ b/packages/haiku-ui-common/src/Palette.ts
@@ -1,41 +1,43 @@
-export default {
-  COAL: 'rgb(33,45,49)',
-  DARK_BLUE: 'rgb(19,106,136)',
-  DARK_GRAY: 'rgb(47, 57, 60)',
-  DARK_ROCK_MUTED2: 'rgba(180, 180, 180, .1)',
-  DARK_ROCK_MUTED: 'rgba(180, 180, 180, .5)',
-  DARKER_GRAY: 'rgb(45,56,58)',
-  DARKER_ROCK2: 'rgb(127, 134, 136)',
-  DARKER_ROCK: 'rgb(180, 180, 180)',
-  FATHER_COAL: 'rgb(21, 32, 34)',
-  GRAY: 'rgb(52,63,65)',
-  GREEN: 'rgb(120, 216, 10)',
-  LIGHT_BLUE: 'rgb(38,145,173)',
-  LIGHT_GRAY: 'rgb(59, 71, 74)',
-  LIGHT_PINK: 'rgb(205,49,114)',
-  LIGHTER_GRAY: 'rgb(62,72,74)',
-  LIGHTEST_GRAY: 'rgb(77, 89, 92)',
-  LIGHTEST_PINK: '#DE5082',
-  MEDIUM_COAL: 'rgb(39,49,51)',
-  MEDIUM_PINK: 'rgb(190, 27, 86)',
-  ORANGE: 'rgb(242, 148, 29)',
-  ORANGE_SUBDUED: 'rgb(192, 128, 19)',
-  PINK: 'rgb(167,22,73)',
-  RED: 'rgb(242, 29, 29)',
-  RED_DARKER: 'rgb(182, 29, 29)',
-  SHADY: 'rgba(21, 32, 34, .3)',
+const enum Palette {
+  COAL = 'rgb(33,45,49)',
+  DARK_BLUE = 'rgb(19,106,136)',
+  DARK_GRAY = 'rgb(47, 57, 60)',
+  DARK_ROCK_MUTED2 = 'rgba(180, 180, 180, .1)',
+  DARK_ROCK_MUTED = 'rgba(180, 180, 180, .5)',
+  DARKER_GRAY = 'rgb(45,56,58)',
+  DARKER_ROCK2 = 'rgb(127, 134, 136)',
+  DARKER_ROCK = 'rgb(180, 180, 180)',
+  FATHER_COAL = 'rgb(21, 32, 34)',
+  GRAY = 'rgb(52,63,65)',
+  GREEN = 'rgb(120, 216, 10)',
+  LIGHT_BLUE = 'rgb(38,145,173)',
+  LIGHT_GRAY = 'rgb(59, 71, 74)',
+  LIGHT_PINK = 'rgb(205,49,114)',
+  LIGHTER_GRAY = 'rgb(62,72,74)',
+  LIGHTEST_GRAY = 'rgb(77, 89, 92)',
+  LIGHTEST_PINK = '#DE5082',
+  MEDIUM_COAL = 'rgb(39,49,51)',
+  MEDIUM_PINK = 'rgb(190, 27, 86)',
+  ORANGE = 'rgb(242, 148, 29)',
+  ORANGE_SUBDUED = 'rgb(192, 128, 19)',
+  PINK = 'rgb(167,22,73)',
+  RED = 'rgb(242, 29, 29)',
+  RED_DARKER = 'rgb(182, 29, 29)',
+  SHADY = 'rgba(21, 32, 34, .3)',
 
   // new stuff - prefer these instead!
-  BLACK: '#0C0C0C',
-  BLUE: '#488192',
-  DARK_PINK: '#F03F82', // used in the tour (buttons and UI)
-  DARK_ROCK: '#5B7373',
-  DARKEST_COAL: '#0F171A',
-  GRAY_FIT1: '#405355', // used for tree line
-  PALE_GRAY: '#d1d1d1',
-  ROCK: '#C0CCCD', // Making ROCK a bit colder
-  ROCK_MUTED: '#C0CCCD',
-  SPECIAL_COAL: '#122022',
-  STAGE_GRAY: '#ebebeb',
-  SUNSTONE: 'rgb(254,254,254)', // This is our "white", use sparingly
-};
+  BLACK = '#0C0C0C',
+  BLUE = '#488192',
+  DARK_PINK = '#F03F82', // used in the tour (buttons and UI)
+  DARK_ROCK = '#5B7373',
+  DARKEST_COAL = '#0F171A',
+  GRAY_FIT1 = '#405355', // used for tree line
+  PALE_GRAY = '#d1d1d1',
+  ROCK = '#C0CCCD', // Making ROCK a bit colder
+  ROCK_MUTED = '#C0CCCD',
+  SPECIAL_COAL = '#122022',
+  STAGE_GRAY = '#ebebeb',
+  SUNSTONE = 'rgb(254,254,254)', // This is our "white", use sparingly
+}
+
+export default Palette;


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

This was suggested by @stristr a [long time ago](https://github.com/HaikuTeam/mono/pull/136/files/6df07a2196762172608e469e200d111f1cff5145#r156742748) as will likely come with a minor performance enhancement.

Summary of work (include Asana links if any):

- [x] Use `const enum` for the color palette

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [ ] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
