### PR TITLE
feat: add script to republish all projects from mono.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "add-experiment": "node ./scripts/add-experiment.js",
+    "republish-all-projects": "node ./scripts/republish-all-projects.js",
     "changelog": "node ./scripts/changelog.js",
     "doctor": "node ./scripts/doctor.js",
     "go": "yarn start default",

--- a/scripts/republish-all-projects.js
+++ b/scripts/republish-all-projects.js
@@ -1,0 +1,104 @@
+const { each } = require('async')
+const Plumbing = require('haiku-plumbing/lib/Plumbing').default
+const haikuInfo = require('haiku-plumbing/lib/haikuInfo').default
+const { ExporterFormat } = require('haiku-sdk-creator/lib/exporter')
+
+const log = require('./helpers/log')
+
+const plumbing = new Plumbing()
+
+const saveProject = (projectObject, cb) => {
+  // Give ourselves some time to cool off so our file watchers can detect any changes.
+  // TODO: Remove this after we implement "Wait for all changes to be written in disk before publishing"
+  // @see {@link https://app.asana.com/0/550212203261201/556129196894307/f}
+  setTimeout(() => {
+    plumbing.saveProject(
+      projectObject.projectPath,
+      projectObject.projectName,
+      undefined,
+      undefined,
+      {
+        commitMessage: 'Manual version bump (via mono script republish-all)',
+        saveStrategy: { strategy: 'recursive', favor: 'ours' },
+        exporterFormats: [ExporterFormat.Bodymovin]
+      },
+      cb
+    )
+  }, 5000)
+}
+
+const startProject = (projectObject, cb) => {
+  plumbing.startProject(
+    projectObject.projectName,
+    projectObject.projectPath,
+    (err) => {
+      if (err) {
+        cb(err)
+        return
+      }
+
+      saveProject(projectObject, cb)
+    }
+  )
+}
+
+const republishProject = (projectObject, cb) => {
+  plumbing.initializeProject(
+    projectObject.projectName,
+    projectObject,
+    undefined,
+    undefined,
+    (err) => {
+      if (err) {
+        cb(err)
+        return
+      }
+
+      startProject(projectObject, cb)
+    }
+  )
+}
+
+plumbing.launch({ ...haikuInfo(), mode: 'headless' }, (err) => {
+  if (err) {
+    throw err
+  }
+
+  plumbing.getCurrentOrganizationName((err, organizationName) => {
+    if (err) {
+      throw err
+    }
+
+    log.hat(`currently signed in as ${organizationName}`)
+
+    plumbing.listProjects((err, projects) => {
+      if (err) {
+        throw err
+      }
+
+      each(
+        projects,
+        (project, next) => {
+          republishProject(
+            {
+              ...project,
+              organizationName,
+              skipContentCreation: true
+            },
+            next
+          )
+        },
+        (err) => {
+          if (err) {
+            log.warn('caught error(s) during publish')
+          }
+
+          if (global.haiku && global.haiku.HaikuGlobalAnimationHarness) {
+            global.haiku.HaikuGlobalAnimationHarness.cancel()
+          }
+          plumbing.teardown()
+        }
+      )
+    })
+  })
+})


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- Add a script to republish all projects from mono ([Asana task](https://app.asana.com/0/548868462189817/571405454816276/f))

Notes for reviewers:

- I initially implemented this via the Konami code in Creator's `ProjectBrowser`, and then realized we should probably discuss this as a team before going down that dark road.
- Writing this script ultimately took less time than the last time @taylorpoe and I had to update all the Haiku versions in www, so…should've done this a long time ago.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality