### PR TITLE
tweak: 2018-03-05 changelog fixes

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -1,22 +1,21 @@
 {
-  "version": "3.1.5",
-  "date": "March 2, 2018",
+  "date": "March 5, 2018",
   "sections": {
-    "Fixes": [
-      "Fixed formatting of the code snippets that are displayed when publishing a project",
-      "Improved the behavior of the app when resizing the library and the timeline panels",
-      "Fixed a bug that prevented expressions from continuing to evaluate after the timeline's animation had been paused",
-      "Addex an explicit default font to text elements when placed on stage to make it clear that imported Sketch slices don't retain their assigned local system fonts",
-      "Fixed a bug with the Lottie export that can occur when translation/scale are specified but the orthogonal dimension is not"
-    ],
     "What's new": [
       "Added a help chat widget so you can get faster support while editing inside Haiku (we'll try to respond within 1-2 business days)",
       "Added a \"What's New\" section (click the present icon near the top) so you know what has changed in the latest release",
       "Added the ability to share your project on your Haiku community profile (coming soon)",
       "Added some additional Vue.js bundle files to projects for convenience when importing components into codebases",
-      "Published JavaScript bundles of our framework adapters (react-dom, vue-dom) to our CDN to make it easier to embed in web pages",
+      "Published JavaScript bundles of our Vue adapters to our CDN to make it easier to embed in web pages",
       "Added the ability to delete actions (look for the trash can icon in the action editor window)",
       "Added a missing \"Save\" button to the multi-line expression editor"
+    ],
+    "Fixes": [
+      "Fixed formatting of the code snippets that are displayed when publishing a project",
+      "Improved the behavior of the app when resizing the library and the timeline panels",
+      "Fixed a bug that prevented expressions from continuing to evaluate after the timeline's animation had been paused",
+      "Added an explicit default font to text elements when placed on stage to make it clear that imported Sketch slices don't retain their assigned local system fonts",
+      "Fixed a bug with the Lottie export that can occur when translation/scale are specified but the orthogonal dimension is not"
     ]
   }
 }


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- Quick changelog fixes.

Summary of work (include Asana links if any):

- [x] Fix typo `s/Addex/Added`.
- [x] Put "What's New" before "Fixes".
- [x] Put today's date in release file.