### PR TITLE
tweak: rename republish script and add support for project filter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "add-experiment": "node ./scripts/add-experiment.js",
-    "republish-all-projects": "node ./scripts/republish-all-projects.js",
+    "republish-projects": "node ./scripts/republish-projects.js",
     "changelog": "node ./scripts/changelog.js",
     "doctor": "node ./scripts/doctor.js",
     "go": "yarn start default",

--- a/scripts/republish-projects.js
+++ b/scripts/republish-projects.js
@@ -1,4 +1,6 @@
 const { each } = require('async')
+const { argv } = require('yargs')
+
 const Plumbing = require('haiku-plumbing/lib/Plumbing').default
 const haikuInfo = require('haiku-plumbing/lib/haikuInfo').default
 const { ExporterFormat } = require('haiku-sdk-creator/lib/exporter')
@@ -71,10 +73,14 @@ plumbing.launch({ ...haikuInfo(), mode: 'headless' }, (err) => {
 
     log.hat(`currently signed in as ${organizationName}`)
 
-    plumbing.listProjects((err, projects) => {
+    plumbing.listProjects((err, allProjects) => {
       if (err) {
         throw err
       }
+
+      const projects = argv.onlyProjects
+        ? allProjects.filter(({ projectName }) => argv.onlyProjects.split(',').includes(projectName))
+        : allProjects
 
       each(
         projects,


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- Tweak republish script to allow targeting a comma-separated list of project names instead of blindly republishing all projects.