### PR TITLE
fix: clean up engines in existing package.json files during init

### DIFF
--- a/packages/haiku-plumbing/src/ProjectFolder.js
+++ b/packages/haiku-plumbing/src/ProjectFolder.js
@@ -195,6 +195,9 @@ export function buildProjectContent (_ignoredLegacyArg, projectPath, projectName
       // TODO: Handle this step more gracefully when we are increasing by a major version.
       packageJson.dependencies['@haiku/core'] = `^${haikuCoreVersion}`
 
+      // #LEGACY: some old Haiku in the wild have an engines entry, which causes issues with yarn.
+      delete packageJson.engines
+
       // Write the file assuming we may have made a change in any of the conditions above
       fse.writeJsonSync(dir(projectPath, 'package.json'), packageJson, { spaces: 2 })
     }


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- Remove `engines` from legacy Haiku projects.