### PR TITLE
feat: register the haiku:// protocol in Haiku.app

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "Matthew Trost <matthew@trost.co>",
   "license": "UNLICENSED",
   "scripts": {
+    "test-url": "node ./scripts/test-url.js",
     "add-experiment": "node ./scripts/add-experiment.js",
     "republish-projects": "node ./scripts/republish-projects.js",
     "changelog": "node ./scripts/changelog.js",
@@ -101,7 +102,16 @@
     "electronVersion": "1.8.2",
     "mac": {
       "category": "public.app-category.developer-tools",
-      "target": "zip"
+      "target": [
+        "zip",
+        "dmg"
+      ]
+    },
+    "protocols": {
+      "name": "haiku",
+      "schemes": [
+        "haiku"
+      ]
     },
     "asar": true,
     "asarUnpack": [

--- a/scripts/test-url.js
+++ b/scripts/test-url.js
@@ -1,0 +1,38 @@
+const cp = require('child_process')
+
+const inquirer = require('inquirer')
+const { argv } = require('yargs')
+
+const log = require('./helpers/log')
+
+const isAcceptableUrl = (url) => url.startsWith('haiku://')
+
+log.hat(`Note: you MUST have Haiku running in dev mode (e.g. with \`yarn go\`) to use this command.
+
+If you want to test a URL in the release version of Haiku, simply use \`open haiku://my/url?to=test\``)
+
+let urlToOpen = ''
+
+if (argv._.length > 0) {
+  urlToOpen = argv._[0]
+}
+
+const promptForUrl = () => inquirer.prompt([{
+  type: 'input',
+  name: 'url',
+  message: 'URL to open',
+  default: 'haiku://'
+}]).then(({ url }) => {
+  log.warn('got ' + url)
+  go(url)
+})
+
+const go = (url) => {
+  if (!isAcceptableUrl(url)) {
+    promptForUrl()
+  } else {
+    cp.execSync(`open '${url}' -a Electron.app`)
+  }
+}
+
+go(urlToOpen)


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- Register `haiku://` protocol and testing utils to unblock right-click fork and Figma integration.

Summary of work (include Asana links if any):

- [x] Register `haiku://` protocol.
- [x] Add `.dmg` build output for later user. (`.dmg` looks like [this](https://cl.ly/3c2a1d3T0J3P) and makes it more likely that users will have the protocol registered even if they haven't opened the app yet). (Not done: everything we need to do to start syndicating this, which is a separate effort.)
- [x] Add listener for handled URLs that emits down to webviews.
- [x] Add `yarn test-url` script for testing in dev mode. (To test in release starting from first release that supports `haiku://`, you can just do `open haiku://blah`.)

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
