### PR TITLE
fix: handle controlFlow.placeholder when children are not an array.

### DIFF
--- a/packages/@haiku/core/src/properties/dom/vanities.ts
+++ b/packages/@haiku/core/src/properties/dom/vanities.ts
@@ -875,6 +875,9 @@ const CONTROL_FLOW_VANITIES = {
     //   - Key/value pairs
     if (context.config.children) {
       surrogates = context.config.children;
+      if (!Array.isArray(surrogates)) {
+        surrogates = [surrogates];
+      }
     } else if (context.config.placeholder) {
       surrogates = context.config.placeholder;
     }


### PR DESCRIPTION
Not sure if this is OK to merge.

Short review.

Purpose of changes:

- Address broken placeholder issues on [www PR](https://github.com/HaikuTeam/www.haiku.ai/pull/31).

Summary of work (include Asana links if any):

- [x] Cast `context.config.children` to an array if it resolves to a single React node in the `controlFlow.placeholder` vanity.

Notes for reviewers:

- It does appear that when placeholders randomly stopped working in www, it was actually a regression in core due to `context.config.children` resolving to a single React node instead of a one-length array of React nodes when there is exactly one child. (At least, I confirmed that linking my local `@haiku/core` as the only change to a snapshot of www where it's working causes it to break.) However, I'm not sure if I'm fixing the regression in the right place, because I could not at all figure out where/how `context.config.children` is actually being set!
- It was also sufficient to add another child to the holster: `<RotaHolster><HaiSectOneIllo /><HaiSectOneIllo /></RotaHolster>`. I figured that's not actually what we want to do here.