### PR TITLE
fix: Don't crash if the function signature is something we cannot parse

### DIFF
--- a/packages/@haiku/core/src/reflection/functionToRFO.ts
+++ b/packages/@haiku/core/src/reflection/functionToRFO.ts
@@ -133,7 +133,12 @@ function signatureToParams(signature) {
       clean.push(tokens[i]);
     }
   }
-  return tokensToParams(clean);
+  try {
+    return tokensToParams(clean);
+  } catch (exception) {
+    console.warn(`Unable to parse signature ${signature}`, exception);
+    return [];
+  }
 }
 
 export default function functionToRFO(fn) {


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- Fix crash that occurs when opening projects that include ES6 destructuring parameters.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
