### PR TITLE
tweak: target ES5 for haiku-ui-common for create-react-app support

### DIFF
--- a/packages/haiku-ui-common/tsconfig.json
+++ b/packages/haiku-ui-common/tsconfig.json
@@ -26,7 +26,7 @@
     "rootDir": "src",
     "sourceMap": true,
     "suppressImplicitAnyIndexErrors": true,
-    "target": "ES6",
+    "target": "ES5",
     "types": [
       "node"
     ],


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- Target ES5 in `haiku-ui-common` so we can use `haiku-ui-common` with `create-react-app` :-(