### PR TITLE
fix: use the correct casing on the npm package name in publish modal

### DIFF
--- a/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/NpmInstallable.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/NpmInstallable.tsx
@@ -49,7 +49,7 @@ export class NpmInstallable extends React.PureComponent {
               <code style={PUBLISH_SHARED.code}>
                 {dedent`
                   haiku init
-                  npm i --save @haiku/${organizationName.toLowerCase()}-${projectName}
+                  npm i --save @haiku/${organizationName.toLowerCase()}-${projectName.toLowerCase()}
                 `}
               </code>
             </pre>


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- Fix publish modal to use correct casing in `npm i` instructions.

Completed checkin tasks:

- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
