### PR TITLE
feat: @haiku/sdk-inkstone hookup to get Figma access token.

### DIFF
--- a/packages/@haiku/sdk-inkstone/src/index.ts
+++ b/packages/@haiku/sdk-inkstone/src/index.ts
@@ -30,6 +30,7 @@ const ENDPOINTS = {
   USER_REQUEST_CONFIRM: 'v0/user/resend-confirmation/:email',
   RESET_PASSWORD: 'v0/reset-password',
   RESET_PASSWORD_CLAIM: 'v0/reset-password/:UUID/claim',
+  FIGMA_ACCCESS_TOKEN_GET: 'v0/integrations/figma/token',
 };
 
 let request = requestLib.defaults({
@@ -470,6 +471,34 @@ export namespace inkstone {
 
     export function assembleSnapshotLinkFromSnapshot(snapshot: Snapshot) {
       return `${inkstoneConfig.baseShareUrl}${snapshot.UniqueId}/latest`;
+    }
+  }
+
+  export namespace integrations {
+    export interface AccessTokenResponse {
+      AccessToken: string;
+      RefreshToken: string;
+      ExpiresIn: number;
+    }
+
+    /**
+     * Get a Figma access token using a Figma authorization code.
+     * @param {string} code
+     * @param {inkstone.Callback<inkstone.integrations.AccessTokenResponse>} cb
+     */
+    export function getFigmaAccessToken(code: string, cb: inkstone.Callback<AccessTokenResponse>) {
+      const options: requestLib.UrlOptions & requestLib.CoreOptions = {
+        url: inkstoneConfig.baseUrl + ENDPOINTS.FIGMA_ACCCESS_TOKEN_GET + '?Code=' + encodeURIComponent(code),
+        headers: baseHeaders,
+      };
+
+      request.get(options, (err, httpResponse, body) => {
+        if (httpResponse && httpResponse.statusCode === 200) {
+          cb(undefined, JSON.parse(body) as AccessTokenResponse, httpResponse);
+        } else {
+          cb(safeError(err), undefined, httpResponse);
+        }
+      });
     }
   }
 


### PR DESCRIPTION
OK to merge, but probably better for @roperzh to cherry-pick this commit into his branch and close this PR.

Short review.

Purpose of changes:

- Add finished form of Figma token exchange endpoint to `@haiku/sdk-inkstone`.

The corresponding functionality in Inkstone is added [here](https://github.com/HaikuTeam/inkstone/pull/35/commits/50bfe091d3270e0c9101da75fa3c9759393bfb5b).