### PR TITLE
chore: fix radium warnings

### DIFF
--- a/packages/haiku-creator/src/react/styles/btnShared.js
+++ b/packages/haiku-creator/src/react/styles/btnShared.js
@@ -16,7 +16,7 @@ export const BTN_STYLES = {
     transform: 'scale(1)',
     cursor: 'pointer',
     transition: 'transform 200ms ease',
-    background: Palette.FATHER_COAL,
+    backgroundColor: Palette.FATHER_COAL,
     ':active': {
       transform: 'scale(.8)'
     }


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

The console is full of warning messages, making difficult to focus on important things like useful warnings, errors, and logs. This fixes most of the Radium warnings.

![screen shot 2018-03-14 at 16 06 37](https://user-images.githubusercontent.com/4419992/37425351-ce9d428a-27a1-11e8-828d-3ca668afc51f.png)
