### PR TITLE
proposal: do not close the app on crashes in dev

### DIFF
--- a/packages/haiku-creator/src/entry.js
+++ b/packages/haiku-creator/src/entry.js
@@ -32,8 +32,10 @@ import {remote} from 'electron'
 
     // Give Raven some time to send a crash report before we close
     setTimeout(() => {
-      remote.getCurrentWindow().close()
-    }, (process.env.NODE_ENV === 'production') ? 500 : 50000)
+      if (process.env.NODE_ENV === 'production') {
+        remote.getCurrentWindow().close()
+      }
+    }, 500)
   }
 
   function go () {

--- a/packages/haiku-creator/src/entry.js
+++ b/packages/haiku-creator/src/entry.js
@@ -28,14 +28,12 @@ import {remote} from 'electron'
     if (process.env.NODE_ENV === 'production') {
       _traceKitFormatErrorStack(error)
       window.Raven.captureException(error)
-    }
 
-    // Give Raven some time to send a crash report before we close
-    setTimeout(() => {
-      if (process.env.NODE_ENV === 'production') {
+      // Give Raven some time to send a crash report before we close
+      setTimeout(() => {
         remote.getCurrentWindow().close()
-      }
-    }, 500)
+      }, 500)
+    }
   }
 
   function go () {

--- a/packages/haiku-creator/src/react/components/Stage.js
+++ b/packages/haiku-creator/src/react/components/Stage.js
@@ -94,11 +94,11 @@ export default class Stage extends React.Component {
           // 'Uncaught' indicates an unrecoverable error in Glass, so we need to crash too
           if (event.message.slice(0, 8) === 'Uncaught') {
             // Give the webview's Raven instance time to transmit its crash report
-            return setTimeout(() => {
-              if (process.env.NODE_ENV === 'production') {
+            if (process.env.NODE_ENV === 'production') {
+              return setTimeout(() => {
                 remote.getCurrentWindow().close()
-              }
-            }, 500)
+              }, 500)
+            }
           }
 
           console.error(event.message)

--- a/packages/haiku-creator/src/react/components/Stage.js
+++ b/packages/haiku-creator/src/react/components/Stage.js
@@ -95,8 +95,10 @@ export default class Stage extends React.Component {
           if (event.message.slice(0, 8) === 'Uncaught') {
             // Give the webview's Raven instance time to transmit its crash report
             return setTimeout(() => {
-              remote.getCurrentWindow().close()
-            }, (process.env.NODE_ENV === 'production') ? 500 : 50000)
+              if (process.env.NODE_ENV === 'production') {
+                remote.getCurrentWindow().close()
+              }
+            }, 500)
           }
 
           console.error(event.message)

--- a/packages/haiku-creator/src/react/components/Timeline.js
+++ b/packages/haiku-creator/src/react/components/Timeline.js
@@ -83,8 +83,10 @@ export default class Timeline extends React.Component {
           if (event.message.slice(0, 8) === 'Uncaught') {
             // Give the webview's Raven instance time to transmit its crash report
             return setTimeout(() => {
-              remote.getCurrentWindow().close()
-            }, (process.env.NODE_ENV === 'production') ? 500 : 50000)
+              if (process.env.NODE_ENV === 'production') {
+                remote.getCurrentWindow().close()
+              }
+            }, 500)
           }
 
           console.error(event.message)

--- a/packages/haiku-creator/src/react/components/Timeline.js
+++ b/packages/haiku-creator/src/react/components/Timeline.js
@@ -82,11 +82,11 @@ export default class Timeline extends React.Component {
           // 'Uncaught' indicates an unrecoverable error in Timeline, so we need to crash too
           if (event.message.slice(0, 8) === 'Uncaught') {
             // Give the webview's Raven instance time to transmit its crash report
-            return setTimeout(() => {
-              if (process.env.NODE_ENV === 'production') {
+            if (process.env.NODE_ENV === 'production') {
+              return setTimeout(() => {
                 remote.getCurrentWindow().close()
-              }
-            }, 500)
+              }, 500)
+            }
           }
 
           console.error(event.message)


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

On development, when the app crashes, it is useful to have the stack trace visible at all times, and the comfort to navigate the code with devtools without time constraints.

My current workflow is to read the error as fast as possible and hit cmd + R to reload the app before it crashes, because reloading is way faster than having to `yarn go`.


Adding @matthewtoast as a reviewer, because iirc, he implemented this and I could be missing something.
