### PR TITLE
feat: support DMG upload and syndication.

### DIFF
--- a/scripts/distro-upload.js
+++ b/scripts/distro-upload.js
@@ -25,6 +25,7 @@ uploadRelease(region, objkey, secret, bucket, RELEASES_FOLDER, platform, environ
 
   var slackMessage = `
 Distro ready (${version} ${environment})
+Patch link: ${urls.patch}
 Download link: ${urls.download}
 _Syndicate with :jenkins:._
   `.trim()


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- Use `.dmg` instead of `.zip` for new users.

Summary of work (include Asana links if any):

- [x] Upload `.dmg` during distro upload.
- [x] Back up and release `.dmg` (instead of `.zip`) as `-latest` for new users.

Notes to reviewer:
 - `squirrel-express` [always](https://github.com/HaikuTeam/squirrel-express/blob/master/server.js#L38) filters down to files ending with `.zip` for its syndication list, so parking a `.dmg` in a subdirectory without a `-pending` flag should be fine.
 - This will require manual intervention the first time we use it; specifically, we'll have to park the `…-latest.dmg` file in S3 or the "backup" step will fail. This will give us a great opportunity to test it before we actually release.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality