### PR TITLE
fix: check if abspath exist before matching

### DIFF
--- a/packages/haiku-serialization/src/bll/Sketch.js
+++ b/packages/haiku-serialization/src/bll/Sketch.js
@@ -43,7 +43,7 @@ Sketch.isSketchFile = (abspath) => {
 }
 
 Sketch.isSketchFolder = (abspath) => {
-  return abspath.match(IS_SKETCH_FOLDER_RE)
+  return !!abspath && abspath.match(IS_SKETCH_FOLDER_RE)
 }
 
 Sketch.exportFolderPath = (sketchRelpath) => {


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

Fix a crash on race conditions: https://sentry.io/haiku-systems/javascript-glass/issues/495111461/?referrer=slack
