### PR TITLE
Prevent e.match crash if there is no source path

### DIFF
--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -1752,7 +1752,8 @@ export class Glass extends React.Component {
     })
 
     items.push({ type: 'separator' })
-    if (Sketch.isSketchFolder(sourcePath)) {
+
+    if (sourcePath && Sketch.isSketchFolder(sourcePath)) {
       const sketchAssetPath = sourcePath && sourcePath.split(/\.sketch\.contents/)[0].concat('.sketch')
 
       items.push({
@@ -1764,7 +1765,7 @@ export class Glass extends React.Component {
       })
     }
 
-    if (Figma.isFigmaFolder(sourcePath)) {
+    if (sourcePath && Figma.isFigmaFolder(sourcePath)) {
       const figmaAssetPath = sourcePath && sourcePath.split(/\.figma\.contents/)[0].concat('.figma')
 
       items.push({


### PR DESCRIPTION
OK to merge.

Fixes https://sentry.io/haiku-systems/javascript-glass/issues/496152172/?referrer=slack