### PR TITLE
Fix changelog

### DIFF
--- a/packages/haiku-serialization/package.json
+++ b/packages/haiku-serialization/package.json
@@ -74,6 +74,7 @@
     "@types/gl-matrix": "^2.4.0",
     "eslint": "^3.19.0",
     "eslint-config-standard": "^10.2.1",
+    "semver": "^5.4.1",
     "snazzy": "^7.0.0",
     "standard": "^10.0.2",
     "tap-spec": "^4.1.1",

--- a/packages/haiku-serialization/src/bll/Asset.js
+++ b/packages/haiku-serialization/src/bll/Asset.js
@@ -169,7 +169,7 @@ class Asset extends BaseModel {
       children: [],
       slicesFolderAsset, // Hacky, but avoids extra 'upsert' logic
       artboardsFolderAsset,
-      dtModified: dict[relpath].dtModified
+      dtModified: (dict[relpath] && dict[relpath].dtModified) || Date.now()
     })
 
     this.addChild(sketchAsset)

--- a/packages/haiku-serialization/test/bll/09_Changelog.test.js
+++ b/packages/haiku-serialization/test/bll/09_Changelog.test.js
@@ -29,12 +29,13 @@ tape('Changelog.readChangelogs reads and parses changelogs in a directory', asyn
 })
 
 tape('Changelog.readChangelogs returns changelogs ordered by version', async (t) => {
-  t.plan(2)
+  t.plan(3)
 
   try {
     const changelogManager = new Changelog('0.0.0', 'test/fixtures/changelog/')
     const changelogs = await changelogManager.readChangelogs()
     t.equal(changelogs[0].version, '1.2.3')
+    t.equal(changelogs[1].version, '1.2.11')
     t.equal(changelogs[2].version, '4.3.2')
   } catch (e) {
     t.error(e)
@@ -65,7 +66,7 @@ tape('Changelog.readChangelogs returns an aggregated changelog with the correct 
     const changelog = await changelogManager.getChangelog()
 
     t.equal(changelog.version, '4.3.2')
-    t.ok(changelog.sections["Fixes"])
+    t.ok(changelog.sections["Fixes"].indexOf('Fix: 1.2.11 fixes') !== -1)
     t.ok(changelog.sections["What's new"])
     t.notOk(changelog.sections["1.2.3 Heading"])
   } catch (e) {

--- a/packages/haiku-serialization/test/fixtures/changelog/1.2.11.json
+++ b/packages/haiku-serialization/test/fixtures/changelog/1.2.11.json
@@ -1,9 +1,9 @@
 {
-  "version": "3.3.0",
+  "version": "1.2.11",
   "date": "January 4, 2002",
   "sections": {
     "Fixes": [
-      "Fix: 3.3.0 fixes"
+      "Fix: 1.2.11 fixes"
     ]
   }
 }

--- a/scripts/push.js
+++ b/scripts/push.js
@@ -2,6 +2,7 @@ const cp = require('child_process')
 
 const getPackages = require('./helpers/packages')
 const log = require('./helpers/log')
+const nowVersion = require('./helpers/nowVersion')
 
 const branch = cp.execSync('git symbolic-ref --short -q HEAD || git rev-parse --short HEAD').toString().trim()
 if (branch !== 'master') {
@@ -89,7 +90,8 @@ cp.execSync(`node ./scripts/build-core.js --skip-compile=1`, processOptions)
 // our standalones.
 cp.execSync('git fetch')
 cp.execSync('git merge origin/master')
-cp.execSync('git push -u origin master')
+cp.execSync(`git tag -a ${nowVersion()} -m 'release ${nowVersion()}'`)
+cp.execSync('git push -u origin master --tags')
 // Sync these changes down to development before continuing.
 cp.execSync('git fetch origin development:development')
 cp.execSync('git checkout development')


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

- Fix changelog to loosen the requirement that we always have a sliced-off changelog version exactly equal to the last version seen.
- Use correct semver ordering so that e.g. `1.3.15` is higher than `1.3.2`.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed