### PR TITLE
feat: show frame action btn only after delay

### DIFF
--- a/packages/haiku-timeline/src/components/FrameAction.js
+++ b/packages/haiku-timeline/src/components/FrameAction.js
@@ -9,7 +9,7 @@ const STYLE = {
     top: '-31px',
     left: '-6px',
     cursor: 'pointer',
-    overflow: 'hidden',
+    overflow: 'hidden'
   },
   addAction: {
     padding: '0 8px',
@@ -21,7 +21,7 @@ const STYLE = {
   },
   show: {
     opacity: 1,
-    transform: 'scale(1)',
+    transform: 'scale(1)'
   },
   plus: {
     width: '12px',
@@ -31,7 +31,7 @@ const STYLE = {
     justifyContent: 'center',
     borderRadius: '50%',
     border: '1px solid rgba(255,255,255,.2)',
-    fontSize: '20px',
+    fontSize: '20px'
   }
 }
 
@@ -74,7 +74,8 @@ class FrameAction extends React.Component {
       return (
         <div
           onMouseDown={(event) => {
-            if (this.state.achievedHover) this.openFrameActionsEditor(event)}
+            if (this.state.achievedHover) this.openFrameActionsEditor(event)
+          }
           }
           style={[STYLE.base, STYLE.addAction, this.state.achievedHover && STYLE.show]}>
           <div

--- a/packages/haiku-timeline/src/components/FrameAction.js
+++ b/packages/haiku-timeline/src/components/FrameAction.js
@@ -35,26 +35,25 @@ const STYLE = {
   }
 }
 
-let timeout
-
 class FrameAction extends React.Component {
   constructor () {
     super()
     this.openFrameActionsEditor = this.openFrameActionsEditor.bind(this)
+    this.timeout = null
     this.state = {
       achievedHover: false
     }
   }
 
   setHover () {
-    timeout = setTimeout(() => {
+    this.timeout = setTimeout(() => {
       this.setState({achievedHover: true})
     }, 520)
   }
 
   componentWillUnmount () {
-    if (timeout) {
-      clearTimeout(timeout)
+    if (this.timeout) {
+      clearTimeout(this.timeout)
     }
   }
 
@@ -81,7 +80,7 @@ class FrameAction extends React.Component {
           <div
             style={STYLE.plus}
             onMouseEnter={() => this.setHover()}
-            onMouseLeave={() => timeout && clearTimeout(timeout)}>
+            onMouseLeave={() => this.timeout && clearTimeout(this.timeout)}>
             +
           </div>
         </div>

--- a/packages/haiku-timeline/src/components/FrameAction.js
+++ b/packages/haiku-timeline/src/components/FrameAction.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import Radium from 'radium'
 import Bolt from 'haiku-ui-common/lib/react/icons/Bolt'
 import Palette from 'haiku-ui-common/lib/Palette'
 
@@ -8,14 +9,53 @@ const STYLE = {
     top: '-31px',
     left: '-6px',
     cursor: 'pointer',
-    overflow: 'hidden'
+    overflow: 'hidden',
+  },
+  addAction: {
+    padding: '0 8px',
+    left: '-14px',
+    opacity: 0,
+    cursor: 'pointer',
+    transform: 'scale(.5)',
+    transition: 'transform 180ms ease'
+  },
+  show: {
+    opacity: 1,
+    transform: 'scale(1)',
+  },
+  plus: {
+    width: '12px',
+    height: '12px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: '50%',
+    border: '1px solid rgba(255,255,255,.2)',
+    fontSize: '20px',
   }
 }
 
-class FrameAction extends React.PureComponent {
+let timeout
+
+class FrameAction extends React.Component {
   constructor () {
     super()
     this.openFrameActionsEditor = this.openFrameActionsEditor.bind(this)
+    this.state = {
+      achievedHover: false
+    }
+  }
+
+  setHover () {
+    timeout = setTimeout(() => {
+      this.setState({achievedHover: true})
+    }, 520)
+  }
+
+  componentWillUnmount () {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
   }
 
   openFrameActionsEditor (e) {
@@ -33,37 +73,14 @@ class FrameAction extends React.PureComponent {
     } else {
       return (
         <div
-          className='frame-action'
-          onMouseDown={(e) => this.openFrameActionsEditor(e)}
-          style={{
-            ...STYLE.base,
-            padding: '0 8px',
-            left: '-14px'
-          }}
-        >
-          <style>
-            {`
-              .frame-action {
-                opacity: 1;
-              }
-              .frame-action:not(:hover) {
-                opacity: 0;
-              }
-            `}
-          </style>
+          onMouseDown={(event) => {
+            if (this.state.achievedHover) this.openFrameActionsEditor(event)}
+          }
+          style={[STYLE.base, STYLE.addAction, this.state.achievedHover && STYLE.show]}>
           <div
-            style={{
-              width: '12px',
-              height: '12px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              borderRadius: '50%',
-              border: '1px solid rgba(255,255,255,.2)',
-              fontSize: '20px',
-              cursor: 'pointer'
-            }}
-          >
+            style={STYLE.plus}
+            onMouseEnter={() => this.setHover()}
+            onMouseLeave={() => timeout && clearTimeout(timeout)}>
             +
           </div>
         </div>
@@ -77,4 +94,4 @@ FrameAction.propTypes = {
   onShowFrameActionsEditor: React.PropTypes.func.isRequired
 }
 
-export default FrameAction
+export default Radium(FrameAction)


### PR DESCRIPTION
OK to merge.

Short review.
This tweak is an effort to mitigate accidentally opening the frame-action editor while merely seeking to jump to a different position in time by clicking the gauge. This inadvertent "user-error" seemed to be happening all too often. This change should help — we now only allow the frame-action-opener button to be seen and clicked after a half second delay. 

https://app.asana.com/0/591362404931103/569621726509834

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [ ] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
