### PR TITLE
Use HaikCore.min.js instead of index.standalone.js in the HTML+CDN embed

### DIFF
--- a/packages/haiku-serialization/src/bll/Figma.js
+++ b/packages/haiku-serialization/src/bll/Figma.js
@@ -219,7 +219,7 @@ class Figma {
    * @returns {string}
    */
   static buildFigmaLink (fileID, fileName = '') {
-    return `${FIGMA_URL}files/${fileID}/${fileName}`
+    return `${FIGMA_URL}file/${fileID}/${fileName}`
   }
 
   /**

--- a/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/Embed.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/Embed.tsx
@@ -22,7 +22,7 @@ export default class Embed extends React.PureComponent {
 
   render () {
     const {userName, projectName, organizationName, sha} = this.props;
-    const scriptPath = `${this.cdnBase}index.standalone.js`;
+    const scriptPath = `https://code.haiku.ai/scripts/core/HaikuCore.${process.env.HAIKU_RELEASE_VERSION}.min.js`;
     const embedPath = `${this.cdnBase}index.embed.js`;
 
     return (


### PR DESCRIPTION
OK to merge.

Short review.

Summary of work (include Asana links if any):

- fix: RCM is missing "view component" in the wild - https://app.asana.com/0/591362404931103/597566743140278

Notes for reviewers:

- I'm assuming that is safe to consider that `HAIKU_RELEASE_VERSION` will always be in sync with the latest Core version, is it a good call?

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] ~Added measurement instrumentation (Mixpanel, etc.)~
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] ~Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)~
- [ ] ~Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)~
- [ ] ~Wrote an automated test covering new functionality~
