### PR TITLE
Publish ui storybook

### DIFF
--- a/packages/haiku-creator/public/stylesheets/global.css
+++ b/packages/haiku-creator/public/stylesheets/global.css
@@ -305,7 +305,7 @@ input::-webkit-input-placeholder {
   right: 5px;
   bottom: 5px;
   cursor: -webkit-image-set(
-    url('./assets/cursors/rotation-cursor-tl.png') 1x
+    url('../assets/cursors/rotation-cursor-tl.png') 1x
   ) 16 16, auto;
 }
 
@@ -313,7 +313,7 @@ input::-webkit-input-placeholder {
   left: 5px;
   bottom: 5px;
   cursor: -webkit-image-set(
-    url('./assets/cursors/rotation-cursor-tr.png') 1x
+    url('../assets/cursors/rotation-cursor-tr.png') 1x
   ) 0 16, auto;
 }
 
@@ -321,7 +321,7 @@ input::-webkit-input-placeholder {
   right: 5px;
   top: 5px;
   cursor: -webkit-image-set(
-    url('./assets/cursors/rotation-cursor-bl.png') 1x
+    url('../assets/cursors/rotation-cursor-bl.png') 1x
   ) 16 0, auto;
 }
 
@@ -329,7 +329,7 @@ input::-webkit-input-placeholder {
   left: 5px;
   top: 5px;
   cursor: -webkit-image-set(
-    url('./assets/cursors/rotation-cursor-br.png') 1x
+    url('../assets/cursors/rotation-cursor-br.png') 1x
   ) 0 0, auto;
 }
 
@@ -337,7 +337,7 @@ input::-webkit-input-placeholder {
   right: 5px;
   bottom: 5px;
   cursor: -webkit-image-set(
-    url('./assets/cursors/rotation-cursor-t.png') 1x
+    url('../assets/cursors/rotation-cursor-t.png') 1x
   ) 11 11, auto;
 }
 
@@ -345,7 +345,7 @@ input::-webkit-input-placeholder {
   left: 5px;
   bottom: 5px;
   cursor: -webkit-image-set(
-    url('./assets/cursors/rotation-cursor-r.png') 1x
+    url('../assets/cursors/rotation-cursor-r.png') 1x
   ) 11 11, auto;
 }
 
@@ -353,7 +353,7 @@ input::-webkit-input-placeholder {
   right: 5px;
   top: 5px;
   cursor: -webkit-image-set(
-    url('./assets/cursors/rotation-cursor-b.png') 1x
+    url('../assets/cursors/rotation-cursor-b.png') 1x
   ) 11 11, auto;
 }
 
@@ -361,7 +361,7 @@ input::-webkit-input-placeholder {
   left: 5px;
   top: 5px;
   cursor: -webkit-image-set(
-    url('./assets/cursors/rotation-cursor-l.png') 1x
+    url('../assets/cursors/rotation-cursor-l.png') 1x
   ) 11 11, auto;
 }
 

--- a/packages/haiku-ui-common/.storybook/webpack.config.js
+++ b/packages/haiku-ui-common/.storybook/webpack.config.js
@@ -3,7 +3,7 @@ module.exports = (baseConfig, env) => {
   const config = genDefaultConfig(baseConfig, env);
   config.module.rules.push({
     test: /\.(ts|tsx)$/,
-    loader: require.resolve('awesome-typescript-loader')
+    use: ['awesome-typescript-loader', 'webpack-conditional-loader']
   });
   config.resolve.extensions.push('.ts', '.tsx');
   return config;

--- a/packages/haiku-ui-common/.storybook/webpack.config.js
+++ b/packages/haiku-ui-common/.storybook/webpack.config.js
@@ -1,10 +1,20 @@
+const path = require('path')
 const genDefaultConfig = require('@storybook/react/dist/server/config/defaults/webpack.config.js');
+
 module.exports = (baseConfig, env) => {
   const config = genDefaultConfig(baseConfig, env);
   config.module.rules.push({
     test: /\.(ts|tsx)$/,
     use: ['awesome-typescript-loader', 'webpack-conditional-loader']
   });
+  config.module.rules.push({
+    test: /\.css$/,
+    include: path.resolve(__dirname, '../../haiku-creator/public/assets/')
+  });
+  config.module.rules.push({
+    test: /\.(png|woff|woff2|eot|ttf|svg)$/,
+    loader: 'url-loader?limit=100000'
+  })
   config.resolve.extensions.push('.ts', '.tsx');
   return config;
 };

--- a/packages/haiku-ui-common/package.json
+++ b/packages/haiku-ui-common/package.json
@@ -33,7 +33,8 @@
     "tape": "^4.8.0",
     "tslint": "^5.7.0",
     "tslint-config-haiku": "^1.0.0",
-    "typescript": "^2.5.2"
+    "typescript": "^2.5.2",
+    "webpack-conditional-loader": "^1.0.12"
   },
   "license": "UNLICENSED",
   "dependencies": {

--- a/packages/haiku-ui-common/package.json
+++ b/packages/haiku-ui-common/package.json
@@ -34,6 +34,7 @@
     "tslint": "^5.7.0",
     "tslint-config-haiku": "^1.0.0",
     "typescript": "^2.5.2",
+    "url-loader": "^1.0.1",
     "webpack-conditional-loader": "^1.0.12"
   },
   "license": "UNLICENSED",

--- a/packages/haiku-ui-common/src/react/ExternalLink.tsx
+++ b/packages/haiku-ui-common/src/react/ExternalLink.tsx
@@ -20,9 +20,11 @@ export class ExternalLink extends React.PureComponent {
         style={this.props.style}
         onClick={(clickEvent) => {
           if (isElectron()) {
+            // #if false
             const {shell} = require('electron');
             clickEvent.preventDefault();
             shell.openExternal(this.props.href);
+            // #endif
           }
 
           if (this.props.onClick) {

--- a/packages/haiku-ui-common/src/react/ShareModal/LinkHolster.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/LinkHolster.tsx
@@ -104,7 +104,7 @@ export class LinkHolster extends React.PureComponent {
             style={STYLES.link}
             onClick={() => {
               // #if false
-              const {shell} = require('electron')
+              const {shell} = require('electron');
               shell.openExternal(linkAddress);
               // #endif
 

--- a/packages/haiku-ui-common/src/react/ShareModal/LinkHolster.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/LinkHolster.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {shell} from 'electron';
 import * as CopyToClipboard from 'react-copy-to-clipboard';
 import {ThreeBounce} from 'better-react-spinkit';
 import Palette from '../../Palette';
@@ -104,7 +103,10 @@ export class LinkHolster extends React.PureComponent {
           <span
             style={STYLES.link}
             onClick={() => {
+              // #if false
+              const {shell} = require('electron')
               shell.openExternal(linkAddress);
+              // #endif
 
               if (onLinkOpen) {
                 onLinkOpen();

--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -11,7 +11,7 @@ const STYLES = {
   wrapper: {
     width: 500,
     overflow: 'hidden',
-    left: '50%',
+    left: 'calc(50% + 150px)',
     transform: 'translateX(-50%)',
     top: 110,
     margin: 0,

--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -11,7 +11,7 @@ const STYLES = {
   wrapper: {
     width: 500,
     overflow: 'hidden',
-    left: 'calc(50% + 150px)',
+    left: '50%',
     transform: 'translateX(-50%)',
     top: 110,
     margin: 0,

--- a/packages/haiku-ui-common/stories/react/PublishUI.js
+++ b/packages/haiku-ui-common/stories/react/PublishUI.js
@@ -1,27 +1,87 @@
-import * as React from 'react';
-import { storiesOf } from '@storybook/react';
+import * as React from 'react'
+import { storiesOf } from '@storybook/react'
 
-import { ShareModal } from '../../src/react/ShareModal';
-import styles from '../../../haiku-creator/public/stylesheets/global.css';
+import { ShareModal } from '../../src/react/ShareModal'
+import styles from '../../../haiku-creator/public/stylesheets/global.css'
 
-console.log(styles)
+const defaultBeforeProps = {
+  project: {
+    projectPath: '/Users/roperzh/.haiku/projects/robertodip/lovedesign',
+    projectName: 'lovedesign',
+    projectExistsLocally: true,
+    projectsHome: '/Users/roperzh/.haiku',
+    repositoryUrl:
+      'https://robertodip-User-1:VaLx7J7OwX1qhWmc3YXBtL0se0zJNKo6@git.haiku.ai/robertodip-projects/lovedesign.git',
+    forkComplete: true,
+    skipContentCreation: true,
+    organizationName: 'robertodip',
+    authorName: 'robertodip',
+  },
+  snapshotSaveConfirmed: null,
+  isSnapshotSaveInProgress: true,
+  linkAddress: 'Fetching Info',
+  semverVersion: '0.0.0',
+  error: null,
+  snapshotSyndicated: false,
+  snapshotPublished: false,
+  userName: 'robertodip',
+  organizationName: 'robertodip',
+  projectUid: '',
+  sha: '',
+  mixpanel: {
+    haikuTrack: () => {},
+  },
+  envoyProject: {
+    getProjectDetail () {
+      return new Promise((resolve, reject) => {
+        resolve({
+          IsPublic: true,
+        })
+      })
+    },
+    setIsPublic() {
+      return new Promise((resolve, reject) => {
+        resolve(true)
+      })
+    }
+  },
+}
+
+const defaultAfterProps = {
+  ...defaultBeforeProps,
+  snapshotSaveConfirmed: false,
+  isSnapshotSaveInProgress: false,
+  linkAddress:
+    'https://share.haiku.ai/6b68c8e4-0c85-42f4-859e-21918e012003/latest',
+  semverVersion: '0.0.15',
+  snapshotSyndicated: true,
+  snapshotPublished: true,
+  projectUid: 'fe00edbe-a00e-45ce-8498-327146d8b3fe',
+  sha: 'b15b287091fd7312998c3158651e673418ec512b',
+}
+
+class Simulator extends React.PureComponent {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      props: props.before || defaultBeforeProps,
+    }
+
+    setTimeout(() => {
+      this.setState({ props: props.after || defaultAfterProps })
+    }, props.timeout || 2000)
+  }
+  render() {
+    return <ShareModal {...this.state.props} />
+  }
+}
 
 storiesOf('ShareModal', module)
-  .add('default', () => (
-    <ShareModal
-      project={{projectName: 'Test'}}
-      error={null}
-      linkAddress={'http://test.com'}
-      snapshotSaveConfirmed={false}
-      isSnapshotSaveInProgress={false}
-      isProjectInfoFetchInProgress={false}
-      snapshotSyndicated={false}
-      snapshotPublished={false}
-      semverVersion={'0.0.1'}
-      userName={'username'}
-      organizationName={'organizationame'}
-      projectUid={'projectUID'}
-      sha={'sha'}
-      mixpanel={{haikuTrack: () => {}}}
-    />
-  ))
+  .add('default', () => {
+    return <Simulator />
+  })
+  .add('with error', () => {
+    const errorProps = { ...defaultAfterProps, error: { message: 'adf' } }
+    return <Simulator after={errorProps} />
+  })

--- a/packages/haiku-ui-common/stories/react/PublishUI.js
+++ b/packages/haiku-ui-common/stories/react/PublishUI.js
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { ShareModal } from '../../src/react/ShareModal';
+import styles from '../../../haiku-creator/public/stylesheets/global.css';
+
+console.log(styles)
+
+storiesOf('ShareModal', module)
+  .add('default', () => (
+    <ShareModal
+      project={{projectName: 'Test'}}
+      error={null}
+      linkAddress={'http://test.com'}
+      snapshotSaveConfirmed={false}
+      isSnapshotSaveInProgress={false}
+      isProjectInfoFetchInProgress={false}
+      snapshotSyndicated={false}
+      snapshotPublished={false}
+      semverVersion={'0.0.1'}
+      userName={'username'}
+      organizationName={'organizationame'}
+      projectUid={'projectUID'}
+      sha={'sha'}
+      mixpanel={{haikuTrack: () => {}}}
+    />
+  ))

--- a/packages/haiku-ui-common/stories/react/index.js
+++ b/packages/haiku-ui-common/stories/react/index.js
@@ -2,5 +2,6 @@ import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import './PopoverMenu';
+import './PublishUI';
 import './OtherIcons';
 import './Palette';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11933,6 +11933,10 @@ webpack-concat-plugin@^2.4.2:
     schema-utils "^0.4.3"
     uglify-es "^3.2.2"
 
+webpack-conditional-loader@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/webpack-conditional-loader/-/webpack-conditional-loader-1.0.12.tgz#3e1d6f182aefac6d914c99acd0f861eddddfb728"
+
 webpack-dev-middleware@^1.12.2:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz#f8fc1120ce3b4fc5680ceecb43d777966b21105e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7433,7 +7433,7 @@ mime@^1.4.1, mime@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
-mime@^2.2.0:
+mime@^2.0.3, mime@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.2.0.tgz#161e541965551d3b549fa1114391e3a3d55b923b"
 
@@ -11647,6 +11647,14 @@ url-loader@^0.6.2:
     loader-utils "^1.0.2"
     mime "^1.4.1"
     schema-utils "^0.3.0"
+
+url-loader@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-1.0.1.tgz#61bc53f1f184d7343da2728a1289ef8722ea45ee"
+  dependencies:
+    loader-utils "^1.1.0"
+    mime "^2.0.3"
+    schema-utils "^0.4.3"
 
 url-parse-lax@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
OK to merge.

Short review.

Summary of work (include Asana links if any):

![2018-03-19 16_30_55](https://user-images.githubusercontent.com/4419992/37618000-74f68bd8-2b93-11e8-9e36-be546a07fc84.gif)

- [x] Port the publish UI to react storybook
- [x] Center the Publish UI modal against the whole app screen

Regressions to look for:

- The path of some `PNG` images in packages/haiku-creator/public/stylesheets/global.css was wrong, after changing it they seem to still work fine in dev, but they will in prod? do we change that path during build?


Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
