### PR TITLE
Fix tour spotlight size

### DIFF
--- a/packages/haiku-creator/src/react/components/Tour/Spotlight.js
+++ b/packages/haiku-creator/src/react/components/Tour/Spotlight.js
@@ -100,7 +100,7 @@ class Spotlight extends React.PureComponent {
             ...STYLES.spotlight,
             ...holeStyles,
             boxShadow: this.state.showBackground
-              ? '0 0 0 2560px rgba(0, 0, 0, 0.5), 0 0 20px 0px #000 inset'
+              ? '0 0 0 150vw rgba(0, 0, 0, 0.5), 0 0 20px 0px #000 inset'
               : ''
           }}
         />


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

Use a value of `150vw` for the spread attribute of the box-shadow that simulates the spotlight in the tour.

While this won't cover all possible scenarios (for example a very wide monitor in portrait mode) it will surely help with most cases out there.

Summary of work (include Asana links if any):

- [x] fix: bug: tour, spotlight shows boundaries on large screens https://app.asana.com/0/591362404931103/528654181791079

Notes for reviewers:

- ~I'm not sure if I understand why the branch is coming with changes from the `slow_action` branch that has already been merged in both `development` and `master`, but the current branch is rebased against latest master.~

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [ ] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
