### PR TITLE
fix: improve the logic to import files from disk

### DIFF
--- a/packages/haiku-creator/src/react/components/library/FileImporter.js
+++ b/packages/haiku-creator/src/react/components/library/FileImporter.js
@@ -65,9 +65,12 @@ class FileImporter extends React.PureComponent {
     this.setState({ isPopoverOpen: false })
   }
 
-  onFileDrop (dropEvent) {
+  onFileDrop (filePaths) {
     this.hidePopover()
-    this.props.onFileDrop(dropEvent)
+
+    if (filePaths) {
+      this.props.onFileDrop(filePaths)
+    }
   }
 
   get popoverBody () {

--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -305,9 +305,8 @@ class Library extends React.Component {
     )
   }
 
-  handleFileDrop (files, event) {
+  handleFileDrop (filePaths) {
     this.setState({isLoading: true})
-    const filePaths = lodash.map(files, file => file.path)
     this.props.projectModel.bulkLinkAssets(
       filePaths,
       (error, assets) => {
@@ -333,7 +332,7 @@ class Library extends React.Component {
             onImportFigmaAsset={this.importFigmaAsset}
             onAskForFigmaAuth={() => { this.askForFigmaAuth() }}
             figma={this.state.figma}
-            onFileDrop={(files, fileDropEvent) => { this.handleFileDrop(files, fileDropEvent) }}
+            onFileDrop={(filePaths) => { this.handleFileDrop(filePaths) }}
           />
         </div>
         <div

--- a/packages/haiku-creator/src/react/components/library/importers/FileSystemImporter.js
+++ b/packages/haiku-creator/src/react/components/library/importers/FileSystemImporter.js
@@ -1,30 +1,27 @@
 import React from 'react'
-
-const STYLES = {
-  filePicker: {
-    opacity: 0,
-    position: 'absolute',
-    left: 0,
-    width: 150,
-    zIndex: 3,
-    cursor: 'pointer'
-  }
-}
+import { remote } from 'electron'
 
 class FileSystemImporter extends React.PureComponent {
+  showImportDialog () {
+    remote.dialog.showOpenDialog(
+      null,
+      {
+        filters: [{ name: 'Valid Files', extensions: ['svg', 'sketch'] }],
+        properties: ['multiSelections', 'openFile']
+      },
+      this.props.onFileDrop
+    )
+  }
+
   render () {
     return (
-      <div style={this.props.style}>
+      <div
+        style={this.props.style}
+        onClick={() => {
+          this.showImportDialog()
+        }}
+      >
         {this.props.text ? this.props.text : 'From File'}
-        <input
-          type='file'
-          ref='filepicker'
-          multiple
-          onChange={fileDropEvent => {
-            this.props.onFileDrop(this.refs.filepicker.files, fileDropEvent)
-          }}
-          style={STYLES.filePicker}
-        />
       </div>
     )
   }


### PR DESCRIPTION
OK to merge.

Short review.

Purpose of changes:

Fix various bugs related to importing files from disk by using `dialog.showOpenDialog` instead of `input[type=file]` which gives us more control and also doesn't have bug limitations (see https://github.com/electron/electron/issues/11456)

Summary of work (include Asana links if any):

- Don't allow to import unsupported file formats
- Close the file import popup on cancel
- Fix bugs with the library UI being empty after clicking on cancel

Regressions to look for:

- None, but if you could test file imports from disk would be great

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Did the [E2E checklist](https://haiku.quip.com/dGqeAEVSWdmg)
- [x] Expanded the [QA checklist](https://haiku.quip.com/rqwsAPsCGxqT)
- [ ] Wrote an automated test covering new functionality
