### PR TITLE
fix: improve error Figma messaging when there are no assets to import

### DIFF
--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -172,7 +172,7 @@ class Library extends React.Component {
     const path = this.props.projectModel.folder
 
     return this.state.figma.importSVG({url, path})
-      .catch((error) => {
+      .catch((error = {}) => {
         mixpanel.haikuTrack('creator:figma:fileImport:fail')
 
         let message = error.err || 'We had a problem connecting with Figma. Please check your internet connection and try again.'

--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -175,7 +175,7 @@ class Library extends React.Component {
       .catch((error) => {
         mixpanel.haikuTrack('creator:figma:fileImport:fail')
 
-        let message = 'We had a problem connecting with Figma. Please check your internet connection and try again.'
+        let message = error.err || 'We had a problem connecting with Figma. Please check your internet connection and try again.'
 
         if (error.status === 403) {
           message = (

--- a/packages/haiku-serialization/src/bll/Figma.js
+++ b/packages/haiku-serialization/src/bll/Figma.js
@@ -138,6 +138,7 @@ class Figma {
       const uri = API_BASE + 'images/' + id + '?' + params.toString()
 
       if (ids.length === 0) {
+        // eslint-disable-next-line
         reject({err: 'We couldn\'t find any groups or slices in your project.'})
       }
 

--- a/packages/haiku-serialization/src/bll/Figma.js
+++ b/packages/haiku-serialization/src/bll/Figma.js
@@ -139,7 +139,7 @@ class Figma {
 
       if (ids.length === 0) {
         // eslint-disable-next-line
-        reject({err: 'We couldn\'t find any groups or slices in your project.'})
+        return reject({err: 'We couldn\'t find any groups or slices in your project.'})
       }
 
       this.request({ uri })

--- a/packages/haiku-serialization/src/bll/Figma.js
+++ b/packages/haiku-serialization/src/bll/Figma.js
@@ -137,6 +137,10 @@ class Figma {
       const params = new URLSearchParams([['format', 'svg'], ['ids', ids]])
       const uri = API_BASE + 'images/' + id + '?' + params.toString()
 
+      if (ids.length === 0) {
+        reject({err: 'We couldn\'t find any groups or slices in your project.'})
+      }
+
       this.request({ uri })
         .then((SVGLinks) => {
           // TODO: links comes with an error param, we should check that


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Current error message is ambiguous and doesn't provide info about the problem at all, I have found a user very confused on Intercom about this. 

Maybe we can revisit the UX later and add an empty file to the library or something on those lines, but for now we are going to display this toast:

![screen shot 2018-03-22 at 21 55 26](https://user-images.githubusercontent.com/4419992/37805913-c2f2aefe-2e1b-11e8-8e11-37b0b863ffd0.png)

Notes for reviewers:

**Important note**: this also includes a tweak in the logic to display `error.err` as a message if there's any, which will also display messages coming from the Figma API that we don't handle yet. IMO this is fine and even useful, because when the user reported this error I was in the dark about what could be the cause since the default message is too generic.


Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed

