### PR TITLE
fix: add better messaging when a file is not found during instantiation

### DIFF
--- a/packages/haiku-creator/src/react/components/Stage.js
+++ b/packages/haiku-creator/src/react/components/Stage.js
@@ -142,7 +142,13 @@ export default class Stage extends React.Component {
       const offsetY = clientY - stageRect.top
       if (this.props.projectModel) {
         return this.props.projectModel.transmitInstantiateComponent(asset.getRelpath(), { offsetX, offsetY }, (err) => {
-          if (err) return this.props.createNotice({ type: 'error', title: 'Error', message: err.message })
+          if (err) {
+            if (err.code === 'ENOENT') {
+              return this.props.createNotice({ type: 'error', title: 'Error', message: 'We couldn\'t find that file. 😩 Please try again in a few moments. If you still see this error, contact Haiku for support.' })
+            } else {
+              return this.props.createNotice({ type: 'error', title: 'Error', message: err.message })
+            }
+          }
         })
       }
     }

--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -226,7 +226,11 @@ class Library extends React.Component {
   handleFileInstantiation (asset) {
     return this.props.projectModel.transmitInstantiateComponent(asset.getRelpath(), {}, (err) => {
       if (err) {
-        return this.props.createNotice({ type: 'danger', title: err.name, message: err.message })
+        if (err.code === 'ENOENT') {
+          return this.props.createNotice({ type: 'error', title: 'Error', message: 'We couldn\'t find that file. 😩 Please try again in a few moments. If you still see this error, contact Haiku for support.' })
+        } else {
+          return this.props.createNotice({ type: 'error', title: 'Error', message: err.message })
+        }
       }
     })
   }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- As the title says, this adds a friendlier error when a file is not found during instantiation. @matthewtoast is planning to revisit the logic underneath this to come with a real solution.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
