### PR TITLE
Tweak Toasts

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1307,7 +1307,7 @@ export default class Creator extends React.Component {
               transitionName='toast'
               transitionEnterTimeout={500}
               transitionLeaveTimeout={300}>
-              <div style={{ position: 'absolute', right: 0, top: 0, width: 300 }}>
+              <div style={{ position: 'absolute', right: 0, top: 44, width: 300 }}>
                 {lodash.map(this.state.notices, this.renderNotifications)}
               </div>
             </ReactCSSTransitionGroup>

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -18,7 +18,7 @@ const HARDCODED_PROJECTS_LIMIT = 15
 
 const STYLES = {
   adminButton: {
-    // TODO: make this a bit more subdued?
+    // TODO: make this a bit more not subdued?
     background: 'linear-gradient(180deg, rgb(247,183,89), rgb(229,116,89) 50%, rgb(213,53,89))'
   }
 }

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -8,7 +8,6 @@ import Palette from 'haiku-ui-common/lib/Palette'
 import { ThreeBounce } from 'better-react-spinkit'
 import Color from 'color'
 import { BTN_STYLES } from '../styles/btnShared'
-import { DASH_STYLES } from '../styles/dashShared'
 import CopyToClipboard from 'react-copy-to-clipboard'
 import ToolSelector from './ToolSelector'
 import Toggle from './Toggle'
@@ -127,7 +126,7 @@ const STYLES = {
   link2: {
     color: Palette.LIGHT_BLUE,
     cursor: 'pointer'
-  },
+  }
 }
 
 const SNAPSHOT_SAVE_RESOLUTION_STRATEGIES = {
@@ -243,8 +242,6 @@ class StageTitleBar extends React.Component {
         this.props.removeNotice(undefined, noticeNotice.id)
       }, 3000)
     })
-
-
 
     ipcRenderer.on('global-menu:save', () => {
       if (!this._isMounted) {

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -123,7 +123,11 @@ const STYLES = {
     marginTop: '10px',
     fontSize: '13px',
     fontStyle: 'oblique'
-  }
+  },
+  link2: {
+    color: Palette.LIGHT_BLUE,
+    cursor: 'pointer'
+  },
 }
 
 const SNAPSHOT_SAVE_RESOLUTION_STRATEGIES = {
@@ -219,14 +223,13 @@ class StageTitleBar extends React.Component {
         return
       }
 
-      this.props.createNotice({
+      const noticeNotice = this.props.createNotice({
         type: 'info',
-        title: 'Notice',
+        title: 'Snapshot saved',
         message: (
           <p>
-            Snapshot saved —{' '}
             <span
-              style={DASH_STYLES.link}
+              style={STYLES.link2}
               onClick={() => {
                 shell.showItemInFolder(this.props.folder)
               }}
@@ -236,7 +239,12 @@ class StageTitleBar extends React.Component {
           </p>
         )
       })
+      window.setTimeout(() => {
+        this.props.removeNotice(undefined, noticeNotice.id)
+      }, 3000)
     })
+
+
 
     ipcRenderer.on('global-menu:save', () => {
       if (!this._isMounted) {


### PR DESCRIPTION
OK to merge.

* Now auto-dismiss the "Snapshot Saved" toast. (Had a user request this on Slack this morning.)
* Cleaned up said toast's styles and title a bit.
* Position all in-Creator toasts down a bit so that they don't overlap the navbar.


Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
