### PR TITLE
fix: use a project names instead of indexes to delete projects

### DIFF
--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -160,6 +160,12 @@ class ProjectBrowser extends React.Component {
           return
         }
 
+        mixpanel.haikuTrack('creator:project:deleted', {
+          username: this.props.username,
+          project: projectToDelete.projectName,
+          organization: this.props.organizationName
+        })
+
         // Make sure at least 200ms (the duration of the "delete" transition) have passed before actually removing
         // the project.
         setTimeout(() => {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

As the title says, this updates the delete logic to use project names instead of the index of the project in the `projectsList` array

Regressions to look for:

- Deleting projects in general

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [x] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality

cc: @taylorpoe 
