### PR TITLE
Fix: use strict mode in Actions/Expressions editors

### DIFF
--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/SyntaxEvaluator.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/SyntaxEvaluator.js
@@ -34,10 +34,15 @@ class SyntaxEvaluator extends React.PureComponent {
 
   componentWillUpdate ({evaluate}) {
     const evaluator = this.getDefaultEvaluator()
-    const parser = new Parser({ sourceType: 'script' })
+    const parser = new Parser({
+      sourceType: 'script',
+      strictMode: true
+    })
 
     try {
-      parser._parseAst(evaluate)
+      // Force strict mode on the block of code to be evaluated
+      const strictEvaluate = '"use strict";' + evaluate
+      parser._parseAst(strictEvaluate)
     } catch (exception) {
       evaluator.text = exception.message
       evaluator.state = EVALUATOR_STATES.ERROR

--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/SyntaxEvaluator.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/SyntaxEvaluator.js
@@ -34,9 +34,7 @@ class SyntaxEvaluator extends React.PureComponent {
 
   componentWillUpdate ({evaluate}) {
     const evaluator = this.getDefaultEvaluator()
-    const parser = new Parser()
-    parser._options.sourceType = 'script'
-    parser._options.strictMode = false
+    const parser = new Parser({ sourceType: 'script' })
 
     try {
       parser._parseAst(evaluate)

--- a/packages/haiku-serialization/src/ast/parseExpression.js
+++ b/packages/haiku-serialization/src/ast/parseExpression.js
@@ -4,9 +4,10 @@ var fsm = require('fuzzy-string-matching')
 var uniq = require('lodash').uniq
 var FORBIDDEN_EXPRESSION_TOKENS = require('@haiku/core/lib/ValueBuilder').default.FORBIDDEN_EXPRESSION_TOKENS
 
-var PARSER = new Parser()
-PARSER._options.sourceType = 'script'
-PARSER._options.strictMode = false
+var PARSER = new Parser({
+  sourceType: 'script',
+  strictMode: true
+})
 
 // Thresholds for fuzzy string matches when detecting any of these types of tokens
 var MATCH_WEIGHTS = {
@@ -16,11 +17,11 @@ var MATCH_WEIGHTS = {
 }
 
 function wrap (exprWithourWrap) {
-  return '(function(){\n' + exprWithourWrap + '\n})'
+  return '(function(){"use strict";\n' + exprWithourWrap + '\n})'
 }
 
 function unwrap (exprWithWrap) {
-  return exprWithWrap.slice(13, exprWithWrap.length - 3)
+  return exprWithWrap.slice(26, exprWithWrap.length - 3)
 }
 
 function getSegsList (list, node) {
@@ -299,7 +300,7 @@ function parseExpression (expr, injectables, keywords, state, cursor, options) {
     var cst = PARSER._parseAst(expr)
 
     var tokens = PARSER._processTokens(cst, expr)
-    tokens = tokens.slice(6) // Slice off the "(function(){\n" tokens
+    tokens = tokens.slice(8) // Slice off the "(function(){"use strict";\n" tokens
     tokens.splice(tokens.length - 4) // Slice off the "})\n\eof" tokens
 
     let candidates = [] // Going to find possible targets and select the best fit


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

This will prevent plumbing (and therefore the app) from crashing 
when parsing Actions/Expressions in certain scenarios where things 
that are valid in non-strict mode cause syntax errors in strict mode, 
for example `000` is interpreted as an octal in non-strict mode,
but causes a SyntaxError in non-strict mode.

This was biting us because all of the parsing infrastructure is based
on babylon, which uses strict mode by default.

Regressions to look for:

- Actions/Expressions bytecode saving/editing

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
