### PR TITLE
fix: update the state of Creator after showing the changelog

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1248,8 +1248,11 @@ export default class Creator extends React.Component {
   }
 
   showChangelogModal () {
-    this.setState({showChangelogModal: true})
-    this.user.setConfig(UserSettings.lastViewedChangelog, process.env.HAIKU_RELEASE_VERSION)
+    this.setState({ showChangelogModal: true }, () => {
+      const lastViewedChangelog = process.env.HAIKU_RELEASE_VERSION
+      this.setState({ lastViewedChangelog })
+      this.user.setConfig(UserSettings.lastViewedChangelog, lastViewedChangelog)
+    })
 
     mixpanel.haikuTrack('creator:changelog:shown')
   }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Update the state of Creator accordingly after a changelog is shown, preventing bugs when opening the changelog twice in the same session.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
