### PR TITLE
tweak: focus the browser window when it handles a URL

### DIFF
--- a/packages/haiku-creator/src/electron.js
+++ b/packages/haiku-creator/src/electron.js
@@ -79,6 +79,7 @@ const handleUrl = (url) => {
   logger.info(`[creator] handling custom protocol URL ${url}`)
   const parsedUrl = parse(url)
   browserWindow.webContents.send(`open-url:${parsedUrl.host}`, parsedUrl.pathname, qs.parse(parsedUrl.query))
+  browserWindow.focus()
 }
 
 function different (a, b) {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Focus the browser window after telling Creator to handle a `haiku://` URL. This should obviate [After forking give some indication to the user that the attempt has been made and that they better switch over to Haiku App](https://app.asana.com/0/591362404931103/606844345802389/f).