### PR TITLE
Basic actions autocompletion/snipets

### DIFF
--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/Editor.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/Editor.js
@@ -88,7 +88,6 @@ class Editor extends React.Component {
       autoIndent: true,
       contextmenu: false,
       codeLens: false,
-      quickSuggestions: false,
       parameterHints: false,
       /* Elements with `will-change: transform` are containing blocks
         for all descendants, meaning that all elements,

--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/Editor.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/Editor.js
@@ -78,24 +78,6 @@ class Editor extends React.Component {
   }
 
   componentDidMount () {
-    monaco.editor.defineTheme('haiku', {
-      base: 'vs-dark',
-      inherit: true,
-      // `rules` requires colors without the leading '#' ¯\_(ツ)_/¯
-      rules: [{backgroundColor: Palette.SPECIAL_COAL.replace('#', '')}],
-      colors: {
-        'editor.foreground': Palette.PALE_GRAY,
-        'editor.background': Palette.DARKEST_COAL,
-        'editorCursor.foreground': Palette.LIGHTEST_PINK,
-        'list.focusBackground': Palette.BLACK,
-        focusBorder: Palette.BLACK,
-        'editorWidget.background': Palette.DARKEST_COAL,
-        'editor.lineHighlightBorder': Palette.DARKEST_COAL
-      }
-    })
-
-    monaco.editor.setTheme('haiku')
-
     this.editor = monaco.editor.create(this._context, {
       value: this.props.contents || '',
       language: 'javascript',

--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/constants.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/constants.js
@@ -9,3 +9,57 @@ export const EVALUATOR_STATES = {
 export const EDITOR_WIDTH = 500
 
 export const EDITOR_HEIGHT = 380
+
+export const AUTOCOMPLETION_ITEMS = [
+  {
+    detail: 'Change State',
+    label: 'setState',
+    insertText: 'this.setState({stateName: value})'
+  },
+  {
+    detail: 'Seek and play from a specific frame.',
+    label: 'gotoAndPlay',
+    insertText: 'this.getDefaultTimeline().gotoAndPlay(ms)'
+  },
+  {
+    detail: 'Seek to a specific frame, and stop the timeline at that point.',
+    label: 'gotoAndStop',
+    insertText: 'this.getDefaultTimeline().gotoAndStop(ms)'
+  },
+  {
+    detail: 'Play this timeline at the current frame.',
+    label: 'play',
+    insertText: 'this.getDefaultTimeline().play()'
+  },
+  {
+    detail: 'Pause this timeline at the current frame.',
+    label: 'pause',
+    insertText: 'this.getDefaultTimeline().pause()'
+  },
+  {
+    detail: 'Pauses the timeline and resets to 0.',
+    label: 'stop',
+    insertText: 'this.getDefaultTimeline().stop()'
+  },
+  {
+    detail: 'Start this timeline from frame 0.',
+    label: 'start',
+    insertText: 'this.getDefaultTimeline().start()'
+  },
+  {
+    detail: 'Jump to a specific time in the timeline.',
+    label: 'seek',
+    insertText: 'this.getDefaultTimeline().seek(ms)'
+  },
+  {
+    detail: 'Returns whether or not this timeline is currently playing.',
+    label: 'isPlaying',
+    insertText: 'this.getDefaultTimeline().isPlaying()'
+  },
+  {
+    detail: 'Returns whether or not this timeline has gone past its max frame.',
+    label: 'isFinished',
+    insertText: 'this.getDefaultTimeline().isFinished()'
+  }
+
+]


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Add snippets to the Actions UI with basic stuff, please note that this is not the same as adding support for `@haiku/core` typings, and this should be done as a separate task.

![snippets](https://user-images.githubusercontent.com/4419992/38052301-2bf726d4-32a7-11e8-9269-ba24211e0c10.gif)

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
