### PR TITLE
fix: enable text to be copied in Creator

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -56,6 +56,7 @@ const electron = require('electron')
 const remote = electron.remote
 const { dialog } = remote
 const ipcRenderer = electron.ipcRenderer
+const clipboard = electron.clipboard
 
 var webFrame = electron.webFrame
 if (webFrame) {
@@ -274,6 +275,8 @@ export default class Creator extends React.Component {
           view: 'timeline',
           name: 'global-menu:copy'
         })
+      } else {
+        clipboard.writeText(window.getSelection().toString())
       }
     }, MENU_ACTION_DEBOUNCE_TIME, {leading: true, trailing: false}))
 


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Enable text to be copied in Creator by hooking into the `global-menu:copy` listener and writing in the clipboard the current selection if and only if is a text selection, otherwise just go on normally.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
