### PR TITLE
[proposal] do not print params in the logs for a defined list of methods

### DIFF
--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -59,8 +59,10 @@ const METHODS_TO_SKIP_IN_SENTRY = {
   requestSyndicationInfo: true
 }
 
+// Use for any methods whose parameters expose sensitive info in the logs, use keys
+// for method names and values for the list of param indices you don't want to log.
 const METHODS_WITH_SENSITIVE_INFO = {
-  authenticateUser: true
+  authenticateUser: [1]
 }
 
 const IGNORED_METHOD_MESSAGES = {
@@ -417,7 +419,7 @@ export default class Plumbing extends StateObject {
   methodMessageBeforeLog (message, alias) {
     if (!IGNORED_METHOD_MESSAGES[message.method]) {
       const paramsLog = METHODS_WITH_SENSITIVE_INFO[message.method]
-        ? message.params.map(() => 'xxxx')
+        ? message.params.map((param, idx) => METHODS_WITH_SENSITIVE_INFO[message.method].includes(idx) ? 'xxxxx' : param)
         : message.params
 
       logger.info(`[plumbing] ↓-- ${message.method} via ${alias} -> ${JSON.stringify(paramsLog)} --↓`)
@@ -900,6 +902,8 @@ export default class Plumbing extends StateObject {
     })
   }
 
+  // Note: param 1 (password) is excluded from logging via `METHODS_WITH_SENSITIVE_INFO`.
+  // Be sure to update `METHODS_WITH_SENSITIVE_INFO` if the sensitive parameters change.
   authenticateUser (username, password, cb) {
     this.set('organizationName', null) // Unset this cache to avoid writing others folders if somebody switches accounts in the middle of a session
     return inkstone.user.authenticate(username, password, (authErr, authResponse, httpResponse) => {

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -59,6 +59,10 @@ const METHODS_TO_SKIP_IN_SENTRY = {
   requestSyndicationInfo: true
 }
 
+const METHODS_WITH_SENSITIVE_INFO = {
+  authenticateUser: true
+}
+
 const IGNORED_METHOD_MESSAGES = {
   setTimelineTime: true,
   doesProjectHaveUnsavedChanges: true,
@@ -412,7 +416,11 @@ export default class Plumbing extends StateObject {
 
   methodMessageBeforeLog (message, alias) {
     if (!IGNORED_METHOD_MESSAGES[message.method]) {
-      logger.info(`[plumbing] ↓-- ${message.method} via ${alias} -> ${JSON.stringify(message.params)} --↓`)
+      const paramsLog = METHODS_WITH_SENSITIVE_INFO[message.method]
+        ? message.params.map(() => 'xxxx')
+        : message.params
+
+      logger.info(`[plumbing] ↓-- ${message.method} via ${alias} -> ${JSON.stringify(paramsLog)} --↓`)
     }
   }
 


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

_Very, very_ rudimentary way of obscuring params, we can (and surely will) revisit this later to add more sophistication, but this is aimed to be a quick fix in order to stop exposing user data in the logs.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
