### PR TITLE
Drag-and-drop timeline elements to reorder z-index

### DIFF
--- a/packages/haiku-serialization/src/bll/ActionStack.js
+++ b/packages/haiku-serialization/src/bll/ActionStack.js
@@ -615,6 +615,16 @@ ActionStack.METHOD_INVERTERS = {
         params: [moves]
       }
     }
+  },
+
+  zShiftIndices: {
+    before: (ac, [componentId, timelineName, timelineTime, newIndex]) => {
+      const moves = ac.gatherZIndexKeyframeMoves(timelineName)
+      return {
+        method: ac.moveKeyframes.name,
+        params: [moves]
+      }
+    }
   }
 
   // mergeDesigns: {

--- a/packages/haiku-serialization/src/utils/Mixpanel.js
+++ b/packages/haiku-serialization/src/utils/Mixpanel.js
@@ -47,7 +47,7 @@ function _safeStringify (obj) {
 
 mixpanel.haikuTrack = function haikuTrack (eventName, eventPayload) {
   const finalPayload = _getPayload(eventName, eventPayload)
-  // console.info('[mixpanel]', eventName, finalPayload)
+  console.info('[mixpanel]', eventName, finalPayload)
   return mixpanel.track(eventName, finalPayload)
 }
 

--- a/packages/haiku-timeline/package.json
+++ b/packages/haiku-timeline/package.json
@@ -47,6 +47,7 @@
     "radium": "0.18.1",
     "raven-js": "^3.18.1",
     "react": "15.6.2",
+    "react-beautiful-dnd": "^6.0.1",
     "react-dom": "15.6.2",
     "react-draggable": "2.2.3",
     "react-intercom": "^1.0.14",

--- a/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
@@ -13,11 +13,13 @@ export default class ComponentHeadingRowHeading extends React.Component {
   componentWillUnmount () {
     this.mounted = false
     this.props.row.removeListener('update', this.handleUpdate)
+    this.props.row.host.removeListener('update', this.handleUpdate)
   }
 
   componentDidMount () {
     this.mounted = true
     this.props.row.on('update', this.handleUpdate)
+    this.props.row.host.on('update', this.handleUpdate)
   }
 
   handleUpdate (what) {
@@ -58,7 +60,7 @@ export default class ComponentHeadingRowHeading extends React.Component {
             color,
             position: 'relative',
             zIndex: 1005,
-            marginLeft: 10,
+            marginLeft: 25,
             display: 'inline-block',
             width: 100,
             height: 20

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1214,6 +1214,8 @@ class Timeline extends React.Component {
           const reflection = groups.length - idx
           console.info(`[timeline] z-drop ${result.draggableId} at`, reflection)
 
+          this.props.mixpanel.haikuTrack('creator:timeline:z-shift')
+
           this.getActiveComponent().zShiftIndices(
             result.draggableId,
             this.getActiveComponent().getInstantiationTimelineName(),
@@ -1371,6 +1373,7 @@ class Timeline extends React.Component {
             const row = this.getActiveComponent().getFocusedRow()
             const ms = this.getActiveComponent().getCurrentTimeline().getCurrentMs()
             console.info('[timeline] commit', JSON.stringify(committedValue), 'at', ms, 'on', row.dump())
+            this.props.mixpanel.haikuTrack('creator:timeline:create-keyframe')
             row.createKeyframe(committedValue, ms, { from: 'timeline' })
           }}
           onFocusRequested={() => {

--- a/packages/haiku-timeline/src/index.js
+++ b/packages/haiku-timeline/src/index.js
@@ -71,8 +71,6 @@ function go () {
     email: config.email
   })
 
-  mixpanel = require('haiku-serialization/src/utils/Mixpanel')
-
   mixpanel.mergeToPayload({
     distinct_id: config.email
   })

--- a/packages/haiku-timeline/src/index.js
+++ b/packages/haiku-timeline/src/index.js
@@ -8,6 +8,8 @@ import MockWebsocket from 'haiku-serialization/src/ws/MockWebsocket'
 import Timeline from './components/Timeline'
 import {sentryCallback} from 'haiku-serialization/src/utils/carbonite'
 
+const mixpanel = require('haiku-serialization/src/utils/Mixpanel')
+
 if (process.env.NODE_ENV === 'production') {
   window.Raven.config('https://d045653ab5d44c808480fa6c3fa8e87c@sentry.io/226387', {
     environment: process.env.NODE_ENV || 'development',
@@ -69,10 +71,17 @@ function go () {
     email: config.email
   })
 
+  mixpanel = require('haiku-serialization/src/utils/Mixpanel')
+
+  mixpanel.mergeToPayload({
+    distinct_id: config.email
+  })
+
   window.isWebview = config.webview
 
   ReactDOM.render(
     <Timeline
+      mixpanel={mixpanel}
       envoy={config.envoy}
       userconfig={userconfig}
       websocket={websocket}

--- a/packages/haiku-ui-common/src/react/icons/DragGrip.tsx
+++ b/packages/haiku-ui-common/src/react/icons/DragGrip.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export default ({color = '#657575'}) => (
+  <svg width="20px" height="15px" viewBox="0 0 20 15">
+    <g id="Group" transform="translate(1.000000, 0.000000)" stroke={color} strokeWidth="2">
+      <path d="M0.5,1.5 L25.5,1.5" id="Line1"></path>
+      <path d="M0.5,7.5 L25.5,7.5" id="Line2"></path>
+      <path d="M0.5,13.5 L25.5,13.5" id="Line3"></path>
+    </g>
+  </svg>
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5745,6 +5745,10 @@ hoist-non-react-statics@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
+hoist-non-react-statics@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -6083,6 +6087,12 @@ into-stream@^3.1.0:
   dependencies:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
+
+invariant@^2.0.0:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  dependencies:
+    loose-envify "^1.0.0"
 
 invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
@@ -6924,6 +6934,10 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash-es@^4.17.5:
+  version "4.17.8"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.8.tgz#6fa8c8c5d337481df0bdf1c0d899d42473121e45"
+
 lodash-es@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
@@ -7173,6 +7187,10 @@ lodash@^3.10.1, lodash@^3.6.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
+lodash@^4.17.5:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
 lodash@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"
@@ -7375,6 +7393,10 @@ mem@^1.1.0:
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
   dependencies:
     mimic-fn "^1.0.0"
+
+memoize-one@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-3.1.1.tgz#ef609811e3bc28970eac2884eece64d167830d17"
 
 memoizee@^0.4.3:
   version "0.4.6"
@@ -9222,6 +9244,10 @@ radium@^0.19.0:
     inline-style-prefixer "^2.0.5"
     prop-types "^15.5.8"
 
+raf-schd@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-2.1.1.tgz#0b59964cee2e96b7dd46ffaeb5c08740f3a5e7ab"
+
 raf@^3.1.0, raf@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
@@ -9306,6 +9332,21 @@ react-addons-css-transition-group@15.6.2:
 react-animations@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/react-animations/-/react-animations-0.1.0.tgz#519b6f4fe0f90b49fbfd4fcd73d978c5087130b1"
+
+react-beautiful-dnd@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-6.0.1.tgz#f5b70cc37188bd9e79c2bd2152bebfadb2861cff"
+  dependencies:
+    babel-runtime "^6.26.0"
+    invariant "^2.2.2"
+    memoize-one "^3.1.1"
+    prop-types "^15.6.0"
+    raf-schd "^2.1.1"
+    react-motion "^0.5.2"
+    react-redux "^5.0.6"
+    redux "^3.7.2"
+    redux-thunk "^2.2.0"
+    reselect "^3.0.1"
 
 react-contextmenu@2.1.0:
   version "2.1.0"
@@ -9422,6 +9463,14 @@ react-motion@0.4.7:
     performance-now "^0.2.0"
     raf "^3.1.0"
 
+react-motion@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.2.tgz#0dd3a69e411316567927917c6626551ba0607316"
+  dependencies:
+    performance-now "^0.2.0"
+    prop-types "^15.5.8"
+    raf "^3.1.0"
+
 react-onclickoutside@^6.4.0:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.0.tgz#997a4d533114c9a0a104913638aa26afc084f75c"
@@ -9436,6 +9485,17 @@ react-popover@^0.4.18:
     lodash.throttle "^3.0.3"
     prop-types "^15.5.10"
     react-dom-factories "^1.0.0"
+
+react-redux@^5.0.6:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.7.tgz#0dc1076d9afb4670f993ffaef44b8f8c1155a4c8"
+  dependencies:
+    hoist-non-react-statics "^2.5.0"
+    invariant "^2.0.0"
+    lodash "^4.17.5"
+    lodash-es "^4.17.5"
+    loose-envify "^1.1.0"
+    prop-types "^15.6.0"
 
 react-router-dom@^4.1.1:
   version "4.2.2"
@@ -9705,6 +9765,10 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+redux-thunk@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
 
 redux@^3.7.2:
   version "3.7.2"
@@ -9985,6 +10049,10 @@ require-uncached@^1.0.2:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
 
 resolve-dir@^1.0.0, resolve-dir@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
OK to merge. (Although is still some refinement/QA/bug-fixing to do.)

Short-ish review.

Summary of changes:

- Let timeline elements be dragged/dropped to reorder z-index.

Regressions to look for:

- Bugs with z-stuff.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [x] Added measurement instrumentation (Mixpanel, etc.)
