### PR TITLE
feat: use iPreview haiku as preview button

### DIFF
--- a/packages/haiku-creator/package.json
+++ b/packages/haiku-creator/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@haiku/core": "3.1.32",
+    "@haiku/taylor-ipreview2": "^0.0.2",
     "@haiku/zack4-creatorintro": "^0.0.6",
     "async": "^2.5.0",
     "better-react-spinkit": "2.0.0-4",

--- a/packages/haiku-creator/src/react/components/Toggle.js
+++ b/packages/haiku-creator/src/react/components/Toggle.js
@@ -1,10 +1,7 @@
 import React from 'react'
 import Radium from 'radium'
 import IPreview from '@haiku/taylor-ipreview2/react'
-import Palette from 'haiku-ui-common/lib/Palette'
 import {Tooltip} from 'haiku-ui-common/lib/react/Tooltip'
-import {EyeIconSVG} from 'haiku-ui-common/lib/react/OtherIcons'
-import {BTN_STYLES} from '../styles/btnShared'
 
 const STYLES = {
   disabled: {

--- a/packages/haiku-creator/src/react/components/Toggle.js
+++ b/packages/haiku-creator/src/react/components/Toggle.js
@@ -1,29 +1,12 @@
 import React from 'react'
 import Radium from 'radium'
+import IPreview from '@haiku/taylor-ipreview2/react'
 import Palette from 'haiku-ui-common/lib/Palette'
 import {Tooltip} from 'haiku-ui-common/lib/react/Tooltip'
 import {EyeIconSVG} from 'haiku-ui-common/lib/react/OtherIcons'
 import {BTN_STYLES} from '../styles/btnShared'
 
 const STYLES = {
-  wrapper: {
-    cursor: 'pointer',
-    borderStyle: 'solid',
-    borderWidth: '1px',
-    borderColor: Palette.FATHER_COAL,
-    marginRight: '7px',
-    padding: '6px 5px 5px',
-    active: {
-      borderColor: Palette.LIGHTEST_PINK
-    }
-  },
-  eye: {
-    transform: 'scale(0.9)',
-    fontFamily: 'Fira Sans, Arial, sans-serif !important',
-    fontSize: '12px',
-    fontWeight: '400',
-    color: Palette.ROCK
-  },
   disabled: {
     pointerEvents: 'none',
     opacity: 0.5
@@ -48,16 +31,22 @@ class Toggle extends React.Component {
         <a
           href='#'
           style={[
-            BTN_STYLES.btnText,
-            STYLES.wrapper,
-            this.props.active && STYLES.wrapper.active,
             this.props.disabled && STYLES.disabled,
-            this.props.style
+            this.props.style,
+            {marginTop: -5}
           ]}
-          onClick={this.onToggle}
+          onClick={() => {
+            this.onToggle()
+            this.props.active
+              ? this.previewHaiku.getDefaultTimeline().gotoAndPlay(0)
+              : this.previewHaiku.getDefaultTimeline().gotoAndPlay(100)
+          }}
         >
           <div style={STYLES.eye}>
-            <EyeIconSVG color={STYLES.eye.color} />
+            <IPreview
+              haikuStates={{isOn: { value: this.props.active } }}
+              onHaikuComponentDidMount={(component) => this.previewHaiku = component}
+            />
           </div>
         </a>
       </Tooltip>

--- a/packages/haiku-creator/src/react/components/Toggle.js
+++ b/packages/haiku-creator/src/react/components/Toggle.js
@@ -41,8 +41,10 @@ class Toggle extends React.Component {
         >
           <div style={STYLES.eye}>
             <IPreview
-              haikuStates={{isOn: { value: this.props.active } }}
-              onHaikuComponentDidMount={(component) => this.previewHaiku = component}
+              haikuStates={{isOn: {value: this.props.active}}}
+              onHaikuComponentDidMount={(component) => {
+                this.previewHaiku = component
+              }}
             />
           </div>
         </a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,6 +26,12 @@
   version "3.0.4"
   resolved "https://reservoir.haiku.ai:8910/@haiku%2fplayer/-/player-3.0.4.tgz#dd0bb8fbdea4751c8825adbd6b8ec528a781abaa"
 
+"@haiku/taylor-ipreview2@^0.0.2":
+  version "0.0.2"
+  resolved "https://reservoir.haiku.ai:8910/@haiku%2ftaylor-ipreview2/-/taylor-ipreview2-0.0.2.tgz#d46e790046082107bb2dc624fd72132e8ba9dd6a"
+  dependencies:
+    "@haiku/core" "^3.1.32"
+
 "@haiku/zack4-creatorintro@^0.0.6":
   version "0.0.6"
   resolved "https://reservoir.haiku.ai:8910/@haiku%2fzack4-creatorintro/-/zack4-creatorintro-0.0.6.tgz#56262dfd64dd54a42609883359c539f812953581"


### PR DESCRIPTION
OK to merge.
![image](https://d2ffutrenqvap3.cloudfront.net/items/023Q3d3D0d2i2y3I2B0I/Screen%20Recording%202018-03-30%20at%2007.14%20PM.gif?v=c010d6e2)

Uses the iPreview haiku for our preview button in the app.
https://app.asana.com/0/591362404931103/601832791404301

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
