### PR TITLE
Public/private tweaks

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -854,6 +854,10 @@ export default class Creator extends React.Component {
     )
   }
 
+  onProjectPublicChange (isPublic) {
+    this.setState({projectObject: {...this.state.projectObject, isPublic}})
+  }
+
   launchProject (projectName, projectObject, cb) {
     projectObject = {
       ...projectObject,
@@ -1559,6 +1563,7 @@ export default class Creator extends React.Component {
                     isPreviewMode={isPreviewMode(this.state.interactionMode)}
                     onPreviewModeToggled={() => { this.togglePreviewMode() }}
                     artboardDimensions={this.state.artboardDimensions}
+                    onProjectPublicChange={(isPublic) => { this.onProjectPublicChange(isPublic) }}
                   />
                   {(this.state.assetDragging)
                     ? <div style={{ width: '100%', height: '100%', backgroundColor: 'white', opacity: 0.01, position: 'absolute', top: 0, left: 0 }} />

--- a/packages/haiku-creator/src/react/components/Stage.js
+++ b/packages/haiku-creator/src/react/components/Stage.js
@@ -221,6 +221,7 @@ export default class Stage extends React.Component {
             isPreviewMode={this.props.isPreviewMode}
             isTimelineReady={this.props.isTimelineReady}
             envoyClient={this.props.envoyClient}
+            onProjectPublicChange={this.props.onProjectPublicChange}
           />
           {(experimentIsEnabled(Experiment.MultiComponentFeatures))
             ? <ComponentMenu

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -589,6 +589,7 @@ class StageTitleBar extends React.Component {
             projectUid={projectInfo.uuid}
             sha={projectInfo.sha}
             mixpanel={mixpanel}
+            onProjectPublicChange={this.props.onProjectPublicChange}
           />
         }
       </div>

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -1465,6 +1465,7 @@ function remapProjectObjectToExpectedFormat (projectObject, organizationName) {
     projectExistsLocally: fse.existsSync(projectPath),
     projectsHome: HOMEDIR_PATH,
     repositoryUrl: projectObject.RepositoryUrl,
-    forkComplete: projectObject.ForkComplete
+    forkComplete: projectObject.ForkComplete,
+    isPublic: projectObject.IsPublic
   }
 }

--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -34,6 +34,7 @@ export interface PropTypes {
   projectUid: string;
   sha: string;
   mixpanel: object;
+  onProjectPublicChange: Function;
 }
 
 export interface StateTypes {
@@ -59,7 +60,7 @@ export class ShareModal extends React.Component<PropTypes, StateTypes> {
 
     this.state = {
       showDetail: false,
-      isPublic: undefined,
+      isPublic: props.project && props.project.isPublic,
       showTooltip: false,
       isPublicKnown: false,
     };
@@ -79,7 +80,9 @@ export class ShareModal extends React.Component<PropTypes, StateTypes> {
 
         // if IsPublic is undefined, it's never been published before. Make it private on first publish
         if (proj.IsPublic === null || proj.IsPublic === undefined) {
-          (nextProps.envoyProject.setIsPublic(nextProps.projectUid, false) as Promise<boolean>).then(() => {});
+          (nextProps.envoyProject.setIsPublic(nextProps.projectUid, false) as Promise<boolean>).then(() => {
+            this.props.onProjectPublicChange(false);
+          });
           this.setState({isPublic: false});
         } else {
           this.setState({isPublic: proj.IsPublic, isPublicKnown: true});
@@ -107,7 +110,9 @@ export class ShareModal extends React.Component<PropTypes, StateTypes> {
       const desiredState = !this.state.isPublic;
       const project = props.envoyProject;
 
-      (project.setIsPublic(props.projectUid, desiredState) as Promise<boolean>).then(() => {});
+      (project.setIsPublic(props.projectUid, desiredState) as Promise<boolean>).then(() => {
+        this.props.onProjectPublicChange(desiredState);
+      });
       this.setState({isPublic: desiredState, isPublicKnown: true});
     } else {
       // TODO:  trigger toast

--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -77,10 +77,10 @@ export class ShareModal extends React.Component<PropTypes, StateTypes> {
     if (nextProps.envoyProject && nextProps.projectUid && !this.state.isPublicKnown) {
       (nextProps.envoyProject.getProjectDetail(nextProps.projectUid) as Promise<inkstone.project.Project>).then((proj: inkstone.project.Project) => {
 
-        // if IsPublic is undefined, it's never been published before.  toggle it true on first publish.
+        // if IsPublic is undefined, it's never been published before. Make it private on first publish
         if (proj.IsPublic === null || proj.IsPublic === undefined) {
-          (nextProps.envoyProject.setIsPublic(nextProps.projectUid, true) as Promise<boolean>).then(() => {});
-          this.setState({isPublic: true});
+          (nextProps.envoyProject.setIsPublic(nextProps.projectUid, false) as Promise<boolean>).then(() => {});
+          this.setState({isPublic: false});
         } else {
           this.setState({isPublic: proj.IsPublic, isPublicKnown: true});
         }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- [Display privacy toggle state instantly](https://app.asana.com/0/607625220671718/612367254519327)
- [Make projects "Private" by default](https://app.asana.com/0/607625220671718/615645754685511)

Notes for reviewers:

Instead of using any kind of storage as initially suggested on Asana, I took another approach:

- "Whitelist" in plumbing the `IsPublic` attribute that is coming when listing projects, allowing `projectObject`s to have the attribute
- Update the state that contains `projectObject` with the proper value of `isPublic` when the toggle is switched (we need some form of state management)

Do you agree that this is a better approach? If no I can change it.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
