### PR TITLE
fix: upgrade bytecode in place only after setting up caches.

### DIFF
--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -155,18 +155,6 @@ export default class HaikuComponent extends HaikuElement {
     // Ensure all __instance, __parent, etc. are properly set up and connected to the models
     this.reinitializeTree(container);
 
-    try {
-      // If the bytecode we got happens to be in an outdated format, we automatically update it to the latest.
-      upgradeBytecodeInPlace(this, {
-        // Random seed for adding instance uniqueness to ids at runtime.
-        referenceUniqueness: (config.hotEditingMode)
-          ? void (0) // During editing, Haiku.app pads ids unless this is undefined
-          : Math.random().toString(36).slice(2),
-      });
-    } catch (e) {
-      console.warn('[haiku core] caught error during attempt to upgrade bytecode in place');
-    }
-
     // Flag used internally to determine whether we need to re-render the full tree or can survive by just patching
     this._needsFullFlush = false;
 
@@ -208,6 +196,18 @@ export default class HaikuComponent extends HaikuElement {
 
     // Flag to indicate whether we are sleeping, an ephemeral condition where no rendering occurs
     this._isSleeping = false;
+
+    try {
+      // If the bytecode we got happens to be in an outdated format, we automatically update it to the latest.
+      upgradeBytecodeInPlace(this, {
+        // Random seed for adding instance uniqueness to ids at runtime.
+        referenceUniqueness: (config.hotEditingMode)
+          ? void (0) // During editing, Haiku.app pads ids unless this is undefined
+          : Math.random().toString(36).slice(2),
+      });
+    } catch (e) {
+      console.warn('[haiku core] caught error during attempt to upgrade bytecode in place');
+    }
 
     // Start the default timeline to initiate the component;
     // run before the did-initialize hook in case the user wants to cancel

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -149,8 +149,6 @@ export class Glass extends React.Component {
     this._stopwatch = null
     this._lastAuthoritativeFrame = 0
 
-    this._clipboardActionInfiniteLoopPrevention = false
-
     this.drawLoop = this.drawLoop.bind(this)
     this.draw = this.draw.bind(this)
 


### PR DESCRIPTION
OK to merge. Rolling PR with additional fixes being added if you'd like to wait.

Short review.

Summary of changes:

- Upgrade bytecode in place only after setting up caches. Fixes silent crash when upgrading projects with event handlers (due to calling `render()` too early).

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [x] Wrote an automated test covering new functionality
