### PR TITLE
fix: use selectSoftly during selectAll to fix selectAll.

### DIFF
--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -525,7 +525,7 @@ class ActiveComponent extends BaseModel {
   selectAll (options, metadata, cb) {
     return Lock.request(Lock.LOCKS.ActiveComponentWork, false, (release) => {
       this.getArtboard().getElement().children.forEach((element) => {
-        element.select(metadata)
+        element.selectSoftly(metadata)
       })
 
       release()


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fix weird `selectAll` regression. If not using `selectSoftly`, the multiselect becomes self-canceling for "reasons".