### PR TITLE
fix: un-break origin upgrade in headless mode.

### DIFF
--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -207,6 +207,7 @@ export default class HaikuComponent extends HaikuElement {
       });
     } catch (e) {
       console.warn('[haiku core] caught error during attempt to upgrade bytecode in place');
+      console.warn(e);
     }
 
     // Start the default timeline to initiate the component;
@@ -1290,17 +1291,19 @@ function applyContextChanges(component, template, container, context, renderOpti
     false, // isPatchOperation
   );
 
-  component.eachEventHandler((eventSelector, eventName, {handler}) => {
-    if (component.registeredEventHandlers[eventName]) {
-      return;
-    }
+  if (component._context.renderer.mount) {
+    component.eachEventHandler((eventSelector, eventName, {handler}) => {
+      if (component.registeredEventHandlers[eventName]) {
+        return;
+      }
 
-    component.registeredEventHandlers[eventName] = true;
+      component.registeredEventHandlers[eventName] = true;
 
-    component._context.renderer.mountEventListener(eventSelector, eventName, (...args) => {
-      component.routeEventToHandlerAndEmit(eventSelector, eventName, args);
+      component._context.renderer.mountEventListener(eventSelector, eventName, (...args) => {
+        component.routeEventToHandlerAndEmit(eventSelector, eventName, args);
+      });
     });
-  });
+  }
 
   if (renderOptions.sizing) {
     computeAndApplyPresetSizing(


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Don't try to mount event listeners if we don't have a mount. Fixes `upgradeBytecodeInPlace` silent crash in headless mode which leads to the necessary mount offsets not being persisted on disk.
- Log `upgradeBytecodeInPlace` crashes. They are too important for us to not know what they are.