### PR TITLE
fix: use isNumeric to determine if a frame is a timeline event or not

### DIFF
--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
@@ -155,7 +155,7 @@ class EventHandlerEditor extends React.PureComponent {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (nextProps.options.frame) {
+    if (isNumeric(nextProps.options.frame)) {
       const event = HandlerManager.frameToEvent(nextProps.options.frame)
       this.setState({ currentEvent: event })
     }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- [Frame 0 action editor shows the element editor](https://app.asana.com/0/607625220671718/622937571264305)

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
