### PR TITLE
Percy fix

### DIFF
--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -1291,11 +1291,13 @@ function applyContextChanges(component, template, container, context, renderOpti
   );
 
   component.eachEventHandler((eventSelector, eventName, {handler}) => {
-    if (component.registeredEventHandlers[eventName]) {
+    const registrationKey  = `${eventSelector}:${eventName}`;
+
+    if (component.registeredEventHandlers[registrationKey]) {
       return;
     }
 
-    component.registeredEventHandlers[eventName] = true;
+    component.registeredEventHandlers[registrationKey] = true;
 
     component._context.renderer.mountEventListener(eventSelector, eventName, (...args) => {
       component.routeEventToHandlerAndEmit(eventSelector, eventName, args);


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes [Putting coin in Percy is broken](https://app.asana.com/0/607625220671718/630526049204162/f). Somewhere in `eventing-refactor` we landed an optimization that only allowed one event handler per event type. This is now fixed to: "one event handler per event type per selector".