### PR TITLE
Feat: import Figma assets 'marked for export'

### DIFF
--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -175,9 +175,10 @@ class Library extends React.Component {
     return this.state.figma.importSVG({url, path})
       .catch((error = {}) => {
         mixpanel.haikuTrack('creator:figma:fileImport:fail')
-        Raven.captureException(error)
 
         let message = error.err || 'We had a problem connecting with Figma. Please check your internet connection and try again.'
+
+        Raven.captureException(message)
 
         if (error.status === 403) {
           message = (


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Add support for importing assets 'marked for export' from the panel on the bottom-right corner:

![screen shot 2018-04-17 at 19 19 17](https://user-images.githubusercontent.com/4419992/38901864-4e8a52d4-4274-11e8-9b40-49b21cb51c1a.png)

*Important:* these assets are going under the 'Slices' folder in the Haiku Library in order to be consistent with the way this feature works with Sketch, please shout if you think we should put them in other folder.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
