### PR TITLE
fix: library scroll area

### DIFF
--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -18,7 +18,7 @@ import FileImporter from './FileImporter'
 const STYLES = {
   scrollwrap: {
     overflowY: 'auto',
-    height: '100%'
+    height: 'calc(100% - 35px)'
   },
   sectionHeader: {
     cursor: 'default',


### PR DESCRIPTION
OK to merge.

This fixes a bug we had where the library scroll area wasn't letting the user get all the way to their last assets.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues