### PR TITLE
tweak: make dashboard btn 'explicit'

### DIFF
--- a/packages/haiku-creator/src/react/components/SideBar.js
+++ b/packages/haiku-creator/src/react/components/SideBar.js
@@ -117,6 +117,7 @@ class SideBar extends React.Component {
                  {width: 'auto', position: 'absolute', right: 6}
                ]}>
                <ChevronLeftMenuIconSVG />
+               DASHBOARD
              </button>
             : ''
           }

--- a/packages/haiku-ui-common/src/react/OtherIcons.tsx
+++ b/packages/haiku-ui-common/src/react/OtherIcons.tsx
@@ -178,7 +178,7 @@ export const CollapseChevronRightSVG = ({color = '#93999A'}) => (
 );
 
 export const ChevronLeftMenuIconSVG = ({color = Palette.ROCK}) => (
-  <svg width="14" height="17" viewBox="0 0 18 18">
+  <svg width="13" height="15" viewBox="0 0 18 18">
     <path d="M10 19a.5.5 0 0 0 .354-.853L1.708 9.501 10.354.855a.5.5 0 0 0-.707-.707l-9 9a.5.5 0 0 0 0 .707l9 9a.498.498 0 0 0 .354.146L10 19z" fill={color}/>
   </svg>
 );


### PR DESCRIPTION

Adds the text 'Dashboard' to the dashboard btn.

![image](https://user-images.githubusercontent.com/1357566/38967675-0b61c658-433d-11e8-944c-e6f0096c25a4.png)


Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues