### PR TITLE
feature: add an overlay to elements hovered

### DIFF
--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -98,5 +98,9 @@
   "AdvancedMultiTransform": {
     "development": true,
     "production": false
+  },
+  "OutliningElementsOnStage": {
+    "development": true,
+    "production": false
   }
 }

--- a/packages/haiku-common/src/experiments/index.ts
+++ b/packages/haiku-common/src/experiments/index.ts
@@ -33,6 +33,7 @@ export enum Experiment {
   OriginIndicator = 'OriginIndicator',
   ComponentInfoInspector = 'ComponentInfoInspector',
   AdvancedMultiTransform = 'AdvancedMultiTransform',
+  OutliningElementsOnStage = 'OutliningElementsOnStage',
 }
 
 /**

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -67,6 +67,8 @@ const DIMENSIONS_RESET_DEBOUNCE_TIME = 100
 
 const BIG_NUMBER = 99999
 
+const OUTLINE_CLONE_SUFFIX = 'outline-clone-helper'
+
 function isNumeric (n) {
   return !isNaN(parseFloat(n)) && isFinite(n)
 }
@@ -252,6 +254,15 @@ export class Glass extends React.Component {
         case 'dimensions-reset':
           this.handleDimensionsReset()
           break
+        case 'hoverElement':
+          this.hoverHighlight(args[1])
+          break
+        case 'unhoverElement':
+          this.unhoverHighlight(args[1])
+          break
+        case 'selectElement':
+          this.unhoverHighlight(args[1])
+          break
       }
     })
 
@@ -262,6 +273,15 @@ export class Glass extends React.Component {
           break
         case 'setInteractionMode':
           this.handleInteractionModeChange()
+          break
+        case 'hoverElement':
+          this.hoverHighlight(args[1])
+          break
+        case 'unhoverElement':
+          this.unhoverHighlight(args[1])
+          break
+        case 'selectElement':
+          this.unhoverHighlight(args[1])
           break
       }
     })
@@ -665,6 +685,7 @@ export class Glass extends React.Component {
     this.addEmitterListener(window, 'dblclick', this.windowDblClickHandler.bind(this))
     this.addEmitterListener(window, 'keydown', this.windowKeyDownHandler.bind(this))
     this.addEmitterListener(window, 'keyup', this.windowKeyUpHandler.bind(this))
+    this.addEmitterListener(window, 'mouseover', this.windowMouseOverHandler.bind(this))
     this.addEmitterListener(window, 'mouseout', this.windowMouseOutHandler.bind(this))
     // When the mouse is clicked, below is the order that events fire
     this.addEmitterListener(window, 'mousedown', this.windowMouseDownHandler.bind(this))
@@ -816,15 +837,80 @@ export class Glass extends React.Component {
     this.getActiveComponent().getArtboard().performPan(dx, dy)
   }
 
-  windowMouseOutHandler (nativeEvent) {
+  hoverHighlight (haikuId) {
+    if (experimentIsEnabled(Experiment.OutliningElementsOnStage) && !this.isPreviewMode()) {
+      const element = Element.find({componentId: haikuId})
+
+      if (!element.isSelected() && !this.state.isMouseDragging) {
+        const $domElement = document.querySelector(`[haiku-id='${haikuId}']`)
+        const $duplicate = $domElement.cloneNode()
+        $duplicate.style.outline = `1px solid ${Palette.LIGHT_PINK}`
+        $duplicate.style.zIndex = '999999999'
+        $duplicate.style.pointerEvents = 'none'
+        $duplicate.setAttribute('haiku-id', `${haikuId}-${OUTLINE_CLONE_SUFFIX}`)
+        $domElement.parentNode.appendChild($duplicate)
+      }
+    }
+  }
+
+  unhoverHighlight (haikuId) {
+    if (experimentIsEnabled(Experiment.OutliningElementsOnStage) && !this.isPreviewMode()) {
+      const $domElement = document.querySelector(`[haiku-id='${haikuId}-${OUTLINE_CLONE_SUFFIX}']`)
+
+      if ($domElement) {
+        $domElement.remove()
+      }
+    }
+  }
+
+  findElementAssociatedToMouseEvent (mouseEvent) {
+    let target = this.findNearestDomSelectionTarget(mouseEvent.target)
+
+    // True if the action was performed on the transform control for a selected element
+    if (target === SELECTION_TYPES.ON_STAGE_CONTROL) {
+      return
+    }
+
+    // True if the action was performed on the stage, but not on any on-stage element
+    if (!target || !target.hasAttribute) {
+      return
+    }
+
+    target = this.validTargetOrNull(target)
+
+    // Truthy if we found a valid, selectable element target
+    if (target) {
+      // First make sure we are grabbing the correct element based on the context.
+      // If we've landed on a component sub-element, we need to go up and select the wrapper.
+      let haikuId = target.getAttribute('haiku-id')
+
+      if (this.isDomNodeChildOfComponentWrapperDomNode(target)) {
+        haikuId = target.parentNode.getAttribute('haiku-id')
+      }
+
+      return this.getActiveComponent().findElementByComponentId(haikuId)
+    }
+  }
+
+  windowMouseOverHandler (mouseOver) {
     if (this.isPreviewMode()) {
       return void (0)
     }
 
-    const source = nativeEvent.relatedTarget || nativeEvent.toElement
-    if (!source || source.nodeName === 'HTML') {
-      // unhover?
-      // cleanup?
+    const element = this.findElementAssociatedToMouseEvent(mouseOver)
+    if (element) {
+      element.hoverOn({from: 'glass'})
+    }
+  }
+
+  windowMouseOutHandler (mouseOut) {
+    if (this.isPreviewMode()) {
+      return void (0)
+    }
+
+    const element = this.findElementAssociatedToMouseEvent(mouseOut)
+    if (element) {
+      element.hoverOff({from: 'glass'})
     }
   }
 

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -844,7 +844,7 @@ export class Glass extends React.Component {
         $duplicate.style.zIndex = '999999999'
         $duplicate.style.pointerEvents = 'none'
         $duplicate.setAttribute('haiku-id', `${haikuId}-${OUTLINE_CLONE_SUFFIX}`)
-        $domElement.parentNode.appendChild($duplicate)
+        this.refs.outline.appendChild($duplicate)
       }
     }
   }
@@ -2481,6 +2481,23 @@ export class Glass extends React.Component {
                 top: container.y,
                 left: container.x,
                 zIndex: 1999,
+                opacity: (this.state.isEventHandlerEditorOpen) ? 0.5 : 1.0
+              }} />
+            : ''}
+
+          {(!this.isPreviewMode())
+            ? <div
+              ref='outline'
+              id='haiku-glass-outline-mount'
+              style={{
+                position: 'absolute',
+                pointerEvents: 'none',
+                left: mount.x,
+                top: mount.y,
+                width: mount.w,
+                height: mount.h,
+                overflow: this.isPreviewMode() ? 'hidden' : 'visible',
+                zIndex: 60,
                 opacity: (this.state.isEventHandlerEditorOpen) ? 0.5 : 1.0
               }} />
             : ''}

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -258,8 +258,6 @@ export class Glass extends React.Component {
           this.hoverHighlight(args[1])
           break
         case 'unhoverElement':
-          this.unhoverHighlight(args[1])
-          break
         case 'selectElement':
           this.unhoverHighlight(args[1])
           break
@@ -278,8 +276,6 @@ export class Glass extends React.Component {
           this.hoverHighlight(args[1])
           break
         case 'unhoverElement':
-          this.unhoverHighlight(args[1])
-          break
         case 'selectElement':
           this.unhoverHighlight(args[1])
           break

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -84,7 +84,9 @@ const METHOD_MESSAGES_TO_HANDLE_IMMEDIATELY = {
   doLogOut: true,
   deleteProject: true,
   teardownMaster: true,
-  requestSyndicationInfo: true
+  requestSyndicationInfo: true,
+  hoverElement: true,
+  unhoverElement: true
 }
 
 const METHOD_MESSAGES_TIMEOUT = 15000

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -150,6 +150,10 @@ class ActiveComponent extends BaseModel {
           this.handleElementSelected(element.getComponentId(), metadata)
         } else if (what === 'element-unselected') {
           this.handleElementUnselected(element.getComponentId(), metadata)
+        } else if (what === 'element-hovered') {
+          this.handleElementHovered(element.getComponentId(), metadata)
+        } else if (what === 'element-unhovered') {
+          this.handleElementUnhovered(element.getComponentId(), metadata)
         } else if (
           what === 'jit-property-added' ||
           what === 'jit-property-removed'
@@ -493,6 +497,14 @@ class ActiveComponent extends BaseModel {
     this.project.updateHook('unselectElement', this.getSceneCodeRelpath(), componentId, metadata, (fire) => fire())
   }
 
+  handleElementHovered (componentId, metadata) {
+    this.project.updateHook('hoverElement', this.getSceneCodeRelpath(), componentId, metadata, (fire) => fire())
+  }
+
+  handleElementUnhovered (componentId, metadata) {
+    this.project.updateHook('unhoverElement', this.getSceneCodeRelpath(), componentId, metadata, (fire) => fire())
+  }
+
   getTopLevelElementHaikuIds () {
     const template = this.getReifiedBytecode().template
     const children = (template && template.children) || []
@@ -573,6 +585,24 @@ class ActiveComponent extends BaseModel {
         release()
         return cb() // Must return or the plumbing action circuit never completes
       })
+    })
+  }
+
+  hoverElement (componentId, metadata, cb) {
+    return Lock.request(Lock.LOCKS.ActiveComponentWork, false, (release) => {
+      const element = Element.findByComponentAndHaikuId(this, componentId)
+      element.hoverOn(metadata)
+      release()
+      return cb()
+    })
+  }
+
+  unhoverElement (componentId, metadata, cb) {
+    return Lock.request(Lock.LOCKS.ActiveComponentWork, false, (release) => {
+      const element = Element.findByComponentAndHaikuId(this, componentId)
+      element.hoverOff(metadata)
+      release()
+      return cb()
     })
   }
 

--- a/packages/haiku-serialization/src/bll/Row.js
+++ b/packages/haiku-serialization/src/bll/Row.js
@@ -193,10 +193,15 @@ class Row extends BaseModel {
     return this._isHidden
   }
 
-  hover () {
+  hover (metadata) {
     if (!this._isHovered) {
       this._isHovered = true
       this.emit('update', 'row-hovered')
+
+      // Roundabout! Note that elements, when hovered, will hover their corresponding row
+      if (this.isHeading() && this.element && !this.element.isHovered() && !this.element.isSelected()) {
+        this.element.hoverOn(metadata)
+      }
     }
     return this
   }
@@ -205,17 +210,22 @@ class Row extends BaseModel {
     return this._isHovered
   }
 
-  hoverAndUnhoverOthers () {
+  hoverAndUnhoverOthers (metadata) {
     Row.where({ component: this.component }).forEach((row) => {
-      if (row !== this) row.unhover()
+      if (row !== this) row.unhover(metadata)
     })
-    this.hover()
+    this.hover(metadata)
   }
 
-  unhover () {
+  unhover (metadata) {
     if (this._isHovered) {
       this._isHovered = false
       this.emit('update', 'row-unhovered')
+
+      // Roundabout! Note that elements, when hovered, will hover their corresponding row
+      if (this.isHeading() && this.element && this.element.isHovered()) {
+        this.element.hoverOff(metadata)
+      }
     }
     return this
   }

--- a/packages/haiku-timeline/src/components/ClusterRow.js
+++ b/packages/haiku-timeline/src/components/ClusterRow.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import lodash from 'lodash'
 import Palette from 'haiku-ui-common/lib/Palette'
 import truncate from 'haiku-ui-common/lib/helpers/truncate'
 import RightCarrotSVG from 'haiku-ui-common/lib/react/icons/RightCarrotSVG'
@@ -10,6 +11,21 @@ import Globals from 'haiku-ui-common/lib/Globals'
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
 
 export default class ClusterRow extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.throttledHandleRowHovered = lodash.throttle(this.handleRowHovered, 20).bind(this)
+    this.throttledHandleRowUnhovered = lodash.throttle(this.handleRowUnhovered, 20).bind(this)
+  }
+
+  handleRowHovered (event) {
+    this.props.row.hoverAndUnhoverOthers({ from: 'timeline' })
+  }
+
+  handleRowUnhovered (event) {
+    this.props.row.unhover({ from: 'timeline' })
+  }
+
   maybeRenderFamilySvg () {
     if (!this.props.prev) return false
     if (this.props.row.doesTargetHostElement()) return false
@@ -51,12 +67,8 @@ export default class ClusterRow extends React.Component {
         }}
         id={`property-cluster-row-${this.props.row.getAddress()}-${componentId}-${clusterName}`}
         className='property-cluster-row'
-        onMouseEnter={() => {
-          this.props.row.hoverAndUnhoverOthers()
-        }}
-        onMouseLeave={() => {
-          this.props.row.unhover()
-        }}
+        onMouseEnter={this.throttledHandleRowHovered}
+        onMouseLeave={this.throttledHandleRowUnhovered}
         onClick={() => {
           this.props.row.expandAndSelect({ from: 'timeline' })
         }}

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import lodash from 'lodash'
 import DownCarrotSVG from 'haiku-ui-common/lib/react/icons/DownCarrotSVG'
 import RightCarrotSVG from 'haiku-ui-common/lib/react/icons/RightCarrotSVG'
 import DragGrip from 'haiku-ui-common/lib/react/icons/DragGrip'
@@ -13,6 +14,8 @@ export default class ComponentHeadingRow extends React.Component {
   constructor (props) {
     super(props)
     this.handleUpdate = this.handleUpdate.bind(this)
+    this.throttledHandleRowHovered = lodash.throttle(this.handleRowHovered, 20).bind(this)
+    this.throttledHandleRowUnhovered = lodash.throttle(this.handleRowUnhovered, 20).bind(this)
   }
 
   componentWillUnmount () {
@@ -42,6 +45,14 @@ export default class ComponentHeadingRow extends React.Component {
       (this.props.isSelected ^ nextProps.isSelected) ||
       (this.props.hasAttachedActions ^ nextProps.hasAttachedActions)
     )
+  }
+
+  handleRowHovered (event) {
+    this.props.row.hoverAndUnhoverOthers({ from: 'timeline' })
+  }
+
+  handleRowUnhovered (event) {
+    this.props.row.unhover({ from: 'timeline' })
   }
 
   render () {
@@ -92,12 +103,8 @@ export default class ComponentHeadingRow extends React.Component {
         }
         <div
           className='component-heading-row-inner no-select'
-          onMouseOver={() => {
-            this.props.row.hoverAndUnhoverOthers()
-          }}
-          onMouseOut={() => {
-            this.props.row.unhover()
-          }}
+          onMouseOver={this.throttledHandleRowHovered}
+          onMouseOut={this.throttledHandleRowUnhovered}
           onClick={(clickEvent) => {
             clickEvent.stopPropagation()
             // Expand and select the entire component area when it is clicked, but note that we

--- a/packages/haiku-timeline/src/components/PropertyRow.js
+++ b/packages/haiku-timeline/src/components/PropertyRow.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import lodash from 'lodash'
 import humanizePropertyName from 'haiku-ui-common/lib/helpers/humanizePropertyName'
 import truncate from 'haiku-ui-common/lib/helpers/truncate'
 import DownCarrotSVG from 'haiku-ui-common/lib/react/icons/DownCarrotSVG'
@@ -11,6 +12,21 @@ import PropertyTimelineSegments from './PropertyTimelineSegments'
 import PropertyRowHeading from './PropertyRowHeading'
 
 export default class PropertyRow extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.throttledHandleRowHovered = lodash.throttle(this.handleRowHovered, 20).bind(this)
+    this.throttledHandleRowUnhovered = lodash.throttle(this.handleRowUnhovered, 20).bind(this)
+  }
+
+  handleRowHovered (event) {
+    this.props.row.hoverAndUnhoverOthers({ from: 'timeline' })
+  }
+
+  handleRowUnhovered (event) {
+    this.props.row.unhover({ from: 'timeline' })
+  }
+
   maybeRenderFamilySvg () {
     if (!this.props.prev) return false
     if (this.props.row.doesTargetHostElement()) return false
@@ -50,12 +66,8 @@ export default class PropertyRow extends React.Component {
       <div
         id={`property-row-${this.props.row.getAddress()}-${componentId}-${propertyName}`}
         className='property-row'
-        onMouseEnter={() => {
-          this.props.row.hoverAndUnhoverOthers()
-        }}
-        onMouseLeave={() => {
-          this.props.row.unhover()
-        }}
+        onMouseEnter={this.throttledHandleRowHovered}
+        onMouseLeave={this.throttledHandleRowUnhovered}
         style={{
           height: this.props.rowHeight,
           width: this.props.timeline.getPropertiesPixelWidth() + this.props.timeline.getTimelinePixelWidth(),


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

![5ada3c495c6d4568757367](https://user-images.githubusercontent.com/4419992/39069494-4d5f8f16-44b6-11e8-8c7b-477bb664892e.gif)

- Add an outline to elements when hovered on stage.
- Add an outline of stage elements when their row is hovered on the timeline.

Notes for reviewers:

- This featured is flagged under `OutliningElementsOnStage` and currently disabled in production
- I tried really hard to draw an outline of the svg shape instead of the bounding box, but it will require a huge amount of work by the approaches that I have found. I have settled to outline for now.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
