### PR TITLE
chore: upgrade monaco version from 0.10.1 to 0.12.0

### DIFF
--- a/packages/haiku-glass/index.html
+++ b/packages/haiku-glass/index.html
@@ -11,6 +11,25 @@
         // noop: eval is forbidden
       }
     </script>
+    <title>Haiku Glass</title>
+    <style>
+      html, body, #root {
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        border: 0;
+        margin: 0;
+        padding: 0;
+        background-color: #ebebeb;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="../../node_modules/raven-js/dist/raven.js"></script>
+    <script>
+      require('./lib/react/index')
+    </script>
     <script>
       // Monaco uses a custom amd loader that over-rides node's require.
       // Keep a reference to node's require so we can restore it after executing the amd loader file.
@@ -42,25 +61,6 @@
       amdRequire(['vs/editor/editor.main'], function() {
         window.monaco = monaco
       });
-    </script>
-    <title>Haiku Glass</title>
-    <style>
-      html, body, #root {
-        width: 100%;
-        height: 100%;
-        overflow: hidden;
-        border: 0;
-        margin: 0;
-        padding: 0;
-        background-color: #ebebeb;
-      }
-    </style>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script src="../../node_modules/raven-js/dist/raven.js"></script>
-    <script>
-      require('./lib/react/index')
     </script>
   </body>
 </html>

--- a/packages/haiku-glass/package.json
+++ b/packages/haiku-glass/package.json
@@ -31,7 +31,7 @@
     "haiku-ui-common": "3.2.16",
     "lodash": "^4.17.4",
     "moment": "2.18.1",
-    "monaco-editor": "^0.10.1",
+    "monaco-editor": "^0.12.0",
     "prettier": "^0.22.0",
     "pretty": "^2.0.0",
     "qs": "6.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7653,9 +7653,9 @@ moment@2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
-monaco-editor@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.10.1.tgz#8c96c4f15b6b5258bf92cbde93cad8a7e3007e14"
+monaco-editor@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.12.0.tgz#cd8621017526b57746245104d764bbf52ad42283"
 
 "mout@>=0.9 <2.0":
   version "1.1.0"


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

There was a [bug in monaco](https://github.com/Microsoft/monaco-editor/issues/621) which caused a [warning for an user](https://sentry.io/haiku-systems/javascript-glass/issues/530917581/?referrer=slack) early this week. This PR upgrades monaco to version 0.12.0 which has a fix for the bug.

Notes for reviewers:

You may notice the gymnastics around loading monaco in `index.html`, it is unbelievable that we have to this, but it is what it is. I had to move the call to the bottom so it doesn't conflict with other `require` calls.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
