### PR TITLE
feat: modify @haiku/sdk-inkstone to accept cookies.

### DIFF
--- a/packages/@haiku/sdk-inkstone/package.json
+++ b/packages/@haiku/sdk-inkstone/package.json
@@ -17,8 +17,6 @@
   "license": "UNLICENSED",
   "types": "./lib/index.d.ts",
   "dependencies": {
-    "lodash": "^4.17.4",
-    "mkdirp": "^0.5.1",
     "request": "^2.83.0"
   },
   "devDependencies": {


### PR DESCRIPTION
OK to merge, but do not upgrade on web until we [Deploy inkstone cookie support](https://app.asana.com/0/0/644197085643548/f), which has some necessary CORS changes whcih would otherwise prevent this from working (essentially deprecation of `Access-Control-Allow-Origin: *` in favor of `Access-Control-Allow-Origin: <value of request Origin header>`).

Short review.

Summary of changes:

- Modify `@haiku/sdk-inkstone` to send the request options `withCredentials`, which unblocks XHR from receiving/sending cookies.
- Make authToken always an optional parameter.
- Remove dependencies bloating the `@haiku/sdk-inkstone` bundle size needlessly
- Slightly modify the module to be compatible with the `xhr` drop-in replacement module (boils down to implementing `request.defaults` in a suitable way).

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed