### PR TITLE
fix: render the container for outline elements above the hot component mount

### DIFF
--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -2485,6 +2485,8 @@ export class Glass extends React.Component {
               }} />
             : ''}
 
+          {this.renderHotComponentMount(mount, drawingClassName)}
+
           {(!this.isPreviewMode())
             ? <div
               ref='outline'
@@ -2501,8 +2503,6 @@ export class Glass extends React.Component {
                 opacity: (this.state.isEventHandlerEditorOpen) ? 0.5 : 1.0
               }} />
             : ''}
-
-          {this.renderHotComponentMount(mount, drawingClassName)}
         </div>
       </div>
     )


### PR DESCRIPTION
OK to merge.

Very short review.

Summary of changes:

- Improve the UI of the outline feature introduced in #446 by drawing the outline above rendered elements. This is useful because some elements can be partially visible or not visible at all due to z-index.

![artboard](https://user-images.githubusercontent.com/4419992/39203425-20c5be4a-47cb-11e8-8c8d-d8da9d2af284.jpg)

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [ ] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
