### PR TITLE
feat: seek timeline and open expression editor on keyframe dblclick

### DIFF
--- a/packages/haiku-timeline/src/components/RowSegments.js
+++ b/packages/haiku-timeline/src/components/RowSegments.js
@@ -136,7 +136,7 @@ export default class RowSegments extends React.Component {
                   this.props.row.blurOthers({ from: 'timeline' })
                   this.props.row.focus({ from: 'timeline' })
                   this.props.row.select({ from: 'timeline' })
-                  mixpanel.haikuTrack('timeline:keyframe:double-clicked')
+                  mixpanel.haikuTrack('creator:timeline:keyframe:double-clicked')
                 }
               }}>
               {segmentPieces}

--- a/packages/haiku-timeline/src/components/RowSegments.js
+++ b/packages/haiku-timeline/src/components/RowSegments.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import mixpanel from 'haiku-serialization/src/utils/Mixpanel'
 import TransitionBody from './TransitionBody'
 import ConstantBody from './ConstantBody'
 import SoloKeyframe from './SoloKeyframe'
@@ -135,6 +136,7 @@ export default class RowSegments extends React.Component {
                   this.props.row.blurOthers({ from: 'timeline' })
                   this.props.row.focus({ from: 'timeline' })
                   this.props.row.select({ from: 'timeline' })
+                  mixpanel.haikuTrack('timeline:keyframe:double-clicked')
                 }
               }}>
               {segmentPieces}

--- a/packages/haiku-timeline/src/components/RowSegments.js
+++ b/packages/haiku-timeline/src/components/RowSegments.js
@@ -124,7 +124,19 @@ export default class RowSegments extends React.Component {
             <div
               id={`keyframe-container-${keyframe.getUniqueKey()}`}
               key={`keyframe-container-${keyframe.getUniqueKey()}`}
-              className={`keyframe-container no-select`}>
+              className={`keyframe-container no-select`}
+              onDoubleClick={(doubleClickEvent) => {
+                if (
+                  doubleClickEvent.target &&
+                  doubleClickEvent.target.id &&
+                  doubleClickEvent.target.id.includes('keyframe-dragger')
+                ) {
+                  this.props.timeline.seekToTime(keyframe.origMs)
+                  this.props.row.blurOthers({ from: 'timeline' })
+                  this.props.row.focus({ from: 'timeline' })
+                  this.props.row.select({ from: 'timeline' })
+                }
+              }}>
               {segmentPieces}
             </div>
           )


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Implements ["Double clicking a keyframe should move the playhead to that point in time and open its expression-editor"](https://app.asana.com/0/607687181871325/614190753418965)

![2018-04-25 15_29_30](https://user-images.githubusercontent.com/4419992/39265621-202cd314-489e-11e8-9a02-d2190ec4f4cb.gif)

Notes for reviewers:

- I had to implement this at `keyframe-container` level because individual keyframes are under `InvisibleKeyframeDragger` instances, which don't support double click events.

At the end it doesn't feel really hacky to me, but if you disagree please shout.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [x] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
