### PR TITLE
chore: Improve Figma error handling II

### DIFF
--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -181,47 +181,63 @@ class Library extends React.Component {
         mixpanel.haikuTrack('creator:figma:fileImport:fail', reportData)
 
         if (error.status === 403) {
-          message = (
-            <p>
-              We had problems importing your file.{' '}
-              If this problem persists, please click{' '}
-              <a
-                href='#'
-                style={STYLES.link}
-                onClick={() => {
-                  this.askForFigmaAuth()
-                }}
-              >
-                here
-              </a>{' '}
-              to log in with Figma again.
-            </p>
-          )
+          return this.props.createNotice({
+            type: 'danger',
+            title: 'Error',
+            message: (
+              <p>
+                We had problems importing your file.{' '}
+                If this problem persists, please click{' '}
+                <a
+                  href='#'
+                  style={STYLES.link}
+                  onClick={() => {
+                    this.askForFigmaAuth()
+                  }}
+                >
+                  here
+                </a>{' '}
+                to log in with Figma again.
+              </p>
+            )
+          })
         }
 
         if (error.status === 404) {
-          message = (
-            <p>
-              We couldn't access your file, please make sure that the file exists
-              and you have access to it.<br />
-              If you need to log in with another Figma account{' '}
-              <a
-                href='#'
-                style={STYLES.link}
-                onClick={() => {
-                  this.askForFigmaAuth()
-                }}
-              >
-                click here.
-              </a>{' '}
-            </p>
-          )
+          return this.props.createNotice({
+            type: 'danger',
+            title: 'Error',
+            message: (
+              <p>
+                We couldn't access your file, please make sure that the file exists
+                and you have access to it.<br />
+                If you need to log in with another Figma account{' '}
+                <a
+                  href='#'
+                  style={STYLES.link}
+                  onClick={() => {
+                    this.askForFigmaAuth()
+                  }}
+                >
+                  click here.
+                </a>{' '}
+              </p>
+            )
+          })
+        }
+
+        if (error.status === 424) {
+          return this.props.createNotice({
+            type: 'info',
+            title: 'Info',
+            message: message
+          })
         }
 
         this.props.createNotice({
           type: 'danger',
           title: 'Error',
-          message
+          message: message
         })
       })
   }

--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -174,11 +174,11 @@ class Library extends React.Component {
 
     return this.state.figma.importSVG({url, path})
       .catch((error = {}) => {
-        mixpanel.haikuTrack('creator:figma:fileImport:fail')
-
         let message = error.err || 'We had a problem connecting with Figma. Please check your internet connection and try again.'
+        const reportData = { url, message }
 
-        Raven.captureException(message)
+        Raven.captureException(new Error(message), reportData)
+        mixpanel.haikuTrack('creator:figma:fileImport:fail', reportData)
 
         if (error.status === 403) {
           message = (

--- a/packages/haiku-serialization/src/bll/Figma.js
+++ b/packages/haiku-serialization/src/bll/Figma.js
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-promise-reject-errors */
 const { URL, URLSearchParams } = require('url')
 const request = require('request')
 const fse = require('haiku-fs-extra')
@@ -148,8 +149,10 @@ class Figma {
       const uri = API_BASE + 'images/' + id + '?' + params.toString()
 
       if (ids.length === 0) {
-        // eslint-disable-next-line
-        return reject({err: 'We couldn\'t find any groups or slices in your project.'})
+        return reject({
+          status: 424,
+          err: 'It looks like the Figma document you imported doesn\'t have any groups or slices. Try adding some and re-syncing.'
+        })
       }
 
       this.request({ uri })
@@ -199,7 +202,7 @@ class Figma {
           try {
             reject(JSON.parse(body))
           } catch (e) {
-            reject(new Error('There was an error connecting with Figma.'))
+            reject({status: 500, err: 'There was an error connecting with Figma.'})
           }
         } else {
           resolve(body)
@@ -262,7 +265,7 @@ class Figma {
   static getAccessToken ({code, state, stateCheck}) {
     return new Promise((resolve, reject) => {
       if (state !== stateCheck) {
-        reject(new Error('Invalid state code'))
+        reject({status: 403, err: 'Invalid state code'})
       }
 
       inkstone.integrations.getFigmaAccessToken(code, (error, response) => {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- standardize error handling in Figma in favor of using `{status: <int>, message: <string>}`
- we had two projects failing to import for unknown reasons and the info provided by Carbonite is not helpful, this includes figma project url in Sentry and Mixpanel reports.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
