### PR TITLE
fix: properly print help info when an unknown command is used in nib

### DIFF
--- a/packages/@haiku/cli/src/nib/nib.ts
+++ b/packages/@haiku/cli/src/nib/nib.ts
@@ -193,7 +193,7 @@ ${vals.options || ''}`);
         context.exit(0);
       } else {
         this.usage(
-          head,
+          [],
           commands,
           context,
         );


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Random issue that I have found investigating possible issues with `haiku init`. Currently, if you provide an invalid command to the CLI, it prints misleading info, for example:

```bash
§ ./bin/haiku asdf

NAME:
    undefined

USAGE:
    haiku asdf

VERSION:
    3.2.16
```

This modifies it to print the default help screen instead.