### PR TITLE
fix: allow the Vue adapter to receive options

### DIFF
--- a/packages/@haiku/core/src/adapters/react-dom/HaikuReactDOMAdapter.ts
+++ b/packages/@haiku/core/src/adapters/react-dom/HaikuReactDOMAdapter.ts
@@ -7,17 +7,9 @@ import * as ReactDOM from 'react-dom';
 import EventsDict from './EventsDict';
 import {DEFAULTS} from '../../Config';
 import {randomString} from '../../helpers/StringUtils';
+import getParsedProperty from '../../helpers/getParsedProperty';
 
 const DEFAULT_HOST_ELEMENT_TAG_NAME = 'div';
-
-const HAIKU_CONFIG_PROPS_RENAME_MAPPING = {
-  haikuOptions: 'options',
-  haikuStates: 'states',
-  haikuInitialStates: 'states',
-  haikuEventHandlers: 'eventHandlers',
-  haikuTimelines: 'timelines',
-  haikuVanities: 'vanities',
-};
 
 export interface HaikuComponentProps {
   [key: string]: any;
@@ -74,7 +66,7 @@ export default function HaikuReactDOMAdapter(haikuComponentFactory, optionalRawB
     buildHaikuCompatibleConfigFromRawProps(rawProps) {
       // Note that these vanities are called _after_ an initial render,
       // i.e., after this.mount is supposed to have been attached.
-      const haikuConfig = {
+      let haikuConfig = {
         ref: this.mount,
         vanities: {
           'controlFlow.placeholder': function _controlFlowPlaceholderReactVanity(
@@ -128,19 +120,7 @@ export default function HaikuReactDOMAdapter(haikuComponentFactory, optionalRawB
             continue;
           }
 
-          const haikuConfigRemappedKey = HAIKU_CONFIG_PROPS_RENAME_MAPPING[verboseKeyName];
-
-          const haikuConfigFinalKey = haikuConfigRemappedKey || verboseKeyName;
-
-          // Special case: Options used to be a separate object, so if we see this legacy
-          // format, just merge it in with the root level of the new options
-          if (haikuConfigFinalKey === 'options') {
-            for (const optionsSubKey in rawProps[verboseKeyName]) {
-              haikuConfig[optionsSubKey] = rawProps[verboseKeyName][optionsSubKey];
-            }
-          } else {
-            haikuConfig[haikuConfigFinalKey] = rawProps[verboseKeyName];
-          }
+          haikuConfig = {...haikuConfig, ...getParsedProperty(rawProps, verboseKeyName)};
         }
       }
 

--- a/packages/@haiku/core/src/adapters/vue-dom/HaikuVueDOMAdapter.ts
+++ b/packages/@haiku/core/src/adapters/vue-dom/HaikuVueDOMAdapter.ts
@@ -3,6 +3,21 @@
  */
 
 import {randomString} from '../../helpers/StringUtils';
+import getParsedProperty from '../../helpers/getParsedProperty';
+
+function clearProps(props): Object {
+  let result = {};
+
+  for (const verboseKeyName in props) {
+    if (props[verboseKeyName] === undefined) {
+      continue;
+    }
+
+    result = {...result, ...getParsedProperty(props, verboseKeyName)};
+  }
+
+  return result;
+}
 
 export interface HaikuVueComponent {}
 
@@ -10,22 +25,43 @@ export interface HaikuVueComponent {}
 export default function HaikuVueDOMAdapter(haikuComponentFactory): HaikuVueComponent {
   return {
     props: {
-      haikuOptions: Object,
-      haikuStates: Object,
+      // We use null (which is the equivalent of 'any') for Boolean values
+      // because Vue does typecasting for us, which sets undefined to false.
+      automount: null,
+      autoplay: null,
+      forceFlush: null,
+      freeze: null,
+      loop: null,
+      alwaysComputeSizing: null,
+      useWebkitPrefix: null,
+      seed: String,
+      sizing: String,
+      timestamp: Number,
+      frame: Function,
+      clock: Object,
+      preserve3d: String,
+      contextMenu: String,
+      position: String,
+      overflowX: String,
+      overflowY: String,
+      overflow: String,
+      mixpanel: String,
+      interactionMode: Object,
+      states: Object,
       eventHandlers: Object,
       timelines: Object,
       vanities: Object,
+      children: Array,
       placeholder: Object,
+      // LEGACY
+      haikuOptions: Object,
     },
     mounted() {
+      const clearedProps = clearProps(this.$props);
+
       this.haiku = haikuComponentFactory(this.$el, {
+        ...clearedProps,
         ref: this.$el,
-        options: this.$props.haikuOptions,
-        states: this.$props.haikuStates,
-        eventHandlers: this.$props.eventHandlers,
-        timelines: this.$props.timelines,
-        vanities: this.$props.vanities,
-        placeholder: this.$props.placeholder,
         onHaikuComponentWillInitialize: (component) => {
           this.$emit('haikuComponentWillInitialize', component);
         },
@@ -44,14 +80,8 @@ export default function HaikuVueDOMAdapter(haikuComponentFactory): HaikuVueCompo
       });
     },
     updated() {
-      this.haiku.assignConfig({
-        options: this.$props.haikuOptions,
-        states: this.$props.haikuStates,
-        eventHandlers: this.$props.eventHandlers,
-        timelines: this.$props.timelines,
-        vanities: this.$props.vanities,
-        placeholder: this.$props.placeholder,
-      });
+      const clearedProps = clearProps(this.$props);
+      this.haiku.assignConfig(clearedProps);
     },
     destroyed() {
       this.haiku.callUnmount();

--- a/packages/@haiku/core/src/helpers/getParsedProperty.ts
+++ b/packages/@haiku/core/src/helpers/getParsedProperty.ts
@@ -1,0 +1,39 @@
+const HAIKU_CONFIG_PROPS_RENAME_MAPPING = {
+  haikuOptions: 'options',
+  haikuStates: 'states',
+  haikuInitialStates: 'states',
+  haikuEventHandlers: 'eventHandlers',
+  haikuTimelines: 'timelines',
+  haikuVanities: 'vanities',
+};
+
+/**
+ * Parses a specific property specified by `verboseKeyName` from the `props`
+ * object, renaming and merging legacy props as necessary.
+ * This method is mainly used by the React and Vue adapters.
+ * @param props
+ * @param verboseKeyName
+ * @returns {Object}
+ */
+
+const getParsedProperty = (props, verboseKeyName) => {
+  const result = {};
+
+  const haikuConfigRemappedKey = HAIKU_CONFIG_PROPS_RENAME_MAPPING[verboseKeyName];
+
+  const haikuConfigFinalKey = haikuConfigRemappedKey || verboseKeyName;
+
+  // Special case: Options used to be a separate object, so if we see this legacy
+  // format, just merge it in with the root level of the new options
+  if (haikuConfigFinalKey === 'options') {
+    for (const optionsSubKey in props[verboseKeyName]) {
+      result[optionsSubKey] = props[verboseKeyName][optionsSubKey];
+    }
+  } else {
+    result[haikuConfigFinalKey] = props[verboseKeyName];
+  }
+
+  return result;
+};
+
+export default getParsedProperty;

--- a/packages/@haiku/core/test/unit/getParsedProperty.test.js
+++ b/packages/@haiku/core/test/unit/getParsedProperty.test.js
@@ -1,21 +1,21 @@
 'use strict'
 
-var test = require('tape')
-var getParsedProperty = require('./../../lib/helpers/getParsedProperty').default
+const test = require('tape')
+const getParsedProperty = require('./../../lib/helpers/getParsedProperty').default
 
 test('getParsedProperty', function (t) {
   t.plan(1)
 
-  var rawProps = {options: {sizing: 'cover'}}
-  var parsedProp = getParsedProperty(rawProps, 'options')
+  const rawProps = {options: {sizing: 'cover'}}
+  const parsedProp = getParsedProperty(rawProps, 'options')
   t.deepEqual(parsedProp, {sizing: 'cover'}, 'flattens out items if they are contained in a poperty named "options"')
 })
 
 test('getParsedProperty', function (t) {
   t.plan(2)
 
-  var rawProps = {haikuOptions: {loop: true}, haikuStates: {count: 1}}
-  var parsedProp = getParsedProperty(rawProps, 'haikuOptions')
+  const rawProps = {haikuOptions: {loop: true}, haikuStates: {count: 1}}
+  let parsedProp = getParsedProperty(rawProps, 'haikuOptions')
   t.equal(parsedProp.loop, true, 'remaps deprecated property names')
 
   parsedProp = getParsedProperty(rawProps, 'haikuStates')
@@ -25,8 +25,8 @@ test('getParsedProperty', function (t) {
 test('getParsedProperty', function (t) {
   t.plan(2)
 
-  var rawProps = {loop: true, alwaysComputeSizing: false}
-  var parsedProp = getParsedProperty(rawProps, 'loop')
+  const rawProps = {loop: true, alwaysComputeSizing: false}
+  let parsedProp = getParsedProperty(rawProps, 'loop')
   t.equal(parsedProp.loop, true)
 
   parsedProp = getParsedProperty(rawProps, 'alwaysComputeSizing')

--- a/packages/@haiku/core/test/unit/getParsedProperty.test.js
+++ b/packages/@haiku/core/test/unit/getParsedProperty.test.js
@@ -1,0 +1,34 @@
+'use strict'
+
+var test = require('tape')
+var getParsedProperty = require('./../../lib/helpers/getParsedProperty').default
+
+test('getParsedProperty', function (t) {
+  t.plan(1)
+
+  var rawProps = {options: {sizing: 'cover'}}
+  var parsedProp = getParsedProperty(rawProps, 'options')
+  t.deepEqual(parsedProp, {sizing: 'cover'}, 'flattens out items if they are contained in a poperty named "options"')
+})
+
+test('getParsedProperty', function (t) {
+  t.plan(2)
+
+  var rawProps = {haikuOptions: {loop: true}, haikuStates: {count: 1}}
+  var parsedProp = getParsedProperty(rawProps, 'haikuOptions')
+  t.equal(parsedProp.loop, true, 'remaps deprecated property names')
+
+  parsedProp = getParsedProperty(rawProps, 'haikuStates')
+  t.deepEqual(parsedProp.states, {count: 1}, 'remaps deprecated property names')
+})
+
+test('getParsedProperty', function (t) {
+  t.plan(2)
+
+  var rawProps = {loop: true, alwaysComputeSizing: false}
+  var parsedProp = getParsedProperty(rawProps, 'loop')
+  t.equal(parsedProp.loop, true)
+
+  parsedProp = getParsedProperty(rawProps, 'alwaysComputeSizing')
+  t.equal(parsedProp.alwaysComputeSizing, false)
+})


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

With the changes introduced in 79225a, `haikuComponentFactory`
doesn't accept options wrapped in an `options` object anymore,
instead it expects the values at the root of the config element.

Regressions to look for:

- Some code in the React adapter has been modified, all demos are working fine for me, but may be worth a gander.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [x] Wrote an automated test covering new functionality
