### PR TITLE
feat: modify expression values by one with arrow keys

### DIFF
--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -59,6 +59,7 @@ const MAX_EDITOR_WIDTH_MULTILINE = 600
 const MIN_EDITOR_WIDTH_SINGLE_LINE = 140
 const MAX_EDITOR_WIDTH_SINGLE_LINE = 400
 const NUMERIC_CHANGE_BATCH = 10
+const NUMERIC_CHANGE_SINGLE = 1
 
 function setOptions (opts) {
   for (var key in opts) this.setOption(key, opts[key])
@@ -602,14 +603,14 @@ export default class ExpressionInput extends React.Component {
     }
 
     if (this.state.editingMode === EDITOR_MODES.SINGLE_LINE) {
-      if (keydownEvent.shiftKey) {
-        if (keydownEvent.which === 38) {
-          return this.changeCurrentValueIfNumericBy(NUMERIC_CHANGE_BATCH)
-        }
+      const numericDelta = keydownEvent.shiftKey ? NUMERIC_CHANGE_BATCH : NUMERIC_CHANGE_SINGLE
 
-        if (keydownEvent.which === 40) {
-          return this.changeCurrentValueIfNumericBy(-NUMERIC_CHANGE_BATCH)
-        }
+      if (keydownEvent.which === 38) {
+        return this.changeCurrentValueIfNumericBy(numericDelta)
+      }
+
+      if (keydownEvent.which === 40) {
+        return this.changeCurrentValueIfNumericBy(-numericDelta)
       }
 
       // If tab during single-line editing, commit and navigate


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

![2018-05-03 11_01_00](https://user-images.githubusercontent.com/4419992/39581157-50659b6e-4ec1-11e8-8777-97788f6f0dd7.gif)

Add the ability to increase/decrease numeric values by one with arrow keys, while keeping the ability to do it in batches of 10 by pressing the shift key.

cc: @taylorpoe 

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
