### PR TITLE
fix: disable ip collection on mixpanel in core phone home

### DIFF
--- a/packages/@haiku/core/src/renderers/dom/mixpanelInit.ts
+++ b/packages/@haiku/core/src/renderers/dom/mixpanelInit.ts
@@ -27,7 +27,7 @@ export default function mixpanelInit(mixpanelToken, component) {
       script.src = 'https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js';
       head.appendChild(script);
 
-      window['mixpanel'].init(mixpanelToken);
+      window['mixpanel'].init(mixpanelToken, {ip: false});
     }
 
     const metadata = (component._bytecode && component._bytecode.metadata) || {};


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Disable IP collection during mixpanel init per [instructions](https://help.mixpanel.com/hc/en-us/articles/115004494803-Disable-Geolocation-Collection#javascript).

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed