### PR TITLE
fix: wrap multi-listener actionpaks down to the next line

### DIFF
--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/Editor.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/Editor.js
@@ -65,13 +65,6 @@ class Editor extends React.Component {
       contextmenu: false,
       codeLens: false,
       parameterHints: false,
-      /* Elements with `will-change: transform` are containing blocks
-        for all descendants, meaning that all elements,
-        *including fixed elements* are positioned against them.
-        In order for snippets and other glorious features to break the overflow
-        of the editor, they need to be fixed against the document. */
-      // disableLayerHinting: true,
-      // fixedOverflowWidgets: true,
       scrollbar: {
         vertical: 'hidden',
         verticalScrollbarSize: '0'

--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/index.js
@@ -35,9 +35,16 @@ const STYLES = {
   frameEditorWrapper: {
     padding: '23px 23px 45px 18px'
   },
+  tagWrapper: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    paddingRight: '25px'
+  },
   tag: {
     padding: '2px 15px',
+    height: '25px',
     marginRight: '15px',
+    marginBottom: '15px',
     background: Palette.BLUE,
     borderRadius: '4px',
     textTransform: 'uppercase',
@@ -295,21 +302,23 @@ class EventHandlerEditor extends React.PureComponent {
                       }}
                     />
 
-                    {this.handlerManager
-                      .userVisibleEvents()
-                      .map(({ id, event, handler }) => {
-                        return (
-                          <span
-                            key={event}
-                            onClick={() => {
-                              this.showEditor(event)
-                            }}
-                            style={STYLES.tag}
-                          >
-                            {event}
-                          </span>
-                        )
-                      })}
+                    <div style={STYLES.tagWrapper}>
+                      {this.handlerManager
+                        .userVisibleEvents()
+                        .map(({ id, event, handler }) => {
+                          return (
+                            <span
+                              key={event}
+                              onClick={() => {
+                                this.showEditor(event)
+                              }}
+                              style={STYLES.tag}
+                            >
+                              {event}
+                            </span>
+                          )
+                        })}
+                    </div>
                   </div>
                 }
                 rightPanel={


### PR DESCRIPTION
OK to merge (⚠️ please note that base branch is `rc-mc-group-highlight`).

Short review.

Summary of changes:

- The title says it all, [here's](https://app.asana.com/0/652747024576300/663763966365985) the detailed issue report.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
