### PR TITLE
Fix copied project asset names

### DIFF
--- a/packages/haiku-plumbing/src/ProjectFolder.js
+++ b/packages/haiku-plumbing/src/ProjectFolder.js
@@ -190,23 +190,23 @@ export function buildProjectContent (
 
       fse.outputFileSync(dir(projectPath, 'README.md'), dedent`
         # ${projectNameSafe}
-  
+
         This project was created with [Haiku](https://haiku.ai).
-  
+
         ## Install
-  
+
         \`\`\`
         $ haiku install ${projectNameSafe}
         \`\`\`
-  
+
         ## Usage
-  
+
         \`\`\`
         var ${projectNameSafe} = require('${npmPackageName}')
         \`\`\`
-  
+
         ## Copyright
-  
+
         Please refer to LICENSE.txt.
       `)
 
@@ -408,12 +408,12 @@ export function duplicateProject (destinationProject, sourceProject, cb) {
     // Create a haiku config file.
     fse.mkdirpSync(destinationProject.projectPath)
 
-    const sourceVariations = Project.getProjectNameVariations(sourceProject.projectPath)
-    const sourceAssetBasename = path.basename(sourceVariations.primaryAssetPath)
+    const sourcePrimaryAssetPath = Project.getPrimaryAssetPath(sourceProject.projectName)
+    const sourceAssetBasename = path.basename(sourcePrimaryAssetPath)
     const sourceAssetPathPattern = new RegExp(escapeRegExp(sourceAssetBasename), 'g')
 
-    const destinationVariations = Project.getProjectNameVariations(destinationProject.projectPath)
-    const destinationAssetBasename = path.basename(destinationVariations.primaryAssetPath)
+    const destinationPrimaryAssetPath = Project.getPrimaryAssetPath(destinationProject.projectName)
+    const destinationAssetBasename = path.basename(destinationPrimaryAssetPath)
     logger.info(`using ${sourceAssetBasename}, ${destinationAssetBasename}, ${sourceAssetPathPattern}`)
 
     const scenes = fse.readdirSync(path.join(sourceProject.projectPath, 'code'))

--- a/packages/haiku-serialization/src/bll/ModuleWrapper.js
+++ b/packages/haiku-serialization/src/bll/ModuleWrapper.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const lodash = require('lodash')
 const BaseModel = require('./BaseModel')
 const overrideModulesLoaded = require('./../utils/overrideModulesLoaded')
 const Lock = require('./Lock')
@@ -360,5 +359,4 @@ module.exports = ModuleWrapper
 
 // Down here to avoid Node circular dependency stub objects. #FIXME
 const Bytecode = require('./Bytecode')
-const Project = require('./Project')
 const Template = require('./Template')

--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -903,6 +903,8 @@ Project.getAngularSelectorName = (name) => name
   .replace(/([A-Z])/g, (char) => `-${char.toLowerCase()}`)
   .replace(/^-/, '')
 
+Project.getPrimaryAssetPath = (name) => `designs/${name}.sketch`
+
 Project.getProjectNameVariations = (folder) => {
   const projectHaikuConfig = Project.readPackageJson(folder).haiku
   const projectNameSafe = Project.getSafeProjectName(folder, projectHaikuConfig.project)
@@ -910,7 +912,8 @@ Project.getProjectNameVariations = (folder) => {
   const projectNameLowerCase = projectNameSafe.toLowerCase()
   const reactProjectName = `React_${projectNameSafe}`
   const angularSelectorName = Project.getAngularSelectorName(projectNameSafe)
-  const primaryAssetPath = `designs/${projectNameSafeShort}.sketch`
+  const primaryAssetPath = Project.getPrimaryAssetPath(projectNameSafeShort)
+
   return {
     projectNameSafe,
     projectNameSafeShort,


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes "[Duplicate projects Sketch files named after full, ugly, filepath](https://app.asana.com/0/652747024576300/666384956899471)"

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [ ] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
