### PR TITLE
fix: update Vue and React examples to use the new options API

### DIFF
--- a/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/ReactHaiku.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/ReactHaiku.tsx
@@ -27,7 +27,7 @@ export default class VanillaJS extends React.PureComponent {
           render() {
             return (
               <div>
-                <${componentName} haikuOptions={{loop: true}} />
+                <${componentName} loop={true} />
               </div>
             );
           }

--- a/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/VueHaiku.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/VueHaiku.tsx
@@ -21,7 +21,7 @@ export default class VueHaiku extends React.PureComponent {
 
           new Vue({
             el: '#vue-dom-mount',
-            template: \`<${projectName} haikuOptions="{{loop: true}}"></${projectName}>\`,
+            template: \`<${projectName} :loop="true"></${projectName}>\`,
             components: {
               ${projectName}
             }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Update embed examples to use the new API for options.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [ ] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
