### PR TITLE
New project modal from anywhere

### DIFF
--- a/packages/haiku-common/src/electron/TopMenu.ts
+++ b/packages/haiku-common/src/electron/TopMenu.ts
@@ -191,6 +191,14 @@ export default class TopMenu {
 
     projectSubmenu.push(
       {
+        label: 'New',
+        accelerator: 'CmdOrCtrl+N',
+        enabled: !options.isSaving,
+        click: () => {
+          this.sender.send('global-menu:show-new-project-modal');
+        },
+      },
+      {
         label: 'Publish',
         enabled: !this.options.isSaving && this.options.isProjectOpen,
         click: () => {

--- a/packages/haiku-creator/package.json
+++ b/packages/haiku-creator/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@haiku/core": "3.3.0",
+    "@haiku/taylor-hai": "^0.0.7",
     "@haiku/taylor-ipreview2": "^0.0.2",
     "@haiku/zack4-creatorintro": "^0.0.6",
     "async": "^2.5.0",

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -918,6 +918,8 @@ export default class Creator extends React.Component {
   }
 
   onProjectLaunchError (error) {
+    console.log(error)
+
     this.createNotice({
       type: 'error',
       title: 'Oh no!',
@@ -930,7 +932,6 @@ export default class Creator extends React.Component {
   }
 
   createProject (projectName, isPublic, duplicate = false, callback) {
-    this.setState({newProjectLoading: true})
     this.props.websocket.request({ method: 'createProject', params: [projectName, isPublic] }, (err, newProject) => {
       callback(err, newProject)
 
@@ -942,11 +943,7 @@ export default class Creator extends React.Component {
           closeText: 'Okay',
           lightScheme: true
         })
-        // if (duplicate) {
-        //   this.setState({ areProjectsLoading: false })
-        // } else {
-          this.setProjectLaunchStatus({newProjectLoading: false})
-        // }
+
         return
       }
 
@@ -964,9 +961,7 @@ export default class Creator extends React.Component {
     })
   }
 
-  launchProject (projectObject) {
-    const {projectName} = projectObject
-
+  launchProject (projectName, projectObject, cb) {
     this.setProjectLaunchStatus({ launchingProject: true, newProjectLoading: false })
 
     projectObject = {
@@ -1455,7 +1450,7 @@ export default class Creator extends React.Component {
     this.setState({ showNewProjectModal: false, isDuplicateProjectModal: false, duplicateProjectName: null })
   }
 
-  renderNewProjectModal() {
+  renderNewProjectModal () {
     return (
       this.state.showNewProjectModal && (
         <NewProjectModal
@@ -1473,19 +1468,19 @@ export default class Creator extends React.Component {
               if (this.state.projectModel) {
                 this.teardownMaster(
                   { shouldFinishTour: true, launchingProject: false },
-                  () => { this.launchProject(projectObject) }
+                  () => { this.launchProject(projectObject.projectName, projectObject, callback) }
                 )
               } else {
-                this.launchProject(projectObject)
+                this.launchProject(projectObject.projectName, projectObject, callback)
               }
             })
           }}
           onClose={() => {
-            this.hideNewProjectModal();
+            this.hideNewProjectModal()
           }}
         />
       )
-    );
+    )
   }
 
   get proxyDescriptor () {

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1446,19 +1446,20 @@ export default class Creator extends React.Component {
     ) : null
   }
 
-  showNewProjectModal (duplicate = false) {
-    this.setState({ showNewProjectModal: true, isDuplicateProjectModal: duplicate })
+  showNewProjectModal (isDuplicateProjectModal = false, duplicateProjectName) {
+    this.setState({ showNewProjectModal: true, isDuplicateProjectModal, duplicateProjectName })
     mixpanel.haikuTrack('creator:new-project:shown')
   }
 
   hideNewProjectModal () {
-    this.setState({ showNewProjectModal: false, isDuplicateProjectModal: false })
+    this.setState({ showNewProjectModal: false, isDuplicateProjectModal: false, duplicateProjectName: null })
   }
 
   renderNewProjectModal() {
     return (
       this.state.showNewProjectModal && (
         <NewProjectModal
+          defaultProjectName={this.state.duplicateProjectName}
           duplicate={this.state.isDuplicateProjectModal}
           disabled={this.state.newProjectLoading}
           onCreateProject={(projectName, isPublic, duplicate, callback) => {
@@ -1595,7 +1596,7 @@ export default class Creator extends React.Component {
         <div>
           <ProjectBrowser
             ref='ProjectBrowser'
-            onShowNewProjectModal={(duplicate) => { this.showNewProjectModal(duplicate) }}
+            onShowNewProjectModal={(...args) => { this.showNewProjectModal(...args) }}
             lastViewedChangelog={this.state.lastViewedChangelog}
             onShowChangelogModal={() => { this.showChangelogModal() }}
             showChangelogModal={this.state.showChangelogModal}
@@ -1650,7 +1651,7 @@ export default class Creator extends React.Component {
           />
           <ProjectBrowser
             ref='ProjectBrowser'
-            onShowNewProjectModal={(duplicate) => { this.showNewProjectModal(duplicate) }}
+            onShowNewProjectModal={(...args) => { this.showNewProjectModal(...args) }}
             lastViewedChangelog={this.state.lastViewedChangelog}
             onShowChangelogModal={() => { this.showChangelogModal() }}
             showChangelogModal={this.state.showChangelogModal}

--- a/packages/haiku-creator/src/react/components/NewProjectModal.js
+++ b/packages/haiku-creator/src/react/components/NewProjectModal.js
@@ -2,8 +2,21 @@ import React from 'react'
 import Radium from 'radium'
 import Palette from 'haiku-ui-common/lib/Palette'
 import PrivatePublicToggle from './PrivatePublicToggle'
+import Hai from '@haiku/taylor-hai/react'
 import { DASH_STYLES } from '../styles/dashShared'
 import { BTN_STYLES } from '../styles/btnShared'
+
+const STYLES = {
+  loadingScreen: {
+    position: 'absolute',
+    height: '340px',
+    width: '100%',
+    left: '0',
+    top: '0',
+    zIndex: '99999',
+    backgroundColor: Palette.COAL
+  }
+}
 
 class NewProjectModal extends React.PureComponent {
   constructor (props) {
@@ -35,11 +48,14 @@ class NewProjectModal extends React.PureComponent {
     if (this.state.newProjectError) return false
     const rawNameValue = this.newProjectInput.value
     if (!rawNameValue) return false
-    // HACK:  strip all non-alphanumeric chars for now.  something more user-friendly would be ideal
+    // HACK: strip all non-alphanumeric chars for now.  something more user-friendly would be ideal
     const name = rawNameValue && rawNameValue.replace(/[^a-z0-9]/gi, '')
     const isPublic = this.state.newProjectIsPublic
 
+    this.setState({isLoading: true})
     this.props.onCreateProject(name, isPublic, duplicate, (err) => {
+      this.setState({isLoading: false})
+
       if (err) {
         return this.setState({ newProjectError: err.message })
       }
@@ -51,7 +67,6 @@ class NewProjectModal extends React.PureComponent {
   handleNewProjectInputKeyDown (e, duplicate = false) {
     if (e.keyCode === 13) {
       this.handleNewProjectGo(duplicate)
-      return
     } else if (e.keyCode === 27) {
       this.props.onClose(e)
     }
@@ -67,6 +82,13 @@ class NewProjectModal extends React.PureComponent {
         }}
       >
         <div style={DASH_STYLES.modal} onClick={(e) => e.stopPropagation()}>
+          {
+            this.state.isLoading && (
+              <div style={STYLES.loadingScreen}>
+                <Hai loop sizing={'contain'} contextMenu={'disabled'} />
+              </div>
+            )
+          }
           <div style={DASH_STYLES.modalTitle}>{duplicate ? 'Name Duplicated Project' : 'Project Setup'}</div>
           <div style={[DASH_STYLES.inputTitle, DASH_STYLES.upcase]}>Project Name</div>
           <input

--- a/packages/haiku-creator/src/react/components/NewProjectModal.js
+++ b/packages/haiku-creator/src/react/components/NewProjectModal.js
@@ -23,7 +23,7 @@ class NewProjectModal extends React.PureComponent {
     super(props)
 
     this.state = {
-      newProjectIsPublic: false,
+      newProjectIsPublic: true,
       newProjecterror: null,
       recordedNewProjectName: props.defaultProjectName || ''
     }

--- a/packages/haiku-creator/src/react/components/NewProjectModal.js
+++ b/packages/haiku-creator/src/react/components/NewProjectModal.js
@@ -12,7 +12,7 @@ class NewProjectModal extends React.PureComponent {
     this.state = {
       newProjectIsPublic: false,
       newProjecterror: null,
-      recordedNewProjectName: ''
+      recordedNewProjectName: props.defaultProjectName || ''
     }
   }
 
@@ -77,7 +77,7 @@ class NewProjectModal extends React.PureComponent {
             disabled={disabled}
             onKeyDown={(e) => { this.handleNewProjectInputKeyDown(e, duplicate) }}
             style={[DASH_STYLES.newProjectInput]}
-            value={this.props.defaultProjectName}
+            value={this.state.recordedNewProjectName}
             onChange={(e) => { this.handleNewProjectInputChange(e) }}
             placeholder='NewProjectName'
             autoFocus />

--- a/packages/haiku-creator/src/react/components/NewProjectModal.js
+++ b/packages/haiku-creator/src/react/components/NewProjectModal.js
@@ -1,0 +1,127 @@
+import React from 'react'
+import Radium from 'radium'
+import Palette from 'haiku-ui-common/lib/Palette'
+import PrivatePublicToggle from './PrivatePublicToggle'
+import { DASH_STYLES } from '../styles/dashShared'
+import { BTN_STYLES } from '../styles/btnShared'
+
+class NewProjectModal extends React.PureComponent {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      newProjectIsPublic: false,
+      newProjecterror: null,
+      recordedNewProjectName: ''
+    }
+  }
+
+  handleNewProjectToggleChange (newProjectIsPublic) {
+    this.setState({newProjectIsPublic})
+  }
+
+  handleNewProjectInputChange (event) {
+    const rawValue = event.target.value || ''
+
+    const recordedNewProjectName = rawValue
+      .replace(/\W+/g, '') // Non-alphanumeric characters not allowed
+      .replace(/_/g, '') // Underscores are considered alphanumeric (?); strip them
+      .slice(0, 32) // Keep the overall name length short
+
+    this.setState({ recordedNewProjectName })
+  }
+
+  handleNewProjectGo (duplicate = false) {
+    if (this.state.newProjectError) return false
+    const rawNameValue = this.newProjectInput.value
+    if (!rawNameValue) return false
+    // HACK:  strip all non-alphanumeric chars for now.  something more user-friendly would be ideal
+    const name = rawNameValue && rawNameValue.replace(/[^a-z0-9]/gi, '')
+    const isPublic = this.state.newProjectIsPublic
+
+    this.props.onCreateProject(name, isPublic, duplicate, (err) => {
+      if (err) {
+        return this.setState({ newProjectError: err.message })
+      }
+
+      this.props.onClose()
+    })
+  }
+
+  handleNewProjectInputKeyDown (e, duplicate = false) {
+    if (e.keyCode === 13) {
+      this.handleNewProjectGo(duplicate)
+      return
+    } else if (e.keyCode === 27) {
+      this.props.onClose(e)
+    }
+  }
+
+  render () {
+    const {duplicate, disabled} = this.props
+
+    return (
+      <div style={DASH_STYLES.overlay}
+        onClick={() => {
+          this.props.onClose()
+        }}
+      >
+        <div style={DASH_STYLES.modal} onClick={(e) => e.stopPropagation()}>
+          <div style={DASH_STYLES.modalTitle}>{duplicate ? 'Name Duplicated Project' : 'Project Setup'}</div>
+          <div style={[DASH_STYLES.inputTitle, DASH_STYLES.upcase]}>Project Name</div>
+          <input
+            key='new-project-input'
+            ref={(input) => {
+              this.newProjectInput = input
+            }}
+            disabled={disabled}
+            onKeyDown={(e) => { this.handleNewProjectInputKeyDown(e, duplicate) }}
+            style={[DASH_STYLES.newProjectInput]}
+            value={this.props.defaultProjectName}
+            onChange={(e) => { this.handleNewProjectInputChange(e) }}
+            placeholder='NewProjectName'
+            autoFocus />
+          <div style={{marginBottom: '30px'}}>
+            <PrivatePublicToggle
+              onChange={(isPublic) => { this.handleNewProjectToggleChange(isPublic) }}
+              isPublic={this.state.newProjectIsPublic}
+            />
+          </div>
+          <span key='new-project-error' style={DASH_STYLES.newProjectError}>{this.state.newProjectError}</span>
+          <button key='new-project-go-button'
+            disabled={disabled || !this.state.recordedNewProjectName || this.state.newProjectError}
+            onClick={() => {
+              this.handleNewProjectGo(duplicate)
+            }}
+            style={[
+              BTN_STYLES.btnText,
+              BTN_STYLES.rightBtns,
+              BTN_STYLES.btnPrimaryAlt,
+              DASH_STYLES.upcase,
+              (!this.state.recordedNewProjectName || this.state.newProjectError) && BTN_STYLES.btnDisabled,
+              {marginRight: 0}
+            ]}>
+            {duplicate ? 'Duplicate Project' : 'Name Project'}
+          </button>
+          <span style={[DASH_STYLES.upcase, BTN_STYLES.btnCancel, BTN_STYLES.rightBtns]}
+            onClick={() => {
+              this.props.onClose()
+            }}
+          >
+            Cancel
+          </span>
+        </div>
+      </div>
+    )
+  }
+}
+
+NewProjectModal.propTypes = {
+  duplicate: React.PropTypes.bool,
+  disabled: React.PropTypes.bool,
+  projectList: React.PropTypes.array,
+  onCancel: React.PropTypes.func,
+  setProjectLaunchStatus: React.PropTypes.func
+}
+
+export default Radium(NewProjectModal)

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -38,12 +38,10 @@ class ProjectBrowser extends React.Component {
       areProjectsLoading: true,
       isPopoverOpen: false,
       showNewProjectModal: false,
-      showDuplicateProjectModal: false,
       showDeleteModal: false,
       recordedDelete: '',
       recordedNewProjectName: '',
       projToDelete: '',
-      projToDuplicateIndex: null,
       confirmDeleteMatches: false,
       atProjectMax: false,
       newProjectError: null
@@ -191,21 +189,30 @@ class ProjectBrowser extends React.Component {
     return this.state.projectsList.find((project) => equivalentNameMatcher.test(project.projectName)) !== undefined
   }
 
+  trimAndSuffix (base, suffix) {
+    const remainingChars = 32 - (base.length + suffix.length)
+
+    if (remainingChars < 0) {
+      base = base.slice(0, remainingChars)
+    }
+
+    return `${base}${suffix}`
+  }
+
   showDuplicateProjectModal (projToDuplicateIndex) {
-    this.props.onShowNewProjectModal(true)
-    const duplicateNameBase = `${this.state.projectsList[projToDuplicateIndex].projectName}Copy`
-    let recordedNewProjectName = duplicateNameBase
+    const duplicateNameBase = this.state.projectsList[projToDuplicateIndex].projectName
+    const suffixBase = 'Copy'
+    let suffix = suffixBase
     let iteration = 1
-    while (this.doesProjectNameExist(recordedNewProjectName)) {
-      recordedNewProjectName = `${duplicateNameBase}${iteration}`
+    let potentialName = this.trimAndSuffix(duplicateNameBase, suffix)
+
+    while (this.doesProjectNameExist(potentialName)) {
+      suffix = `${suffixBase}${iteration}`
+      potentialName = this.trimAndSuffix(duplicateNameBase, suffix)
       iteration++
     }
-    this.setState({
-      projToDuplicateIndex,
-      recordedNewProjectName,
-      showDuplicateProjectModal: true,
-      newProjectError: null
-    })
+
+    this.props.onShowNewProjectModal(true, potentialName)
   }
 
   projectsListElement () {
@@ -280,10 +287,7 @@ class ProjectBrowser extends React.Component {
 
   closeModals () {
     this.setState({
-      showNewProjectModal: false,
-      showDuplicateProjectModal: false,
       showDeleteModal: false,
-      recordedNewProjectName: '',
       recordedDelete: '',
       newProjectIsPublic: true
     })

--- a/packages/haiku-creator/src/react/styles/dashShared.js
+++ b/packages/haiku-creator/src/react/styles/dashShared.js
@@ -306,7 +306,8 @@ export const DASH_STYLES = {
     padding: '30px 40px 20px',
     backgroundColor: Palette.COAL,
     transform: 'translate(-50%, -50%)',
-    boxShadow: '0 12px 60px 0 rgba(21,32,34,0.9)'
+    boxShadow: '0 12px 60px 0 rgba(21,32,34,0.9)',
+    overflow: 'hidden'
   },
   modalTitle: {
     color: Palette.SUNSTONE,

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,12 @@
   version "3.0.4"
   resolved "https://reservoir.haiku.ai:8910/@haiku%2fplayer/-/player-3.0.4.tgz#dd0bb8fbdea4751c8825adbd6b8ec528a781abaa"
 
+"@haiku/taylor-hai@^0.0.7":
+  version "0.0.7"
+  resolved "https://reservoir.haiku.ai:8910/@haiku%2ftaylor-hai/-/taylor-hai-0.0.7.tgz#313a06f7bf8307de4edb1fec4eed130b59dde761"
+  dependencies:
+    "@haiku/core" "^3.2.16"
+
 "@haiku/taylor-ipreview2@^0.0.2":
   version "0.0.2"
   resolved "https://reservoir.haiku.ai:8910/@haiku%2ftaylor-ipreview2/-/taylor-ipreview2-0.0.2.tgz#d46e790046082107bb2dc624fd72132e8ba9dd6a"


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Add a new shortcut to create a project: `⌘ + n`.
- Allow the new project modal to be invoked from the project detail page (both from the top menu and with `⌘ + n`).
- Fix a [bug](https://app.asana.com/0/670246721316721/629632357785540) regarding max limit on project names and duplicated projects.
- Added an intermediary step between creating the project on inkstone and setting the project locally in order to properly display errors coming from inkstone.

[Here's a video of the new workflow ](https://github.com/HaikuTeam/mono/files/2023217/newproject.mov.zip)

Regressions to look for:

- New project creation, duplication and fork.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
