### PR TITLE
perf: reduce the number of plumbing calls on pink outline

### DIFF
--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -1858,6 +1858,10 @@ Element.unselectAllElements = function (criteria, metadata) {
   Element.where(criteria).forEach((element) => element.unselect(metadata))
 }
 
+Element.hoverOffAllElements = function (criteria, metadata) {
+  Element.where(criteria).forEach((element) => element.hoverOff(metadata))
+}
+
 Element.clearCaches = function clearCaches () {
   Element.cache = {
     domNodes: {},


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Quick pass on outline perf, featuring:

- Disable outline during marquee selection
- Use a single function to track mouseover and mouseout events
so we can debounce all outline calls.
- Try to not invoke calls for an already hovered element

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Ran `$ yarn lint-all` and fixed all formatting issues
- [x] Ran `$ yarn test-all` and all tests passed
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
