### PR TITLE
Migrate seek/gotoAndPlay/gotoAndStop APIs to use frames by default.

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,5 @@ Notes for reviewers:
 Completed checkin tasks:
 
 - [ ] Did manual testing of interrelated functionality
-- [ ] Ran `$ yarn lint-all` and fixed all formatting issues
-- [ ] Ran `$ yarn test-all` and all tests passed
 - [ ] Added measurement instrumentation (Mixpanel, etc.)
 - [ ] Wrote an automated test covering new functionality

--- a/packages/@haiku/core/demo/projects/heartstry4/code/main/dom.js
+++ b/packages/@haiku/core/demo/projects/heartstry4/code/main/dom.js
@@ -7,21 +7,21 @@ module.exports = HaikuCreation(require('./code.js'), {
     var tl = instance.getDefaultTimeline()
     console.log(tl.duration())
     setTimeout(function () {
-      tl.gotoAndStop(500)
+      tl.gotoAndStop(500, 'ms')
       setTimeout(function () {
         tl.play()
         setTimeout(function () {
           tl.pause()
           setTimeout(function () {
-            tl.seek(100)
+            tl.seek(100, 'ms')
             setTimeout(function () {
               tl.play()
               setTimeout(function () {
-                tl.gotoAndPlay(300)
+                tl.gotoAndPlay(300, 'ms')
                 setTimeout(function () {
-                  tl.gotoAndStop(1200)
+                  tl.gotoAndStop(1200, 'ms')
                   setTimeout(function () {
-                    tl.seek(1735)
+                    tl.seek(1735, 'ms')
                   }, 500)
                 }, 500)
               }, 500)

--- a/packages/@haiku/core/fixme.js
+++ b/packages/@haiku/core/fixme.js
@@ -1,0 +1,7 @@
+const {default: composedTransformsToTimelineProperties} = require('./lib/helpers/composedTransformsToTimelineProperties');
+const out = {};
+composedTransformsToTimelineProperties(out, [
+  [-0.869104, 0.494629, 0, 0, -0.494629, -0.869104, 0, 0, 0, 0, 1, 0, 369.461, 284.514, 0, 1],
+  [1.97164, 0.346414, -1.03811, 0, 0.174201, 2.06622, 1.02034, 0, 0.479426, -0.420735, 0.770151, 0, 0, 0, 0, 1]
+]);
+console.log(out);

--- a/packages/@haiku/core/fixme.js
+++ b/packages/@haiku/core/fixme.js
@@ -1,7 +1,0 @@
-const {default: composedTransformsToTimelineProperties} = require('./lib/helpers/composedTransformsToTimelineProperties');
-const out = {};
-composedTransformsToTimelineProperties(out, [
-  [-0.869104, 0.494629, 0, 0, -0.494629, -0.869104, 0, 0, 0, 0, 1, 0, 369.461, 284.514, 0, 1],
-  [1.97164, 0.346414, -1.03811, 0, 0.174201, 2.06622, 1.02034, 0, 0.479426, -0.420735, 0.770151, 0, 0, 0, 0, 1]
-]);
-console.log(out);

--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -1065,8 +1065,8 @@ export default class HaikuComponent extends HaikuElement {
     if (playbackValue === PLAYBACK_SETTINGS.LOOP) {
       if (guestTimeline) {
         const guestMax = guestTimeline.getMaxTime();
-        const finalFrame = timelineTime % guestMax; // TODO: What if final frame has a change?
-        return finalFrame;
+        const finalTime = timelineTime % guestMax; // TODO: What if final frame has a change?
+        return finalTime;
       }
 
       return timelineTime;

--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -316,7 +316,7 @@ export default class HaikuComponent extends HaikuElement {
 
     bindStates(this._states, this, this.config.states);
 
-    bindEventHandlers(this, this.config.eventHandlers);
+    this.bindEventHandlers();
 
     assign(this.bytecode.timelines, this.config.timelines);
 
@@ -362,7 +362,7 @@ export default class HaikuComponent extends HaikuElement {
 
     // Gotta bind any event handlers that may have been dynamically added
     if (options['clearEventHandlers'] !== false) {
-      bindEventHandlers(this, this.config.eventHandlers);
+      this.bindEventHandlers();
     }
 
     this._flatManaTree = manaFlattenTree(this.getTemplate(), CSS_QUERY_MAPPING);
@@ -571,6 +571,31 @@ export default class HaikuComponent extends HaikuElement {
     }
 
     return out;
+  }
+
+  bindEventHandlers() {
+    if (
+      !this.bytecode.eventHandlers ||
+      Array.isArray(this.bytecode.eventHandlers) // Skip legacy format; must migrate first
+    ) {
+      return;
+    }
+
+    const allEventHandlers = assign(
+      {},
+      this.bytecode.eventHandlers,
+      this.config.eventHandlers,
+    );
+
+    for (const selector in allEventHandlers) {
+      const handlerGroup = allEventHandlers[selector];
+
+      for (const eventName in handlerGroup) {
+        const eventHandlerDescriptor = handlerGroup[eventName];
+
+        bindEventHandler(this, eventHandlerDescriptor, selector, eventName);
+      }
+    }
   }
 
   eachEventHandler (iteratee: Function) {
@@ -1114,31 +1139,6 @@ function assertTemplate(template) {
   }
 
   throw new Error('Unknown bytecode template format');
-}
-
-function bindEventHandlers(component, extraEventHandlers) {
-  if (
-    !component.bytecode.eventHandlers ||
-    Array.isArray(component.bytecode.eventHandlers) // Skip legacy format; must migrate first
-  ) {
-    return;
-  }
-
-  const allEventHandlers = assign(
-    {},
-    component.bytecode.eventHandlers,
-    extraEventHandlers,
-  );
-
-  for (const selector in allEventHandlers) {
-    const handlerGroup = allEventHandlers[selector];
-
-    for (const eventName in handlerGroup) {
-      const eventHandlerDescriptor = handlerGroup[eventName];
-
-      bindEventHandler(component, eventHandlerDescriptor, selector, eventName);
-    }
-  }
 }
 
 function bindEventHandler(component, eventHandlerDescriptor, selector, eventName) {

--- a/packages/@haiku/core/src/properties/dom/vanities.ts
+++ b/packages/@haiku/core/src/properties/dom/vanities.ts
@@ -844,18 +844,51 @@ const applyPlaybackStatus = (
       } else {
         receivingTimeline.playSoftly();
       }
-    } else if (shouldStop) {
+
+      return;
+    }
+
+    if (shouldStop) {
       if (receivingTimeline._isPlaying) {
         receivingTimeline.stop();
       } else {
         receivingTimeline.stopSoftly();
       }
+
+      return;
     }
   }
 
   if (typeof val === 'number') {
-    receivingTimeline.seek(val);
+    receivingTimeline.seek(val); // Numbers are assumed to be frames
+    return;
   }
+
+  // Attempt to handle strings that specify a unit, e.g. '123ms'
+  if (typeof val === 'string') {
+    const numericSpec = unitizeString(val);
+
+    if (numericSpec) {
+      receivingTimeline.seek(numericSpec.value, numericSpec.units);
+    }
+  }
+};
+
+/**
+ * @function unitizeString
+ * @description Convert a string like '123ms' to {value: 123, units: 'ms'}
+ */
+const unitizeString = (str: string) => {
+  const match = str.match(/(\d+)(\w+)/);
+
+  if (!match || !match[1] || !match[2]) {
+    return;
+  }
+
+  return {
+    value: Number(match[1]),
+    units: match[2],
+  };
 };
 
 const PLAYBACK_VANITIES = {

--- a/packages/@haiku/core/test/api/00_HaikuTimeline.test.ts
+++ b/packages/@haiku/core/test/api/00_HaikuTimeline.test.ts
@@ -28,12 +28,12 @@ tape('HaikuTimeline', (t) => {
         if (err) { throw err; }
         component.getDefaultTimeline().play();
         t.equal(mount.firstChild.haiku.virtual.layout.opacity, 0, 'initial opacity is 0');
-        component.getDefaultTimeline().seek(750);
+        component.getDefaultTimeline().seek(750, 'ms');
         context.tick();
         t.equal(mount.firstChild.haiku.virtual.layout.opacity, 0.75, 'seek to 750ms');
         setTimeout(() => {
           t.notEqual(mount.firstChild.haiku.virtual.layout.opacity, 0.75, 'playhead is moving');
-          component.getDefaultTimeline().gotoAndStop(500);
+          component.getDefaultTimeline().gotoAndStop(500, 'ms');
           setTimeout(() => {
             t.equal(mount.firstChild.haiku.virtual.layout.opacity, 0.5, 'stopped at 500ms');
             setTimeout(() => {

--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/Snippets.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/Snippets.js
@@ -38,11 +38,11 @@ class Snippets extends React.PureComponent {
       },
       {
         label: 'Go To And Play',
-        onClick: () => { this.insertSnippet('this.getDefaultTimeline().gotoAndPlay(ms)') }
+        onClick: () => { this.insertSnippet('this.getDefaultTimeline().gotoAndPlay(frame)') }
       },
       {
         label: 'Go To And Stop',
-        onClick: () => { this.insertSnippet('this.getDefaultTimeline().gotoAndStop(ms)') }
+        onClick: () => { this.insertSnippet('this.getDefaultTimeline().gotoAndStop(frame)') }
       },
       {
         label: 'Pause',

--- a/packages/haiku-glass/src/react/components/EventHandlerEditor/constants.js
+++ b/packages/haiku-glass/src/react/components/EventHandlerEditor/constants.js
@@ -8,8 +8,6 @@ export const EVALUATOR_STATES = {
 
 export const EDITOR_WIDTH = 500
 
-export const EDITOR_HEIGHT = 480
-
 export const AUTOCOMPLETION_ITEMS = [
   {
     detail: 'Change State',
@@ -19,12 +17,12 @@ export const AUTOCOMPLETION_ITEMS = [
   {
     detail: 'Seek and play from a specific frame.',
     label: 'gotoAndPlay',
-    insertText: 'this.getDefaultTimeline().gotoAndPlay(ms)'
+    insertText: 'this.getDefaultTimeline().gotoAndPlay(frame)'
   },
   {
     detail: 'Seek to a specific frame, and stop the timeline at that point.',
     label: 'gotoAndStop',
-    insertText: 'this.getDefaultTimeline().gotoAndStop(ms)'
+    insertText: 'this.getDefaultTimeline().gotoAndStop(frame)'
   },
   {
     detail: 'Play this timeline at the current frame.',
@@ -47,9 +45,9 @@ export const AUTOCOMPLETION_ITEMS = [
     insertText: 'this.getDefaultTimeline().start()'
   },
   {
-    detail: 'Jump to a specific time in the timeline.',
+    detail: 'Jump to a specific frame in the timeline.',
     label: 'seek',
-    insertText: 'this.getDefaultTimeline().seek(ms)'
+    insertText: 'this.getDefaultTimeline().seek(frame)'
   },
   {
     detail: 'Returns whether or not this timeline is currently playing.',


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Migration `seek`/`gotoAndPlay`/`gotoAndStop` APIs to use frames by default.
- [unrelated] Remove automatic health checks from the PR template checkin tasks…because we have a butler to do them for us.

Regressions to look for:

- Any problems with old projects that have event listeners not being upgraded correctly.

Notes for reviewers:

- I used a naive parenthesis balancing routine that doesn't check if parens occur outside of quotation marks. I figured this is fine because I couldn't imagine having a quoted string somehow wrapped inside 
a call to `gotoAndPlay(...)`… in fact, I haven't ever seen anything except a number, but just in case, balanced parens. I probably thought about this more than you will 😺.
- Note [corresponding PR](https://github.com/HaikuTeam/docs/pull/10) to update docs.


Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test covering new functionality
