### PR TITLE
fix: update broken imports in core and tests

### DIFF
--- a/packages/@haiku/core/src/Migration.ts
+++ b/packages/@haiku/core/src/Migration.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Haiku 2016-2018. All rights reserved.
  */
 
-import reifyRFO from '@haiku/player/lib/reflection/reifyRFO';
+import reifyRFO from './reflection/reifyRFO';
 import HaikuComponent from './HaikuComponent';
 import addLegacyOriginSupport from './helpers/addLegacyOriginSupport';
 import compareSemver from './helpers/compareSemver';

--- a/test/TestHelpers.js
+++ b/test/TestHelpers.js
@@ -4,7 +4,7 @@ const fse = require('fs-extra')
 const lodash = require('lodash')
 const os = require('os')
 const async = require('async')
-const functionToRFO = require('@haiku/player/lib/reflection/functionToRFO').default
+const functionToRFO = require('@haiku/core/lib/reflection/functionToRFO').default
 const haikuInfo = require('../packages/haiku-plumbing/lib/haikuInfo').default()
 const Plumbing = require('../packages/haiku-plumbing/lib/Plumbing').default
 


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- As the title says, this fixes imports referencing `@haiku/player` both in core and tests.

Notes for reviewers:

Worth noting that e2e tests run without issues but failed for me for reasons that are not related to this PR.

![screen shot 2018-05-21 at 09 04 58](https://user-images.githubusercontent.com/4419992/40306700-11d7ea8c-5cd6-11e8-8c7c-86ab0ff4ea42.png)


Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
