### PR TITLE
Display multi-components as top menu entries

### DIFF
--- a/packages/haiku-common/src/electron/TopMenu.ts
+++ b/packages/haiku-common/src/electron/TopMenu.ts
@@ -52,9 +52,6 @@ export default class TopMenu {
     for (const key in this.options) {
       if (nextOptions[key] !== undefined && !isEqual(nextOptions[key], this.options[key])) {
         didChange = true;
-        if (didChange) {
-          console.log(':::::::::::::::::::',key);
-        }
       }
     }
 

--- a/packages/haiku-common/src/electron/TopMenu.ts
+++ b/packages/haiku-common/src/electron/TopMenu.ts
@@ -52,6 +52,7 @@ export default class TopMenu {
     for (const key in this.options) {
       if (nextOptions[key] !== undefined && !isEqual(nextOptions[key], this.options[key])) {
         didChange = true;
+        break;
       }
     }
 
@@ -182,6 +183,12 @@ export default class TopMenu {
 
     const projectSubmenu = [];
 
+    const isSubComponentsMenuEnabled = (
+      this.options.subComponents &&
+      this.options.subComponents.length > 0 &&
+      this.options.isProjectOpen
+    );
+
     projectSubmenu.push(
       {
         label: 'Publish',
@@ -201,8 +208,8 @@ export default class TopMenu {
       {type: 'separator'},
       {
         label: 'Components',
-        enabled: this.options.subComponents && this.options.subComponents.length > 0,
-        submenu: componentsSubSubmenu,
+        enabled: isSubComponentsMenuEnabled,
+        submenu: (isSubComponentsMenuEnabled) ? componentsSubSubmenu : undefined,
       },
     );
 

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1213,6 +1213,7 @@ export default class Creator extends React.Component {
 
   onNavigateToDashboard () {
     this.teardownMaster({ shouldFinishTour: true })
+    ipcRenderer.send('topmenu:update', {subComponents: [], isProjectOpen: false})
   }
 
   awaitAuthAndFire (cb) {

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -218,6 +218,11 @@ export default class Creator extends React.Component {
       this.showChangelogModal()
     }, MENU_ACTION_DEBOUNCE_TIME, {leading: true, trailing: false}))
 
+    ipcRenderer.on('global-menu:set-active-component', lodash.debounce((ipcEvent, scenename) => {
+      logger.info(`[creator] global-menu:set-active-component`)
+      this.state.projectModel.setCurrentActiveComponent(scenename, {from: 'creator'}, () => {})
+    }, MENU_ACTION_DEBOUNCE_TIME, {leading: true, trailing: false}))
+
     ipcRenderer.on('global-menu:zoom-in', lodash.debounce(() => {
       logger.info(`[creator] global-menu:zoom-in`)
       // Timeline will send to Glass if it doesn't want to zoom
@@ -894,11 +899,11 @@ export default class Creator extends React.Component {
         timeout: 5000,
         retry: 5
       },
-      (error, projectsList) => {
+      (error, projectList) => {
         if (error) return cb(error)
-        this.setState({ projectsList })
-        ipcRenderer.send('renderer:projects-list-fetched', projectsList)
-        return cb(null, projectsList)
+        this.setState({ projectList })
+        ipcRenderer.send('topmenu:update', {projectList, isProjectOpen: false})
+        return cb(null, projectList)
       }
     )
   }
@@ -1048,6 +1053,10 @@ export default class Creator extends React.Component {
 
   handleActiveComponentReady () {
     this.mountHaikuComponent()
+
+    ipcRenderer.send('topmenu:update', {
+      subComponents: this.state.projectModel.describeSubComponents()
+    })
 
     // Hide loading screens, re-enable navigating back to dashboard but only after a
     // delay since we've seen race-related crashes when people nav back too early.

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -218,7 +218,11 @@ class StageTitleBar extends React.Component {
             })
           }
 
-          ipcRenderer.send('master:heartbeat', assign({}, masterState))
+          ipcRenderer.send('topmenu:update', {
+            isProjectOpen: !!masterState.folder,
+            isSaving: !!masterState.isSaving,
+            subComponents: this.props.projectModel.describeSubComponents()
+          })
         })
       }
     }, 1000)

--- a/packages/haiku-glass/src/electron.js
+++ b/packages/haiku-glass/src/electron.js
@@ -1,5 +1,5 @@
 import qs from 'qs'
-import {app, BrowserWindow} from 'electron'
+import {app, BrowserWindow, ipcMain} from 'electron'
 import path from 'path'
 import TopMenu from 'haiku-common/lib/electron/TopMenu'
 import logger from 'haiku-serialization/src/utils/LoggerInstance'
@@ -42,15 +42,20 @@ function createWindow () {
   })
 
   const topmenu = new TopMenu({
-    send: (name) => {
-      mainWindow.webContents.send('relay', {name, from: 'electron'})
+    send: (name, data) => {
+      mainWindow.webContents.send('relay', {name, data, from: 'electron'})
     }
   })
 
   topmenu.create({
     projectList: [],
     isSaving: false,
-    isProjectOpen: true
+    isProjectOpen: true,
+    subComponents: []
+  })
+
+  ipcMain.on('topmenu:update', (ipcEvent, nextTopmenuOptions) => {
+    topmenu.update(nextTopmenuOptions)
   })
 }
 

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -33,7 +33,7 @@ import {isMac} from 'haiku-common/lib/environments/os'
 
 const mixpanel = require('haiku-serialization/src/utils/Mixpanel')
 const Globals = require('haiku-ui-common/lib/Globals').default
-const {clipboard, shell, remote} = require('electron')
+const {clipboard, shell, remote, ipcRenderer} = require('electron')
 const fse = require('haiku-fs-extra')
 const moment = require('moment')
 const {HOMEDIR_PATH} = require('haiku-serialization/src/utils/HaikuHomeDir')
@@ -294,6 +294,10 @@ export class Glass extends React.Component {
 
   handleActiveComponentReady () {
     this.mountHaikuComponent()
+
+    ipcRenderer.send('topmenu:update', {
+      subComponents: this.project.describeSubComponents()
+    })
   }
 
   mountHaikuComponent () {
@@ -541,6 +545,10 @@ export class Glass extends React.Component {
         case 'global-menu:zoom-out':
           mixpanel.haikuTrack('creator:glass:zoom-out')
           this.getActiveComponent().getArtboard().zoomOut(1.25)
+          break
+
+        case 'global-menu:set-active-component':
+          this.project.setCurrentActiveComponent(message.data, {from: 'glass'}, () => {})
           break
 
         case 'global-menu:group':

--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -245,6 +245,16 @@ class Project extends BaseModel {
     }
   }
 
+  describeSubComponents () {
+    return this._multiComponentTabs.map(({scenename, active}) => {
+      return {
+        isActive: !!active,
+        scenename,
+        title: toTitleCase(scenename)
+      }
+    })
+  }
+
   getExistingComponentNames () {
     const names = {
       'main': true // Never allow 'main'

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1,4 +1,4 @@
-import {remote} from 'electron'
+import {remote, ipcRenderer} from 'electron'
 import React from 'react'
 import Color from 'color'
 import lodash from 'lodash'
@@ -285,6 +285,10 @@ class Timeline extends React.Component {
           }
           break
 
+        case 'global-menu:set-active-component':
+          this.project.setCurrentActiveComponent(message.data, {from: 'timeline'}, () => {})
+          break
+
         case 'global-menu:zoom-in':
           // For now, zoom controls only affect the stage
           this.props.websocket.send(relayable)
@@ -436,6 +440,10 @@ class Timeline extends React.Component {
 
   handleActiveComponentReady () {
     this.mountHaikuComponent()
+
+    ipcRenderer.send('topmenu:update', {
+      subComponents: this.project.describeSubComponents()
+    })
   }
 
   mountHaikuComponent () {

--- a/packages/haiku-timeline/src/electron.js
+++ b/packages/haiku-timeline/src/electron.js
@@ -1,7 +1,7 @@
 import path from 'path'
 
 import qs from 'qs'
-import {app, BrowserWindow} from 'electron'
+import {app, BrowserWindow, ipcMain} from 'electron'
 
 import TopMenu from 'haiku-common/lib/electron/TopMenu'
 
@@ -40,6 +40,7 @@ function createWindow () {
       webSecurity: false
     }
   })
+
   mainWindow.maximize()
   mainWindow.loadURL(url)
 
@@ -50,15 +51,20 @@ function createWindow () {
   mainWindow.on('closed', () => { mainWindow = null })
 
   const topmenu = new TopMenu({
-    send: (name) => {
-      mainWindow.webContents.send('relay', {name, from: 'electron'})
+    send: (name, data) => {
+      mainWindow.webContents.send('relay', {name, data, from: 'electron'})
     }
   })
 
   topmenu.create({
     projectList: [],
     isSaving: false,
-    isProjectOpen: true
+    isProjectOpen: true,
+    subComponents: []
+  })
+
+  ipcMain.on('topmenu:update', (ipcEvent, nextTopmenuOptions) => {
+    topmenu.update(nextTopmenuOptions)
   })
 }
 

--- a/packages/haiku-timeline/test/projects/complex/code/bubtonkillingsworth/code.js
+++ b/packages/haiku-timeline/test/projects/complex/code/bubtonkillingsworth/code.js
@@ -1,6 +1,8 @@
 var Haiku = require("@haiku/core");
 module.exports = {
-  metadata: {},
+  metadata: {
+    relpath: "code/main/bubtonkillingsworth.js"
+  },
   options: {},
   states: {
     foo: {

--- a/packages/haiku-timeline/test/projects/complex/code/main/code.js
+++ b/packages/haiku-timeline/test/projects/complex/code/main/code.js
@@ -1,6 +1,10 @@
 var Haiku = require("@haiku/core");
 var bubtonkillingsworth = require("../bubtonkillingsworth/code.js");
 module.exports = {
+  metadata: {
+    relpath: "code/main/code.js"
+  },
+
   states: {
     hello: {
       value: 123


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Adds Project > Components > [...] menu to the application menu in all views (standalone and full). Allows user to switch between components using this menu.
- Refactors a few pathways related to updating the top menu, consolidating under the single `topmenu:update` listener instead of different types of events.

Regressions to look for:

- The top menu otherwise continues to work normally.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
