### PR TITLE
fix: make new projects public by default

### DIFF
--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -375,7 +375,7 @@ class ProjectBrowser extends React.Component {
       showDeleteModal: false,
       recordedNewProjectName: '',
       recordedDelete: '',
-      newProjectIsPublic: false
+      newProjectIsPublic: true
     })
   }
 


### PR DESCRIPTION
OK to merge.

Short review.

Notes for reviewers:

Ideal scenario would be to merge #470 which also includes this fix, but it is way more dangerous (it touches a lot of code related to creating/duplicating/forking projects).

As you can see in the diff, this is a very small change so I created a separate PR in case we want to merge ASAP and include in the next release.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
