### PR TITLE
Envoy error handling

### DIFF
--- a/packages/haiku-sdk-creator/src/envoy/EnvoyClient.ts
+++ b/packages/haiku-sdk-creator/src/envoy/EnvoyClient.ts
@@ -291,7 +291,7 @@ export default class EnvoyClient<T> {
         const success = new Promise<any>((acceptInner: Function, rejectInner: Function) => {
           this.outstandingRequests.set(datagram.id, (data) => {
             if (data && data.error) {
-              return rejectInner(new Error(data.error));
+              return rejectInner(data.error);
             }
 
             return acceptInner(data);

--- a/packages/haiku-sdk-creator/src/envoy/EnvoyClient.ts
+++ b/packages/haiku-sdk-creator/src/envoy/EnvoyClient.ts
@@ -288,13 +288,13 @@ export default class EnvoyClient<T> {
         const timeout = this.generateTimeoutPromise(mergedOptions.timeout);
 
         // TODO: Fix Bluebird typing error by removing any
-        const success = new Promise<any>((acceptInner: any, rejectInner: Function) => {
+        const success = new Promise<any>((acceptInner: Function, rejectInner: Function) => {
           this.outstandingRequests.set(datagram.id, (data) => {
             if (data && data.error) {
-              return rejectInner(new Error(data.error))
+              return rejectInner(new Error(data.error));
             }
 
-            return acceptInner(data)
+            return acceptInner(data);
           });
         });
 
@@ -304,9 +304,9 @@ export default class EnvoyClient<T> {
           },
           (error) => {
             reject(error);
-            this.logger.warn("[haiku envoy client]", error);
+            this.logger.warn('[haiku envoy client]', error);
             this.outstandingRequests.delete(requestId);
-          }
+          },
         );
       }
 

--- a/packages/haiku-sdk-creator/src/envoy/EnvoyServer.ts
+++ b/packages/haiku-sdk-creator/src/envoy/EnvoyServer.ts
@@ -189,6 +189,17 @@ export default class EnvoyServer {
               // TODO: could reply directly to the client that requested instead of broadcasting to all
               //       would require identifying the client (via datagram) & then tracking clientId in future datagrams
               this.broadcast(response);
+            })
+            .catch((error) => {
+              const response = <Datagram>{
+                channel: data.channel,
+                data: {error},
+                id: data.id,
+                intent: DatagramIntent.RESPONSE,
+              };
+              // TODO: could reply directly to the client that requested instead of broadcasting to all
+              //       would require identifying the client (via datagram) & then tracking clientId in future datagrams
+              this.broadcast(response);
             });
 
           } else {

--- a/packages/haiku-sdk-creator/src/envoy/index.ts
+++ b/packages/haiku-sdk-creator/src/envoy/index.ts
@@ -17,7 +17,7 @@ export interface Datagram {
   channel: string;
   method?: string;
   params?: string[];
-  data?: string;
+  data?: any;
 }
 
 export interface EnvoyOptions {

--- a/packages/haiku-sdk-creator/src/envoy/index.ts
+++ b/packages/haiku-sdk-creator/src/envoy/index.ts
@@ -11,13 +11,17 @@ export enum DatagramIntent {
   ID_REQUEST,
 }
 
+export type EnvoySerializable = any;
+
+export type ClientRequestCallback = (data: EnvoySerializable) => void;
+
 export interface Datagram {
   id: string;
   intent: DatagramIntent;
   channel: string;
   method?: string;
   params?: string[];
-  data?: any;
+  data?: EnvoySerializable;
 }
 
 export interface EnvoyOptions {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

As I was implementing Figma API calls trough Envoy, I discovered that we aren't handling errors in promises executed in handlers; if the handler fails there's no way for clients to know what happened.

This chains into the pipeline errors that occur when client-executed methods are invoked.

Regressions to look for:

- Envoy in general

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
