### PR TITLE
Move Figma API calls to Envoy

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -32,6 +32,7 @@ import { EXPORTER_CHANNEL, ExporterFormat } from 'haiku-sdk-creator/lib/exporter
 import { USER_CHANNEL, User, UserSettings } from 'haiku-sdk-creator/lib/bll/User' // eslint-disable-line no-unused-vars
 import { PROJECT_CHANNEL } from 'haiku-sdk-creator/lib/bll/Project'
 import { TOUR_CHANNEL } from 'haiku-sdk-creator/lib/tour'
+import { SERVICES_CHANNEL } from 'haiku-sdk-creator/lib/services'
 import { InteractionMode, isPreviewMode } from '@haiku/core/lib/helpers/interactionModes'
 import Palette from 'haiku-ui-common/lib/Palette'
 import ActivityMonitor from '../utils/activityMonitor.js'
@@ -60,6 +61,7 @@ if (webFrame) {
 const MENU_ACTION_DEBOUNCE_TIME = 100
 const FORK_OPERATION_TIMEOUT = 2000
 const MAX_FORK_ATTEMPTS = 15
+const FIGMA_IMPORT_TIMEOUT = 1000 * 60 * 5 /* 5 minutes */
 
 export default class Creator extends React.Component {
   constructor (props) {
@@ -115,7 +117,8 @@ export default class Creator extends React.Component {
       interactionMode: InteractionMode.EDIT,
       artboardDimensions: null,
       showChangelogModal: false,
-      showProxySettings: false
+      showProxySettings: false,
+      servicesEnvoyClient: null
     }
 
     this.envoyOptions = {
@@ -634,6 +637,10 @@ export default class Creator extends React.Component {
         // this.handleEnvoyProjectReady()
       }
     )
+
+    this.envoyClient.get(SERVICES_CHANNEL, {timeout: FIGMA_IMPORT_TIMEOUT}).then((servicesEnvoyClient) => {
+      this.setState({servicesEnvoyClient})
+    })
 
     this.envoyClient.get(TOUR_CHANNEL).then((tourChannel) => {
       this.tourChannel = tourChannel
@@ -1636,6 +1643,7 @@ export default class Creator extends React.Component {
                     )
                   }
                   <Library
+                    servicesEnvoyClient={this.state.servicesEnvoyClient}
                     user={this.user}
                     projectModel={this.state.projectModel}
                     layout={this.layout}

--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -129,11 +129,11 @@ class Library extends React.Component {
   }
 
   figmaAuthCallback ({state, code}) {
-    Figma.getAccessToken({state, code, stateCheck: this.state.figmaState})
+    this.props.servicesEnvoyClient.figmaGetAccessToken({state, code, stateCheck: this.state.figmaState})
       .then(({AccessToken}) => {
         this.props.user.setConfig(UserSettings.figmaToken, AccessToken)
         this.state.figma.token = AccessToken
-        this.props.createNotice({
+        return this.props.createNotice({
           type: 'success',
           title: 'Yay!',
           message: 'You are authenticated with Figma'
@@ -172,8 +172,7 @@ class Library extends React.Component {
 
   importFigmaAsset (url) {
     const path = this.props.projectModel.folder
-
-    return this.state.figma.importSVG({url, path})
+    return this.props.servicesEnvoyClient.figmaImportSVG({url, path}, this.state.figma.token)
       .catch((error = {}) => {
         let message = error.err || 'We had a problem connecting with Figma. Please check your internet connection and try again.'
         const reportData = { url, message }

--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -129,6 +129,10 @@ class Library extends React.Component {
   }
 
   figmaAuthCallback ({state, code}) {
+    if (!this.props.servicesEnvoyClient || this.props.servicesEnvoyClient.isInMockMode()) {
+      return void(0)
+    }
+
     this.props.servicesEnvoyClient.figmaGetAccessToken({state, code, stateCheck: this.state.figmaState})
       .then(({AccessToken}) => {
         this.props.user.setConfig(UserSettings.figmaToken, AccessToken)
@@ -171,6 +175,10 @@ class Library extends React.Component {
   }
 
   importFigmaAsset (url) {
+    if (!this.props.servicesEnvoyClient || this.props.servicesEnvoyClient.isInMockMode()) {
+      return void(0)
+    }
+
     const path = this.props.projectModel.folder
     return this.props.servicesEnvoyClient.figmaImportSVG({url, path}, this.state.figma.token)
       .catch((error = {}) => {

--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -130,7 +130,7 @@ class Library extends React.Component {
 
   figmaAuthCallback ({state, code}) {
     if (!this.props.servicesEnvoyClient || this.props.servicesEnvoyClient.isInMockMode()) {
-      return void(0)
+      return
     }
 
     this.props.servicesEnvoyClient.figmaGetAccessToken({state, code, stateCheck: this.state.figmaState})
@@ -176,7 +176,7 @@ class Library extends React.Component {
 
   importFigmaAsset (url) {
     if (!this.props.servicesEnvoyClient || this.props.servicesEnvoyClient.isInMockMode()) {
-      return void(0)
+      return
     }
 
     const path = this.props.projectModel.folder

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -18,6 +18,7 @@ import { PROJECT_CHANNEL, ProjectHandler } from 'haiku-sdk-creator/lib/bll/Proje
 import { GLASS_CHANNEL, GlassHandler } from 'haiku-sdk-creator/lib/glass'
 import { TIMELINE_CHANNEL, TimelineHandler } from 'haiku-sdk-creator/lib/timeline'
 import { TOUR_CHANNEL, TourHandler } from 'haiku-sdk-creator/lib/tour'
+import { SERVICES_CHANNEL, ServicesHandler } from 'haiku-sdk-creator/lib/services'
 import { inkstone } from '@haiku/sdk-inkstone'
 import { client as sdkClient, FILE_PATHS } from '@haiku/sdk-client'
 import { Experiment, experimentIsEnabled } from 'haiku-common/lib/experiments'
@@ -235,6 +236,7 @@ export default class Plumbing extends StateObject {
       const envoyGlassHandler = new GlassHandler(this.envoyServer)
       const envoyUserHandler = new UserHandler(this.envoyServer)
       const envoyProjectHandler = new ProjectHandler(this.envoyServer)
+      const envoyServicesHandler = new ServicesHandler(this.envoyServer)
 
       this.envoyServer.bindHandler(TIMELINE_CHANNEL, TimelineHandler, envoyTimelineHandler)
       this.envoyServer.bindHandler(TOUR_CHANNEL, TourHandler, envoyTourHandler)
@@ -242,6 +244,7 @@ export default class Plumbing extends StateObject {
       this.envoyServer.bindHandler(USER_CHANNEL, UserHandler, envoyUserHandler)
       this.envoyServer.bindHandler(GLASS_CHANNEL, GlassHandler, envoyGlassHandler)
       this.envoyServer.bindHandler(PROJECT_CHANNEL, ProjectHandler, envoyProjectHandler)
+      this.envoyServer.bindHandler(SERVICES_CHANNEL, ServicesHandler, envoyServicesHandler)
 
       logger.info('[plumbing] launching plumbing control server')
 

--- a/packages/haiku-sdk-creator/src/envoy/EnvoyClient.ts
+++ b/packages/haiku-sdk-creator/src/envoy/EnvoyClient.ts
@@ -44,7 +44,7 @@ export default class EnvoyClient<T> {
    * @param channel unique string representing the channel of the handler
    * that this client should be bound to
    */
-  get(channel: string): Promise<T> {
+  get(channel: string, requestOptions?: RequestOptions): Promise<T> {
     // Since mock mode skips the connection, there's nothing to retrieve, and
     // we will just go ahead and return ourselves early instead of schema discovery
     if (this.isInMockMode()) {
@@ -75,7 +75,7 @@ export default class EnvoyClient<T> {
                 params: args,
               };
 
-              return this.send(datagram);
+              return this.send(datagram, requestOptions);
             };
           })(property);
         }

--- a/packages/haiku-sdk-creator/src/services/ServicesHandler.ts
+++ b/packages/haiku-sdk-creator/src/services/ServicesHandler.ts
@@ -1,0 +1,26 @@
+import * as Figma from 'haiku-serialization/src/bll/Figma';
+import EnvoyServer from '../envoy/EnvoyServer';
+import {ImportSpec, MaybeAsync, TokenExchange} from '.';
+
+export interface Services {
+  figmaImportSVG(importSpec: ImportSpec, authToken: string): MaybeAsync<void>;
+
+  figmaGetAccessToken(tokenExchange: TokenExchange): MaybeAsync<object>;
+}
+
+export class ServicesHandler implements Services {
+  private server: EnvoyServer;
+
+  constructor(server: EnvoyServer) {
+    this.server = server;
+  }
+
+  figmaImportSVG(importSpec, authToken) {
+    const figma = new Figma({token: authToken});
+    return figma.importSVG(importSpec);
+  }
+
+  figmaGetAccessToken(tokenExchange) {
+    return Figma.getAccessToken(tokenExchange);
+  }
+}

--- a/packages/haiku-sdk-creator/src/services/index.ts
+++ b/packages/haiku-sdk-creator/src/services/index.ts
@@ -1,0 +1,16 @@
+export const SERVICES_CHANNEL = 'services';
+
+export interface ImportSpec {
+  url: string;
+  path: string;
+}
+
+export interface TokenExchange {
+  code: string;
+  state: number;
+  stateCheck: string;
+}
+
+export type MaybeAsync<T> = T | Promise<T>;
+
+export * from './ServicesHandler';


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Move Figma API calls to Envoy

Regressions to look for:

- Figma integration

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
