### PR TITLE
dev: enable react devtools in development for all views

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "dotenv": "^5.0.1",
     "electron": "1.8.2",
     "electron-builder": "20.0.8",
-    "electron-react-devtools": "^0.5.3",
     "electron-rebuild": "^1.6.0",
     "fs-extra": "^4.0.2",
     "git-branch": "0.3.0",

--- a/packages/haiku-creator/package.json
+++ b/packages/haiku-creator/package.json
@@ -68,6 +68,7 @@
     "babel-register": "6.26.0",
     "cross-env": "^5.1.4",
     "electron": "1.8.2",
+    "electron-devtools-installer": "^2.2.4",
     "eslint": "^3.19.0",
     "eslint-config-standard-jsx": "^4.0.2",
     "snazzy": "^7.0.0",

--- a/packages/haiku-creator/src/electron.js
+++ b/packages/haiku-creator/src/electron.js
@@ -15,6 +15,8 @@ import mixpanel from 'haiku-serialization/src/utils/Mixpanel'
 import logger from 'haiku-serialization/src/utils/LoggerInstance'
 import {isMac} from 'haiku-common/lib/environments/os'
 
+import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer'
+
 if (!app) {
   throw new Error('You can only run electron.js from an electron process')
 }
@@ -114,6 +116,10 @@ function createWindow () {
 
   if (process.env.DEV === '1') {
     browserWindow.openDevTools()
+
+    installExtension(REACT_DEVELOPER_TOOLS)
+        .then((name) => console.log(`Added Extension:  ${name}`))
+        .catch((err) => console.log('An error occurred: ', err))
   }
 
   // Sending our haiku configuration into the view so it can correctly set up

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,10 @@
     "7zip-bin-mac" "~1.0.1"
     "7zip-bin-win" "~2.2.0"
 
+"7zip@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/7zip/-/7zip-0.0.6.tgz#9cafb171af82329490353b4816f03347aa150a30"
+
 "@angular/core@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@angular/core/-/core-6.0.0.tgz#785cc8a37b7fb784a6b7dcbd0984abb4f10e5dfe"
@@ -3104,6 +3108,10 @@ cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-unzip@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/cross-unzip/-/cross-unzip-0.0.2.tgz#5183bc47a09559befcf98cc4657964999359372f"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -3835,6 +3843,15 @@ electron-chromedriver@~1.7.1:
     electron-download "^4.1.0"
     extract-zip "^1.6.5"
 
+electron-devtools-installer@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.4.tgz#261a50337e37121d338b966f07922eb4939a8763"
+  dependencies:
+    "7zip" "0.0.6"
+    cross-unzip "0.0.2"
+    rimraf "^2.5.2"
+    semver "^5.3.0"
+
 electron-download-tf@4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/electron-download-tf/-/electron-download-tf-4.3.4.tgz#b03740b2885aa2ad3f8784fae74df427f66d5165"
@@ -3911,10 +3928,6 @@ electron-publish@20.0.6:
     fs-extra-p "^4.5.2"
     lazy-val "^1.0.3"
     mime "^2.2.0"
-
-electron-react-devtools@^0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/electron-react-devtools/-/electron-react-devtools-0.5.3.tgz#c74edb1245dc1cfe1380b93016cd4eb588ed00b7"
 
 electron-rebuild@^1.6.0:
   version "1.7.3"
@@ -10206,7 +10219,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.4.0, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2, rimraf@^2.4.0, rimraf@^2.5.1, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

As the title says, this should help a big deal with the visibility of the components, especially for people that is new to the app.

Notes to reviewers:

I switched from `electron-react-devtools` to `electron-devtools-installer` because the latter is more versatile, allowing us to install any extension we want.

![screen shot 2018-05-24 at 10 40 50](https://user-images.githubusercontent.com/4419992/40489191-f4d3d07a-5f3e-11e8-8318-6c39378b82f9.png)
