### PR TITLE
proposal for allowing project launch to be interrupted with ESC

### DIFF
--- a/packages/haiku-creator/src/react/components/ProjectLoader.js
+++ b/packages/haiku-creator/src/react/components/ProjectLoader.js
@@ -101,12 +101,14 @@ class ProjectLoader extends React.Component {
 
   componentDidMount () {
     this.incrementReticulator()
+    document.addEventListener('keydown', this.props.onKeyDown)
   }
 
   componentWillUnmount () {
     if (_reticularHandle) {
       clearTimeout(_reticularHandle)
     }
+    document.removeEventListener('keydown', this.props.onKeyDown)
   }
 
   incrementReticulator () {


### PR DESCRIPTION
Needs discussion.

Short review.

Summary:

This is a _possible_ solution to interrupting project launch when pressing the `ESC` key, boils down to:

- If the user presses `ESC` during project launch, set `this.state.launchingProject` to `false` in Creator, and immediately hide the reticulating splines screen.
- After every async step of launching a project, check if `this.state.launchingProject` has been set to `false`, if yes, early return and call `teardownMaster`.

The idea is to check if there are any fundamental flaws with this approach because this code path is delicate, if this idea is good to go, I will clean up and add documentation. 

Caveats:

- "Can only update a mounted or mounting component" may appear for the `Timeline` and `Glass` components because the views are abruptly unmounted, should we worry about this or it's expected? 

Completed checkin tasks:

- [ ] Did manual testing of interrelated functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
