### PR TITLE
UI Tweaks

### DIFF
--- a/packages/haiku-creator/src/react/components/ComponentMenu/ComponentMenu.js
+++ b/packages/haiku-creator/src/react/components/ComponentMenu/ComponentMenu.js
@@ -8,10 +8,10 @@ const STYLES = {
     position: 'relative',
     width: '100%',
     height: 30,
-    backgroundColor: Palette.GRAY,
+    backgroundColor: Palette.PALE_GRAY,
     paddingLeft: '5px',
     paddingRight: '5px',
-    paddingTop: '7px',
+    paddingTop: '6px',
     overflow: 'hidden',
     verticalAlign: 'top'
   }

--- a/packages/haiku-creator/src/react/components/ComponentMenu/ComponentTab.js
+++ b/packages/haiku-creator/src/react/components/ComponentMenu/ComponentTab.js
@@ -26,7 +26,7 @@ const STYLES = {
     width: '100%',
     cursor: 'default',
     ':hover': {
-      color: Palette.GRAY,
+      color: Palette.GRAY
     },
     active: {
       backgroundColor: Palette.STAGE_GRAY,

--- a/packages/haiku-creator/src/react/components/ComponentMenu/ComponentTab.js
+++ b/packages/haiku-creator/src/react/components/ComponentMenu/ComponentTab.js
@@ -18,17 +18,19 @@ const STYLES = {
     position: 'relative',
     display: 'inline-block',
     backgroundColor: 'transparent',
-    borderTopLeftRadius: '6px',
-    borderTopRightRadius: '6px',
-    borderLeft: `1px solid ${Palette.GRAY}`,
-    color: Palette.STAGE_GRAY,
-    padding: '5px 25px',
+    borderTopLeftRadius: '5px',
+    borderTopRightRadius: '5px',
+    color: Palette.LIGHTEST_GRAY,
+    padding: '4px 20px',
     height: '100%',
     width: '100%',
     cursor: 'default',
+    ':hover': {
+      color: Palette.GRAY,
+    },
     active: {
       backgroundColor: Palette.STAGE_GRAY,
-      color: Palette.GRAY,
+      color: Palette.FATHER_COAL,
       cursor: 'default'
     }
   },

--- a/packages/haiku-creator/src/react/components/library/AssetItem.js
+++ b/packages/haiku-creator/src/react/components/library/AssetItem.js
@@ -110,7 +110,7 @@ const STYLES = {
     opacity: 0,
     top: 3,
     left: 22,
-    zIndex: 2,
+    zIndex: 2000,
     padding: 8,
     backgroundColor: Color(Palette.COAL).fade(0.4),
     border: '1px solid rgba(0,0,0,.2)',

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -1742,7 +1742,7 @@ export class Glass extends React.Component {
               point.x,
               point.y
             ]),
-            Palette.LIGHT_PINK
+            Palette.LIGHTEST_PINK
           )
         )
       }
@@ -2462,7 +2462,7 @@ export class Glass extends React.Component {
                 style={{
                   strokeWidth: 1.5,
                   fill: 'none',
-                  stroke: Palette.LIGHT_PINK,
+                  stroke: Palette.LIGHTEST_PINK,
                   opacity: this.state.isStageNameHovering && !this.state.isStageSelected ? 0.75 : 0,
                   overflow: 'visible'
                 }}

--- a/packages/haiku-glass/src/react/Modal.js
+++ b/packages/haiku-glass/src/react/Modal.js
@@ -10,10 +10,18 @@ export const MODAL_STYLES = {
     padding: 20,
     margin: '0 auto'
   },
+  title: {
+    textTransform: 'uppercase',
+    fontWeight: 'normal',
+    fontSize: 15,
+    textAlign: 'left',
+    marginBottom: 7,
+    marginLeft: 7
+  },
   input: (valid) => ({
-    width: 300,
+    width: '100%',
     padding: 10,
-    backgroundColor: 'black',
+    backgroundColor: Palette.DARKEST_COAL,
     borderRadius: 2,
     color: Palette.SUNSTONE,
     border: `1px solid ${valid ? Palette.MEDIUM_COAL : Palette.RED}`,
@@ -21,21 +29,23 @@ export const MODAL_STYLES = {
   }),
   feedback: (valid) => ({
     minHeight: 18,
+    textAlign: 'left',
     color: valid ? Palette.ROCK : Palette.RED,
-    fontStyle: 'italic'
+    fontStyle: 'italic',
+    marginLeft: 7
   }),
   submit: (enabled) => ({
+    float: 'right',
     cursor: enabled ? 'pointer' : 'not-allowed',
     backgroundColor: enabled ? Palette.LIGHTEST_PINK : Palette.DARKER_GRAY,
     color: enabled ? 'white' : Palette.ROCK,
-    borderRadius: 4,
-    marginLeft: 10,
+    borderRadius: 3,
     padding: '10px 15px 8px'
   }),
   cancel: {
-    backgroundColor: Palette.DARKER_GRAY,
+    float: 'right',
     color: Palette.ROCK,
-    borderRadius: 4,
+    borderRadius: 3,
     marginRight: 10,
     padding: '10px 15px 8px'
   }

--- a/packages/haiku-glass/src/react/modals/CreateComponentModal.js
+++ b/packages/haiku-glass/src/react/modals/CreateComponentModal.js
@@ -61,7 +61,7 @@ export default class CreateComponentModal extends React.Component {
         isOpen={this.props.isOpen}>
         <div
           style={MODAL_STYLES.wrapper}>
-          <p>Enter a name for your component:</p>
+          <div style={MODAL_STYLES.title}>Name your component</div>
           <input
             type='text'
             autoFocus
@@ -96,7 +96,7 @@ export default class CreateComponentModal extends React.Component {
           <p style={MODAL_STYLES.feedback(this.state.componentName.length === 0)}>
             {this.state.invalidityReason || ''}
           </p>
-          <div>
+          <div style={{minHeight: 30}}>
             <button
               style={MODAL_STYLES.cancel}
               onClick={() => {

--- a/packages/haiku-glass/src/react/modals/CreateComponentModal.js
+++ b/packages/haiku-glass/src/react/modals/CreateComponentModal.js
@@ -98,13 +98,6 @@ export default class CreateComponentModal extends React.Component {
           </p>
           <div style={{minHeight: 30}}>
             <button
-              style={MODAL_STYLES.cancel}
-              onClick={() => {
-                this.cancelForm()
-              }}>
-              Cancel
-            </button>
-            <button
               disabled={!this.state.isSubmitEnabled}
               style={MODAL_STYLES.submit(this.state.isSubmitEnabled)}
               onClick={() => {
@@ -113,6 +106,13 @@ export default class CreateComponentModal extends React.Component {
                 }
               }}>
               Create Component
+            </button>
+            <button
+              style={MODAL_STYLES.cancel}
+              onClick={() => {
+                this.cancelForm()
+              }}>
+              Cancel
             </button>
           </div>
         </div>


### PR DESCRIPTION
OK to merge.

* Styles component tab UI a bit further
* Makes 'Create Component' modal UI consistent with other modals
* Fixes a clipping issue on library previews (the split pane divider was showing z-index above the preview).
* Tweaks the stage highlight and hovered-element highlight to a lighter pink

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
