### PR TITLE
fix: for TypeError crash during interpolation.

### DIFF
--- a/packages/@haiku/core/src/Interpolate.ts
+++ b/packages/@haiku/core/src/Interpolate.ts
@@ -48,6 +48,10 @@ function interpolate(now: number, curve: CurveDefinition, started: number, ends:
   // If curve is a string, transform into a function using justCurves
   const curveFunc = typeof curve === 'string' ? justCurves[curve] : curve;
 
+  if (typeof curveFunc !== 'function') {
+    return origin;
+  }
+
   if (Array.isArray(origin) && Array.isArray(destination)) {
     const arrayOutput = [];
     for (let i = 0; i < origin.length; i++) {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes this [crash](https://the-haiku-team.slack.com/archives/C84GP1HK7/p1527437076000019). I believe this happens because there are some code pathways that result in a falsey curve (e.g. weird combinations of undo/redo with keyframe editing).

Regressions to look for:

- None.