### PR TITLE
perf: do not render the timeline tree when toggling rows

### DIFF
--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -2718,7 +2718,7 @@ class ActiveComponent extends BaseModel {
     const groups = [{
       host: root,
       id: root.getComponentId(),
-      rows: rows.filter((row) => !row.isWithinCollapsedRow())
+      rows: rows
     }].concat(stack.map(({haikuId}) => {
       const child = this.findElementByComponentId(haikuId)
       const rows = child.getHostedPropertyRows()
@@ -2726,7 +2726,7 @@ class ActiveComponent extends BaseModel {
       return {
         host: child,
         id: child.getComponentId(),
-        rows: rows.filter((row) => !row.isWithinCollapsedRow())
+        rows: rows
       }
     }))
 

--- a/packages/haiku-timeline/src/components/RowManager.js
+++ b/packages/haiku-timeline/src/components/RowManager.js
@@ -1,0 +1,104 @@
+import React from 'react'
+import ClusterRow from './ClusterRow'
+import PropertyRow from './PropertyRow'
+import ComponentHeadingRow from './ComponentHeadingRow'
+
+class RowManager extends React.PureComponent {
+  constructor (props) {
+    super(props)
+
+    this.handleUpdate = this.handleUpdate.bind(this)
+  }
+
+  handleUpdate (what) {
+    if (what === 'row-collapsed' || what === 'row-expanded') {
+      this.forceUpdate()
+    }
+  }
+
+  componentDidMount () {
+    this.props.group.rows.forEach((row) => {
+      if (row.isHeading() || row.isClusterHeading()) {
+        row.on('update', this.handleUpdate)
+      }
+    })
+  }
+
+  componentWillUnmount () {
+    this.props.group.rows.forEach((row) => {
+      if (row.isHeading() || row.isClusterHeading()) {
+        row.removeListener('update', this.handleUpdate)
+      }
+    })
+  }
+
+  renderComponentRow (row, prev) {
+    // Cluster rows only display if collapsed, otherwise we show their properties
+    const activeComponent = this.props.getActiveComponent()
+
+    if (row.isClusterHeading() && !row.isExpanded()) {
+      return (
+        <ClusterRow
+          key={row.getUniqueKey()}
+          rowHeight={this.props.rowHeight}
+          timeline={activeComponent.getCurrentTimeline()}
+          component={activeComponent}
+          prev={prev}
+          row={row}
+        />
+      )
+    }
+
+    if (row.isProperty()) {
+      return (
+        <PropertyRow
+          key={row.getUniqueKey()}
+          rowHeight={this.props.rowHeight}
+          timeline={activeComponent.getCurrentTimeline()}
+          component={activeComponent}
+          prev={prev}
+          row={row}
+        />
+      )
+    }
+
+    if (row.isHeading()) {
+      return (
+        <ComponentHeadingRow
+          key={row.getUniqueKey()}
+          rowHeight={this.props.rowHeight}
+          timeline={activeComponent.getCurrentTimeline()}
+          component={activeComponent}
+          row={row}
+          prev={prev}
+          onEventHandlerTriggered={this.props.showEventHandlersEditor}
+          isExpanded={row.isExpanded()}
+          isHidden={row.isHidden()}
+          isSelected={row.isSelected()}
+          hasAttachedActions={row.element.getVisibleEvents().length > 0}
+          dragHandleProps={this.props.dragHandleProps}
+        />
+      )
+    }
+
+    // If we got here, display nothing since we don't know what to render
+    return null
+  }
+
+  render () {
+    const { group, prevGroup } = this.props
+
+    const elements = group.rows
+      .filter((row) => !row.isWithinCollapsedRow())
+      .map((row, indexOfRowWithinGroup) => {
+        let prevRow = group.rows[indexOfRowWithinGroup - 1]
+        if (!prevRow && prevGroup) { prevRow = prevGroup.rows[prevGroup.length - 1] }
+
+        return this.renderComponentRow(row, Boolean(prevRow))
+      })
+
+    return <div>{elements}</div>
+  }
+}
+
+export default RowManager

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -16,9 +16,7 @@ import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
 import ControlsArea from './ControlsArea'
 import ExpressionInput from './ExpressionInput'
 import Scrubber from './ScrubberInterior'
-import ClusterRow from './ClusterRow'
-import PropertyRow from './PropertyRow'
-import ComponentHeadingRow from './ComponentHeadingRow'
+import RowManager from './RowManager'
 import FrameGrid from './FrameGrid'
 import IntercomWidget from './IntercomWidget'
 import Gauge from './Gauge'
@@ -429,9 +427,7 @@ class Timeline extends React.Component {
     })
 
     this.addEmitterListener(Row, 'update', (row, what) => {
-      if (what === 'row-collapsed' || what === 'row-expanded') {
-        this.forceUpdate()
-      } else if (what === 'row-selected') {
+      if (what === 'row-selected') {
         // TODO: Handle scrolling to the correct row
       }
     })
@@ -1132,69 +1128,6 @@ class Timeline extends React.Component {
     )
   }
 
-  renderComponentRow (row, prev, dragHandleProps) {
-    // Cluster rows only display if collapsed, otherwise we show their properties
-    if (row.isClusterHeading() && !row.isExpanded()) {
-      return (
-        <ClusterRow
-          key={row.getUniqueKey()}
-          rowHeight={this.state.rowHeight}
-          timeline={this.getActiveComponent().getCurrentTimeline()}
-          component={this.getActiveComponent()}
-          prev={prev}
-          row={row} />
-      )
-    }
-
-    if (row.isProperty()) {
-      return (
-        <PropertyRow
-          key={row.getUniqueKey()}
-          rowHeight={this.state.rowHeight}
-          timeline={this.getActiveComponent().getCurrentTimeline()}
-          component={this.getActiveComponent()}
-          prev={prev}
-          row={row} />
-      )
-    }
-
-    if (row.isHeading()) {
-      return (
-        <ComponentHeadingRow
-          key={row.getUniqueKey()}
-          rowHeight={this.state.rowHeight}
-          timeline={this.getActiveComponent().getCurrentTimeline()}
-          component={this.getActiveComponent()}
-          row={row}
-          prev={prev}
-          onEventHandlerTriggered={this.showEventHandlersEditor}
-          isExpanded={row.isExpanded()}
-          isHidden={row.isHidden()}
-          isSelected={row.isSelected()}
-          hasAttachedActions={row.element.getVisibleEvents().length > 0}
-          dragHandleProps={dragHandleProps}
-        />
-      )
-    }
-
-    // If we got here, display nothing since we don't know what to render
-    return ''
-  }
-
-  calcGroupRowsHeight (rows) {
-    let height = 0
-
-    rows.forEach((row) => {
-      if ((row.isHeading() || row.isClusterHeading()) && !row.isExpanded()) {
-        height += 1
-      } else if (row.isProperty()) {
-        height += 1
-      }
-    })
-
-    return height
-  }
-
   renderComponentRows () {
     const groups = this.getActiveComponent().getDisplayableRowsGroupedByElementInZOrder()
 
@@ -1230,7 +1163,6 @@ class Timeline extends React.Component {
                 className='droppable-wrapper'
                 ref={provided.innerRef}>
                 {groups.map((group, indexOfGroup) => {
-                  const minHeight = this.state.rowHeight * this.calcGroupRowsHeight(group.rows)
                   const minWidth = this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth() + this.getActiveComponent().getCurrentTimeline().getTimelinePixelWidth()
                   const prevGroup = groups[indexOfGroup - 1]
                   return (
@@ -1241,7 +1173,6 @@ class Timeline extends React.Component {
                       {(provided, snapshot) => {
                         return (
                           <div style={{
-                            minHeight, /* Row drops are mis-targeted unless we specify this height */
                             minWidth /* Prevent horizontal scrolling in the overflow-x:auto box */
                           }}>
                             <div
@@ -1251,11 +1182,18 @@ class Timeline extends React.Component {
                               style={{
                                 ...provided.draggableProps.style
                               }}>
-                              {group.rows.map((row, indexOfRowWithinGroup) => {
-                                let prevRow = group.rows[indexOfRowWithinGroup - 1]
-                                if (!prevRow && prevGroup) prevRow = prevGroup.rows[prevGroup.length - 1]
-                                return this.renderComponentRow(row, prevRow, provided.dragHandleProps)
-                              })}
+                              <RowManager
+                                group={group}
+                                prevGroup={prevGroup}
+                                dragHandleProps={provided.dragHandleProps}
+                                rowHeight={this.state.rowHeight}
+                                getActiveComponent={() => {
+                                  return this.getActiveComponent()
+                                }}
+                                showEventHandlersEditor={() => {
+                                  this.showEventHandlersEditor()
+                                }}
+                                />
                             </div>
                             {provided.placeholder}
                           </div>


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

This is accomplished by removing a listener over the Row object
that basically triggered a `forceUpdate` at root level (updating
the whole tree no matter what) every time a row was toggled.

Regressions to look for:

- Timeline drag & drop
- Expanding/collapsing rows

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
