### PR TITLE
perf: avoid re-rendering the whole timeline twice every click

### DIFF
--- a/packages/haiku-timeline/src/components/RowSegments.js
+++ b/packages/haiku-timeline/src/components/RowSegments.js
@@ -95,7 +95,7 @@ export default class RowSegments extends React.Component {
                   keyframe={keyframe} />
               )
             }
-            if (keyframe.isSoloKeyframe()) {
+            if (keyframe.isSoloKeyframe() || !keyframe.hasNextKeyframe()) {
               segmentPieces.push(
                 <SoloKeyframe
                   id={`keyframe-${keyframe.getUniqueKey()}-${this.props.scope}-solo-keyframe`}

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -60,7 +60,6 @@ const DEFAULTS = {
   isCommandKeyDown: false,
   isControlKeyDown: false,
   isAltKeyDown: false,
-  avoidTimelinePointerEvents: false,
   isPreviewModeActive: false,
   isRepeat: true,
   flush: false,
@@ -157,9 +156,10 @@ class Timeline extends React.Component {
         isShiftKeyDown: false,
         isCommandKeyDown: false,
         isControlKeyDown: false,
-        isAltKeyDown: false,
-        avoidTimelinePointerEvents: false
+        isAltKeyDown: false
       })
+
+      this.enableTimelinePointerEvents()
     }
 
     // If the user e.g. Cmd+tabs away from the window
@@ -1041,12 +1041,9 @@ class Timeline extends React.Component {
           onMouseDown={(event) => {
             event.persist()
 
-            this.setState({
-              doHandleMouseMovesInGauge: true,
-              avoidTimelinePointerEvents: true
-            }, () => {
-              this.mouseMoveListener(event)
-            })
+            this._doHandleMouseMovesInGauge = true
+            this.disableTimelinePointerEvents()
+            this.mouseMoveListener(event)
           }}
           style={{
             position: 'absolute',
@@ -1073,7 +1070,7 @@ class Timeline extends React.Component {
   }
 
   mouseMoveListener (evt) {
-    if (!this.state.doHandleMouseMovesInGauge) {
+    if (!this._doHandleMouseMovesInGauge) {
       return
     }
 
@@ -1100,10 +1097,18 @@ class Timeline extends React.Component {
   }
 
   mouseUpListener () {
-    this.setState({
-      doHandleMouseMovesInGauge: false,
-      avoidTimelinePointerEvents: false
-    })
+    this._doHandleMouseMovesInGauge = false
+    this.enableTimelinePointerEvents()
+  }
+
+  disableTimelinePointerEvents () {
+    this.refs.scrollview.style.pointerEvents = 'none'
+    this.refs.scrollview.style.WebkitUserSelect = 'none'
+  }
+
+  enableTimelinePointerEvents () {
+    this.refs.scrollview.style.pointerEvents = 'auto'
+    this.refs.scrollview.style.WebkitUserSelect = 'auto'
   }
 
   disablePreviewMode () {
@@ -1125,7 +1130,8 @@ class Timeline extends React.Component {
           zIndex: 10000
         }}>
         <TimelineRangeScrollbar
-          reactParent={this}
+          disableTimelinePointerEvents={() => { this.disableTimelinePointerEvents() }}
+          enableTimelinePointerEvents={() => { this.enableTimelinePointerEvents() }}
           timeline={this.getActiveComponent().getCurrentTimeline()} />
         {this.renderTimelinePlaybackControls()}
       </div>
@@ -1342,8 +1348,8 @@ class Timeline extends React.Component {
             top: 35,
             left: 0,
             width: '100%',
-            pointerEvents: this.state.avoidTimelinePointerEvents ? 'none' : 'auto',
-            WebkitUserSelect: this.state.avoidTimelinePointerEvents ? 'none' : 'auto',
+            pointerEvents: 'auto',
+            WebkitUserSelect: 'auto',
             bottom: 0,
             overflowY: 'auto',
             overflowX: 'hidden'

--- a/packages/haiku-timeline/src/components/TimelineRangeScrollbar.js
+++ b/packages/haiku-timeline/src/components/TimelineRangeScrollbar.js
@@ -53,16 +53,12 @@ export default class TimelineRangeScrollbar extends React.Component {
 
   onStartDragContainer (dragEvent, dragData) {
     this.props.timeline.scrollbarBodyStart(dragData)
-    this.props.reactParent.setState({
-      avoidTimelinePointerEvents: true
-    })
+    this.props.disableTimelinePointerEvents()
   }
 
   onStopDragContainer (dragEvent, dragData) {
     this.props.timeline.scrollbarBodyStop(dragData)
-    this.props.reactParent.setState({
-      avoidTimelinePointerEvents: false
-    })
+    this.props.enableTimelinePointerEvents()
   }
 
   onDragContainer (dragEvent, dragData) {
@@ -171,5 +167,6 @@ export default class TimelineRangeScrollbar extends React.Component {
 
 TimelineRangeScrollbar.propTypes = {
   timeline: React.PropTypes.object.isRequired,
-  reactParent: React.PropTypes.object.isRequired
+  disableTimelinePointerEvents: React.PropTypes.func.isRequired,
+  enableTimelinePointerEvents: React.PropTypes.func.isRequired
 }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Doing research on timeline perf, I noticed that the whole timeline
is rendered twice on every click.

This is caused because we are setting state on mousedown and mouseup,
and setting styles in one of the root elements based on this.

This changes the logic to modify the styles via plain old JS and
use attributes in the component itself instead of states.

Regressions to look for:

As @stristr mentioned in the past, some bugs may be hidden because we are re-rendering the timeline way too many times. After implementing this, I have found one totally unrelated bug, which is also solved. (see comment below)

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
