### PR TITLE
feat: enable public/private to be toggled during publish

### DIFF
--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -148,7 +148,7 @@ export class ShareModal extends React.Component<ShareModalProps, ShareModalState
           <ProjectShareDetails
             semverVersion={semverVersion}
             projectName={project.projectName}
-            isDisabled={!this.state.isPublicKnown || !snapshotSyndicated}
+            isDisabled={!this.state.isPublicKnown}
             linkAddress={linkAddress}
             isSnapshotSaveInProgress={isSnapshotSaveInProgress}
             isPublic={this.state.isPublic}


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- The title says all, this was disabled because we needed to switch licenses, which is no
longer the case.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
