### PR TITLE
Finish queued state transitions behavior implementation

### DIFF
--- a/packages/@haiku/core/test/unit/stateTransitions.test.ts
+++ b/packages/@haiku/core/test/unit/stateTransitions.test.ts
@@ -6,7 +6,7 @@ import * as tape from 'tape';
 tape(
   'Test state transitions',
   (t) => {
-    t.plan(28);
+    t.plan(31);
 
     const states = {
       var1: 0,
@@ -410,12 +410,50 @@ tape(
       18,
       'A setState without transition parameter should cancel any queued transition',
     );
+
+    stateTransitionManager.setState(
+      {var1: 20},
+      {
+        duration: 1000,
+        curve: Curve.Linear,
+        queue: true,
+      },
+    );
+    stateTransitionManager.setState(
+      {var1: 22},
+      {
+        duration: 1000,
+        curve: Curve.Linear,
+        queue: true,
+      },
+    );
     haikuClock.setTime(19000);
     stateTransitionManager.tickStateTransitions();
     t.is(
       states.var1,
-      18,
-      'A setState without transition parameter should cancel any queued transition',
+      20,
+      'First queued state transition should be executed',
+    );
+
+    haikuClock.setTime(19500);
+    stateTransitionManager.tickStateTransitions();
+    t.is(
+      states.var1,
+      21,
+      'Second queued state transition is updated on its start',
+    );
+
+    haikuClock.setTime(20000);
+    stateTransitionManager.tickStateTransitions();
+    t.is(
+      states.var1,
+      22,
+      'Second queued state transition should be executed',
+    );
+    t.is(
+      stateTransitionManager.numQueuedTransitions,
+      0,
+      'All transitions should be finished',
     );
 
   },


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:
The behavior details of queued state transitions was discussed on slacks's #product on May 29th:

1- A 'packed' setState transition,

```
setState({var1: 10, var2: 10}, {duration: 4000, curve: 'linear'}
```

is implemented essentially as a short for

```
setState({var1: 10}, {duration: 4000, curve: 'linear'}
setState({var2: 10}, {duration: 4000, curve: 'linear'}
```
 
2 - If you pass the parameter `queue: true`

```
setState({var1: 10}, {duration: 4000, curve: 'linear', queue:true}
```

It will queue (or execute right away if no other transition is executing on that state) the state transition. If a normal setState is called (without any transition parameter) or a not queue setState(eg. `setState({var1: 10}, {duration: 4000, curve: 'linear'}` or `setState({var1: 10})` ), it will cancel any state transition on that state and execute the non queued state transition. 

3- Transition origin (startTime and trasitionStart) for queued transitions is calculated when transition is about to start


Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Wrote an automated test covering new functionality
