### PR TITLE
Fix: timeline frame actions on sub components

### DIFF
--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -185,17 +185,13 @@ class ActiveComponent extends BaseModel {
     )
   }
 
-  findElementRoots () {
-    return Element.findRoots()
-  }
-
   findElementRoot () {
     for (let element of Element.findRoots()) {
-        if (element.component.uid === this.uid){
+      if (element.component.uid === this.uid) {
         return element
       }
     }
-    return null;
+    return null
   }
 
   queryElements (criteria) {

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -189,6 +189,15 @@ class ActiveComponent extends BaseModel {
     return Element.findRoots()
   }
 
+  findElementRoot () {
+    for (let element of Element.findRoots()) {
+        if (element.component.uid === this.uid){
+        return element
+      }
+    }
+    return null;
+  }
+
   queryElements (criteria) {
     if (!criteria) criteria = {}
     criteria.component = this // Only query elements that belong to us

--- a/packages/haiku-timeline/src/components/FrameGrid.js
+++ b/packages/haiku-timeline/src/components/FrameGrid.js
@@ -7,8 +7,8 @@ export default class FrameGrid extends React.Component {
   constructor (props) {
     super(props)
     this.handleUpdate = this.handleUpdate.bind(this)
-    // # FIXME in multicomponents (matthew)
-    this.rootElement = props.timeline.component.findElementRoots()[0]
+
+    this.rootElement = props.timeline.component.findElementRoot()
     this.upsertTimelineEvents()
   }
 
@@ -27,6 +27,9 @@ export default class FrameGrid extends React.Component {
     if (nextProps.timeline !== this.props.timeline) {
       this.props.timeline.removeListener('update', this.handleUpdate)
       nextProps.timeline.on('update', this.handleUpdate)
+
+      this.rootElement = nextProps.timeline.component.findElementRoot()
+      this.upsertTimelineEvents()
     }
   }
 

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -930,7 +930,7 @@ class Timeline extends React.Component {
   }
 
   showFrameActionsEditor (frame) {
-    const elementPrimaryKey = this.getActiveComponent().findElementRoots()[0].getPrimaryKey()
+    const elementPrimaryKey = this.getActiveComponent().findElementRoot().getPrimaryKey()
     this.showEventHandlersEditor(
       elementPrimaryKey,
       frame


### PR DESCRIPTION
Fix: Frame actions on sub-component do not persist :
 - https://app.asana.com/0/687739386153745/696932519911311  
 - https://app.asana.com/0/687739386153745/699216096995317

Fix Frame actions show up across all component timelines:
 - https://app.asana.com/0/687739386153745/699216096995305


OK to merge.

Short review.

Summary of changes:

- …

Regressions to look for:

- …

Notes for reviewers:

- …

Completed checkin tasks:

- [ ] Did manual testing of interrelated functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
