### PR TITLE
Add RCM option to first non-zero keyframe 'Send to t0'

### DIFF
--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -2755,6 +2755,20 @@ class ActiveComponent extends BaseModel {
     return Keyframe.where({ component: this, _selected: true })
   }
 
+  /**
+   * Returns a boolean indicating if *all* of the selected keyframes
+   * are the first non-zero keyframe in their row.
+   *
+   * @returns Boolean
+   */
+  checkIfSelectedKeyframesAreMovableToZero () {
+    const selectedKeyframes = this.getSelectedKeyframes()
+    const notMovable = selectedKeyframes.findIndex(
+      (keyframe) => !(keyframe.prev() && keyframe.prev().origMs === 0)
+    )
+    return notMovable === -1
+  }
+
   getCurrentKeyframes (criteria) {
     if (!criteria) criteria = {}
     criteria.component = this

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -832,11 +832,6 @@ Keyframe.buildKeyframeMoves = (criteria, serialized) => {
     if (!moves[timelineName][componentId]) moves[timelineName][componentId] = {}
     if (!moves[timelineName][componentId][propertyName]) moves[timelineName][componentId][propertyName] = {}
 
-    moves[timelineName][componentId][propertyName][movable.getMs()] = movable.getSpec(true, serialized)
-
-    // Since this action resolves the move, exclude it from future calls until set again
-    movable._needsMove = false
-
     // Because the keyframe move action interprets excluded entries as *deletes*, we have to
     // also include all keyframes that are a part of the same timeline/component/property tuple
     Keyframe.where(criteria).forEach((partner) => {
@@ -849,6 +844,11 @@ Keyframe.buildKeyframeMoves = (criteria, serialized) => {
       // Since this action resolves the move, exclude it from future calls until set again
       partner._needsMove = false
     })
+
+    moves[timelineName][componentId][propertyName][movable.getMs()] = movable.getSpec(true, serialized)
+
+    // Since this action resolves the move, exclude it from future calls until set again
+    movable._needsMove = false
   })
 
   return moves

--- a/packages/haiku-serialization/test/bll/05_Keyframe.test.js
+++ b/packages/haiku-serialization/test/bll/05_Keyframe.test.js
@@ -176,6 +176,22 @@ tape('Keyframe.03', (t) => {
   })
 })
 
+tape('Keyframe.04', (t) => {
+  t.plan(3)
+  return setupTest('keyframe-04', (err, ac, rows, done) => {
+    if (err) throw err
+    const kfs = rows[0].getKeyframes()
+    fireClick(kfs[0], false, { shift: false })
+    t.equal(ac.checkIfSelectedKeyframesAreMovableToZero(), false, 'the first keyframe cannot be moved to zero')
+    fireClick(kfs[1], false, { shift: false })
+    t.equal(ac.checkIfSelectedKeyframesAreMovableToZero(), true, 'the first non-zero keyframe can be moved to zero')
+    fireClick(kfs[2], false, { shift: false })
+    t.equal(ac.checkIfSelectedKeyframesAreMovableToZero(), false, 'any other keyframe cannot be moved to zero')
+
+    done()
+  })
+})
+
 // Please implement the rest of these as unit tests:
 // I am able to create a tween between two keyframes
 // I am able to select a single tween by clicking on it

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -520,6 +520,8 @@ class Timeline extends React.Component {
       }
     })
 
+    items.push({ type: 'separator' })
+
     items.push({
       label: 'Send to t0',
       enabled: this.getActiveComponent().checkIfSelectedKeyframesAreMovableToZero(),

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -487,7 +487,8 @@ class Timeline extends React.Component {
   getPopoverMenuItems ({ event, type, model, offset, curve }) {
     const items = []
 
-    const numSelectedKeyframes = this.getActiveComponent().getSelectedKeyframes().length
+    const selectedKeyframes = this.getActiveComponent().getSelectedKeyframes()
+    const numSelectedKeyframes = selectedKeyframes.length
 
     items.push({
       label: 'Create Keyframe',
@@ -516,6 +517,15 @@ class Timeline extends React.Component {
       enabled: type === 'keyframe',
       onClick: (event) => {
         this.getActiveComponent().deleteSelectedKeyframes({ from: 'timeline' })
+      }
+    })
+
+    items.push({
+      label: 'Send to t0',
+      enabled: this.getActiveComponent().checkIfSelectedKeyframesAreMovableToZero(),
+      onClick: (event) => {
+        selectedKeyframes.forEach((keyframe) => { keyframe.moveTo(0, 0) })
+        this.getActiveComponent().commitAccumulatedKeyframeMovesDebounced()
       }
     })
 


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

This PR is mainly composed of two changes:

- Implements ["Add RCM option to first non-zero keyframe 'Send to t0'"](https://app.asana.com/0/687739386153745/682255795316585) (via c8227c0 and 5a64e89)
- Fixes a bug that raised from testing this which was present in the app, I filled [a task](https://app.asana.com/0/687739386153745/700316634325328) with steps to repro

Regressions to look for:

- Maybe updating keyframes

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Wrote an automated test covering new functionality
