### PR TITLE
Undo/Redo Multi-Component Aware (700284159196026) [for RC-3.4.3]

### DIFF
--- a/packages/haiku-serialization/src/bll/ActionStack.js
+++ b/packages/haiku-serialization/src/bll/ActionStack.js
@@ -224,10 +224,12 @@ class ActionStack extends BaseModel {
   }
 
   addUndoable (undoable, ac) {
+    // TODO: reimplement this.undoables as a Map<ActiveComponent, Undoable[]>
     this.addDoable(Object.assign(undoable, {ac}), this.undoables)
   }
 
   addRedoable (redoable, ac) {
+    // TODO: reimplement this.redoables as a Map<ActiveComponent, Undoable[]>
     this.addDoable(Object.assign(redoable, {ac}), this.redoables)
   }
 

--- a/packages/haiku-serialization/src/bll/ActionStack.js
+++ b/packages/haiku-serialization/src/bll/ActionStack.js
@@ -357,6 +357,7 @@ class ActionStack extends BaseModel {
 
   undo (options, metadata, cb) {
     this.forceAccumulation()
+
     if (this.getUndoables().length < 1) {
       return cb()
     }
@@ -385,6 +386,7 @@ class ActionStack extends BaseModel {
 
   redo (options, metadata, cb) {
     this.forceAccumulation()
+
     if (this.getRedoables().length < 1) {
       return cb()
     }

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -2462,7 +2462,9 @@ class ActiveComponent extends BaseModel {
   pushBytecodeSnapshot (done) {
     // Push our reified decycled bytecode into our local snapshots with no prejudice.
     // TODO: does this leak too much memory?
-    this.snapshots.push(Bytecode.snapshot(this.fetchActiveBytecodeFile().getReifiedDecycledBytecode()))
+    this.snapshots.push(
+      Bytecode.snapshot(this.fetchActiveBytecodeFile().getReifiedDecycledBytecode({suppressSubcomponents: false}))
+    )
     done()
   }
 


### PR DESCRIPTION
OK to merge into `rc-3.4.3`.

Short review.

Summary of changes:

- Have undo/redo stack entries aware of the active component context in which they originated, such that doing undo in a specific multi-component tab will only affect that tab. 

Regressions to look for:

- Undo/redo regressions.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
