### PR TITLE
Enable interpolation for boolean only. Fix (703436957231272)

### DIFF
--- a/packages/@haiku/core/src/Interpolate.ts
+++ b/packages/@haiku/core/src/Interpolate.ts
@@ -8,6 +8,7 @@ import justCurves from './vendor/just-curves';
 const CENT = 1.0;
 const OBJECT = 'object';
 const NUMBER = 'number';
+const BOOLEAN = 'boolean';
 
 function percentOfTime (t0: number, t1: number, tnow: number) {
   const span = t1 - t0;
@@ -78,6 +79,12 @@ function interpolate (
 
   if (typeof origin === NUMBER && typeof destination === NUMBER) {
     return interpolateValue(origin as number, destination as number, started, ends, now, curveFunc as CurveFunction);
+  }
+
+  // To interpolate booleans, assumes origin/destination are 0 (false) or 1(true), interpolate,
+  // and if interpolation result>=0.5, assumes it true, false otherwise, ofc.
+  if (typeof origin === BOOLEAN && typeof destination === BOOLEAN) {
+    return interpolateValue(Number(origin), Number(destination), started, ends, now, curveFunc as CurveFunction) >= 0.5;
   }
 
   return origin;

--- a/packages/@haiku/core/src/StateTransitionManager.ts
+++ b/packages/@haiku/core/src/StateTransitionManager.ts
@@ -118,11 +118,13 @@ export default class StateTransitionManager {
           // Remove expired transition.
           this.transitions[stateName].splice(0, 1);
 
-          // Update next queued state transition
+          // Update next queued state transition or delete empty transition vector for performance reasons
           if (this.transitions[stateName].length > 0) {
             this.transitions[stateName][0].transitionStart = {[stateName]: interpolatedStates[stateName]};
             this.transitions[stateName][0].startTime = currentTime;
             this.transitions[stateName][0].endTime = currentTime + this.transitions[stateName][0].duration;
+          } else {
+            delete this.transitions[stateName];
           }
 
         } else {

--- a/packages/@haiku/core/test/unit/stateTransitions.test.ts
+++ b/packages/@haiku/core/test/unit/stateTransitions.test.ts
@@ -6,8 +6,6 @@ import * as tape from 'tape';
 tape(
   'Test state transitions',
   (t) => {
-    t.plan(31);
-
     const states = {
       var1: 0,
       var2: 5,
@@ -247,22 +245,46 @@ tape(
     t.is(
       states.varNull,
       null,
-      'Do not stete transition null',
+      'Do not state transition null',
     );
 
     stateTransitionManager.setState(
-      {varBool: 10},
+      {varBool: false},
       {
         duration: 1000,
         curve: Curve.Linear,
       },
     );
-    haikuClock.setTime(12000);
+    haikuClock.setTime(11400);
     stateTransitionManager.tickStateTransitions();
     t.is(
       states.varBool,
       true,
-      'Do not state transition boolean',
+      'State transition boolean',
+    );
+
+    haikuClock.setTime(11500);
+    stateTransitionManager.tickStateTransitions();
+    t.is(
+      states.varBool,
+      true,
+      'State transition boolean',
+    );
+
+    haikuClock.setTime(11501);
+    stateTransitionManager.tickStateTransitions();
+    t.is(
+      states.varBool,
+      false,
+      'State transition boolean',
+    );
+
+    haikuClock.setTime(12000);
+    stateTransitionManager.tickStateTransitions();
+    t.is(
+      states.varBool,
+      false,
+      'State transition boolean',
     );
 
     stateTransitionManager.setState(
@@ -456,5 +478,6 @@ tape(
       'All transitions should be finished',
     );
 
+    t.end();
   },
 );

--- a/packages/@haiku/core/test/unit/stateTransitions.test.ts
+++ b/packages/@haiku/core/test/unit/stateTransitions.test.ts
@@ -222,30 +222,41 @@ tape(
         curve: Curve.Linear,
       },
     );
-    haikuClock.setTime(10000);
+    haikuClock.setTime(9500);
     stateTransitionManager.tickStateTransitions();
     t.deepEqual(
       states.varObject,
       {
         varString: 'string',
+        var: 7.5,
+      },
+      'Interpolate numbers and set transition end directly on non interpolable objects',
+    );
+
+    haikuClock.setTime(10000);
+    stateTransitionManager.tickStateTransitions();
+    t.deepEqual(
+      states.varObject,
+      {
+        varString: 10,
         var: 10,
       },
-      'Interpolate only numbers on objects',
+      'Interpolate numbers and set transitionEnd directly on non interpolable objects',
     );
 
     stateTransitionManager.setState(
       {varNull: 10},
       {
         duration: 1000,
-        curve: Curve.Linear,
+        curve: Curve.EaseOutQuad,
       },
     );
     haikuClock.setTime(11000);
     stateTransitionManager.tickStateTransitions();
     t.is(
       states.varNull,
-      null,
-      'Do not state transition null',
+      10,
+      'Set transitionEnd directly on non interpolable objects',
     );
 
     stateTransitionManager.setState(
@@ -470,6 +481,26 @@ tape(
     t.is(
       states.var1,
       22,
+      'Second queued state transition should be executed',
+    );
+    t.is(
+      stateTransitionManager.numQueuedTransitions,
+      0,
+      'All transitions should be finished',
+    );
+
+    stateTransitionManager.setState(
+      {var1: 50},
+      {
+        duration: 1000,
+        curve: Curve.EaseInExpo,
+      },
+    );
+    haikuClock.setTime(21000);
+    stateTransitionManager.tickStateTransitions();
+    t.is(
+      states.var1,
+      50,
       'Second queued state transition should be executed',
     );
     t.is(


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Booleans weren't interpolatable(_sic_) in interpolation function. Because setting state was generalized inside  stateTransitionManager, booleans were being skipped.

Additionally, for the hypothetical user who wants to do a boolean interpolation, this patch enables it.. It assumes 0 for false and 1 for true, and if interpolation result is >= 0.5, it is true.


The ideal solution (eg, if we enable number->boolean transition, if we enable boolean -> boolean transition) is discussed on #product on 8th June

Regressions to look for:

- …

Notes for reviewers:

- …

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Wrote an automated test covering new functionality
