### PR TITLE
tweak: move phone-home to inkstone-edge to save DB/server load.

### DIFF
--- a/packages/@haiku/core/src/renderers/dom/createRightClickMenu.ts
+++ b/packages/@haiku/core/src/renderers/dom/createRightClickMenu.ts
@@ -107,7 +107,7 @@ export default function createRightClickMenu (domElement, component) {
 
   if (metadata && metadata.project && metadata.organization && window && window.fetch) {
     try {
-      window.fetch(`https://inkstone.haiku.ai/v0/community/${metadata.organization}/${metadata.project}/metadata`)
+      window.fetch(`https://inkstone-edge.haiku.ai/v0/community/${metadata.organization}/${metadata.project}/metadata`)
         .then((response) => response.json() as Promise<{IsPublic: boolean, IsForkable: boolean}>)
         .then((responseJson) => {
           isPublic = responseJson.IsPublic;


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Move RCM phone-home (which we use to determine which RCM options to show) to a CloudFront-backed server to save load.

Regressions to look for:

- Known regression—fork/view options might be up to five minutes old in right-click menu when privacy settings CHANGE.

Notes for reviewers:

- Today, every time a Haiku loads a RCM, phone-home will trigger a real API call. Essentially, one very popular Haiku can DDOS our DB using client browsers as bots.
 - With this change, we are using a value that is cached every five minutes and served from CloudFront (edge node caches per origin and viewer country). This should bring down the load significantly if a very popular web page is hosting a Haiku today.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
