### PR TITLE
Fix write races

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -137,10 +137,7 @@ export default class Creator extends React.Component {
 
     // fileOptions is something of a misnomer, but we pass these into Project so they
     // can be forwarded to file. They're also used to configure the Project model itself.
-    this.fileOptions = {
-      doWriteToDisk: false,
-      skipDiffLogging: true
-    }
+    this.fileOptions = {}
 
     // Callback for post-authentication
     this._postAuthCallback = undefined

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -141,10 +141,7 @@ export class Glass extends React.Component {
       this.props.websocket,
       window,
       this.props.userconfig,
-      { // fileOptions
-        doWriteToDisk: false,
-        skipDiffLogging: true
-      },
+      {}, // fileOptions
       this.props.envoy,
       (err, project) => {
         if (err) throw err

--- a/packages/haiku-plumbing/src/Master.js
+++ b/packages/haiku-plumbing/src/Master.js
@@ -15,7 +15,6 @@ import logger from 'haiku-serialization/src/utils/LoggerInstance'
 import MockWebsocket from 'haiku-serialization/src/ws/MockWebsocket'
 import { EventEmitter } from 'events'
 import EmitterManager from 'haiku-serialization/src/utils/EmitterManager'
-import * as Git from './Git'
 import Watcher from './Watcher'
 import * as ProjectFolder from './ProjectFolder'
 import MasterGitProject from './MasterGitProject'
@@ -82,11 +81,6 @@ function _isFileSignificant (relpath) {
   if (UNWATCHABLE_BASENAMES[path.basename(relpath)]) return false
   if (!WATCHABLE_EXTNAMES[path.extname(relpath)]) return false
   return true
-}
-
-function _excludeIfNotJs (relpath) {
-  if (path.extname(relpath) !== '.js') return true
-  return !_isFileSignificant(relpath)
 }
 
 export default class Master extends EventEmitter {

--- a/packages/haiku-plumbing/src/Master.js
+++ b/packages/haiku-plumbing/src/Master.js
@@ -494,24 +494,6 @@ export default class Master extends EventEmitter {
     return cb(null, state)
   }
 
-  doesProjectHaveUnsavedChanges (cb) {
-    return Git.status(this.folder, {}, (statusErr, statusesDict) => {
-      if (statusErr) return cb(statusErr)
-      if (Object.keys(statusesDict).length < 1) return cb(null, false)
-      return cb(null, true)
-    })
-  }
-
-  discardProjectChanges (cb) {
-    return Git.hardReset(this.folder, 'HEAD', (err) => {
-      if (err) return cb(err)
-      return Git.removeUntrackedFiles(this.folder, (err) => {
-        if (err) return cb(err)
-        return cb()
-      })
-    })
-  }
-
   getAssets (cb) {
     return cb(null, this._knownLibraryAssets)
   }
@@ -722,14 +704,6 @@ export default class Master extends EventEmitter {
               return cb()
             }
           )
-        },
-
-        // Load all relevant files into memory (only JavaScript files for now)
-        (cb) => {
-          logger.info(`[master] ${loggingPrefix}: ingesting js files in ${this.folder}`)
-          return File.ingestFromFolder(this.project, this.folder, {
-            exclude: _excludeIfNotJs
-          }, cb)
         },
 
         // Take an initial commit of the starting state so we have a baseline

--- a/packages/haiku-plumbing/src/MasterGitProject.js
+++ b/packages/haiku-plumbing/src/MasterGitProject.js
@@ -10,6 +10,7 @@ import logger from 'haiku-serialization/src/utils/LoggerInstance'
 import * as Git from './Git'
 import * as ProjectFolder from './ProjectFolder'
 import * as Inkstone from './Inkstone'
+import * as Lock from 'haiku-serialization/src/bll/Lock'
 
 const PLUMBING_PKG_PATH = path.join(__dirname, '..')
 const PLUMBING_PKG_JSON_PATH = path.join(PLUMBING_PKG_PATH, 'package.json')
@@ -945,24 +946,26 @@ export default class MasterGitProject extends EventEmitter {
       // git status is async so we lock queued commit requests until we finish
       this._isCommittingLocked = true
 
-      return this.statusForFile(relpath, (err, status) => {
-        // Everything until we commit is now sync so it's safe to turn this off
-        this._isCommittingLocked = false
+      const abspath = path.join(this.folder, relpath)
+      return Lock.request(Lock.LOCKS.FileReadWrite(abspath), false, (release) => {
+        return this.statusForFile(relpath, (err, status) => {
+          // Everything until we commit is now sync so it's safe to turn this off
+          this._isCommittingLocked = false
 
-        if (err) {
-          return cb(err)
-        }
-        if (!status) {
-          return cb() // No status means no changes
-        }
+          const finish = (err) => {
+            release()
+            return cb(err)
+          }
 
-        // 0 is UNMODIFIED, everything else is a change
-        // See http://www.nodegit.org/api/diff/#getDelta
-        if (status.num && status.num > 0) {
-          return this.commit(relpath, message, cb)
-        }
+          // No status means no changes.
+          // 0 is UNMODIFIED, everything else is a change
+          // See http://www.nodegit.org/api/diff/#getDelta
+          if (err || !status || !status.num || status.num < 1) {
+            return finish(err)
+          }
 
-        return cb()
+          return this.commit(relpath, message, finish)
+        })
       })
     })
   }

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -1398,8 +1398,8 @@ Plumbing.prototype.spawnSubgroup = function (haiku, cb) {
         token: process.env.ENVOY_TOKEN
       }, haiku.envoy),
       fileOptions: {
-        doWriteToDisk: true, // default
-        skipDiffLogging: false // default
+        doWriteToDisk: true,
+        skipDiffLogging: false
       }
     })
   }

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -351,11 +351,10 @@ class ActiveComponent extends BaseModel {
 
     // There is a race where the file might not be ready, so we upsert
     if (!file) {
-      file = File.upsert({
-        uid,
+      logger.warn(`[active component (${folder})] fetchActiveBytecodeFile called before file was upserted`)
+      file = this.project.upsertFile({
         relpath,
-        folder,
-        project: this.project
+        type: File.TYPES.code
       })
 
       // This calls require, which might introduce its own race ¯\_(ツ)_/¯

--- a/packages/haiku-serialization/src/bll/File.js
+++ b/packages/haiku-serialization/src/bll/File.js
@@ -1,4 +1,3 @@
-const async = require('async')
 const fse = require('fs-extra')
 const {debounce} = require('lodash')
 const path = require('path')
@@ -6,7 +5,6 @@ const xmlToMana = require('@haiku/core/lib/helpers/xmlToMana').default
 const objectToRO = require('@haiku/core/lib/reflection/objectToRO').default
 const BaseModel = require('./BaseModel')
 const logger = require('./../utils/LoggerInstance')
-const walkFiles = require('./../utils/walkFiles')
 const {Experiment, experimentIsEnabled} = require('haiku-common/lib/experiments')
 const getSvgOptimizer = require('./../svg/getSvgOptimizer')
 const Lock = require('./Lock')

--- a/packages/haiku-serialization/src/bll/File.js
+++ b/packages/haiku-serialization/src/bll/File.js
@@ -208,6 +208,9 @@ class File extends BaseModel {
   }
 
   writeSync () {
+    if (!this.options.doWriteToDisk) {
+      throw new Error('[file] illegal write requested')
+    }
     this.assertContents(this.contents)
     this.dtLastWriteStart = Date.now()
     logger.info(`[file] writing ${this.relpath} to disk`)
@@ -300,7 +303,7 @@ File.DEFAULT_CONTEXT_SIZE = DEFAULT_CONTEXT_SIZE
 File.cache = new Cache()
 
 File.write = (folder, relpath, contents, cb) => {
-  let abspath = path.join(folder, relpath)
+  const abspath = path.join(folder, relpath)
   return Lock.request(Lock.LOCKS.FileReadWrite(abspath), true, (release) => {
     return fse.outputFile(abspath, contents, (err) => {
       release()

--- a/packages/haiku-serialization/src/bll/File.js
+++ b/packages/haiku-serialization/src/bll/File.js
@@ -287,8 +287,8 @@ BaseModel.extend(File)
 File.TYPES = FILE_TYPES
 
 File.DEFAULT_OPTIONS = {
-  doWriteToDisk: true, // Write all actions/content updates to disk
-  skipDiffLogging: false, // Log a colorized diff of every content update
+  doWriteToDisk: false, // Write all actions/content updates to disk
+  skipDiffLogging: true, // Log a colorized diff of every content update
   required: {
     relpath: true,
     folder: true,

--- a/packages/haiku-serialization/src/bll/File.js
+++ b/packages/haiku-serialization/src/bll/File.js
@@ -385,29 +385,6 @@ File.expelOne = (folder, relpath, cb) => {
   cb()
 }
 
-File.ingestFromFolder = (project, folder, options, cb) => {
-  return walkFiles(folder, (err, entries) => {
-    if (err) return cb(err)
-    const picks = []
-    entries.forEach((entry) => {
-      const relpath = path.relative(folder, entry.path)
-
-      // Only allow bytecode files
-      if (!path.basename(relpath, '.js') === 'code') {
-        return picks.push(entry)
-      }
-    })
-    // Load the code first, then designs. This is so we can merge design changes!
-    return async.mapSeries(picks, (entry, next) => {
-      const relpath = path.relative(folder, entry.path)
-      return File.ingestOne(project, folder, relpath, next)
-    }, (err, files) => {
-      if (err) return cb(err)
-      return cb(null, files)
-    })
-  })
-}
-
 File.buildManaCacheKey = (folder, relpath) => {
   return `mana:${path.join(folder, relpath)}`
 }

--- a/packages/haiku-serialization/src/bll/Lock.js
+++ b/packages/haiku-serialization/src/bll/Lock.js
@@ -39,12 +39,6 @@ const request = (key, emit, cb) => {
   return cb(release)
 }
 
-const clearAll = () => {
-  for (const key in ACTIVE_LOCKS) {
-    delete ACTIVE_LOCKS[key]
-  }
-}
-
 const awaitFree = (keys, cb) => {
   let anyLocked = false
 
@@ -61,11 +55,13 @@ const awaitFree = (keys, cb) => {
   return cb()
 }
 
+const awaitAllLocksFree = (cb) => awaitFree(Object.keys(ACTIVE_LOCKS), cb)
+
 module.exports = {
   request,
   emitter,
-  clearAll,
   awaitFree,
+  awaitAllLocksFree,
   LOCKS,
   ACTIVE_LOCKS
 }

--- a/packages/haiku-serialization/src/bll/ModuleWrapper.js
+++ b/packages/haiku-serialization/src/bll/ModuleWrapper.js
@@ -168,7 +168,7 @@ class ModuleWrapper extends BaseModel {
             this.file.maybeFlushContentForceSync()
           }
           release()
-          return cb()
+          return cb(null, this.exp)
         })
       }
 

--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -918,7 +918,14 @@ class Project extends BaseModel {
   }
 
   setupScene (scenename, cb) {
-    return this.setupActiveComponent(path.join('code', scenename, 'code.js'), cb)
+    const relpath = path.join('code', scenename, 'code.js')
+    const abspath = path.join(this.getFolder(), relpath)
+    return Lock.request(Lock.LOCKS.FileReadWrite(abspath), false, (release) => {
+      return this.setupActiveComponent(relpath, (err) => {
+        release()
+        return cb(err)
+      })
+    })
   }
 
   getCodeFolderAbspath () {

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -81,10 +81,7 @@ class Timeline extends React.Component {
       this.props.websocket,
       window,
       this.props.userconfig,
-      { // fileOptions
-        doWriteToDisk: false,
-        skipDiffLogging: true
-      },
+      {}, // fileOptions
       this.props.envoy,
       (err, project) => {
         if (err) throw err


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes problem where we commit an empty `code/<scene>/code.js`.
- Shores up other potential weak points.

Regressions to look for:

- Any ungood changes to Git behavior or files not being committed.
- Any possibility of getting infinite locks.

Notes for reviewers:

- This PR is intentionally to `master` (still only good at building from `master` r.n.)

The race resulting in _commits_ of an empty `code.js` this should fix is:
  1. some change A occurs -> file lock granted -> commit A of relpath is pushed into commit queue -> file lock released
  1. some other change occured during above -> file lock granted -> write begins -> file is truncated
  1. commit A is completed -> file write completes -> file lock released

Other changes include:
  1. vacate all locks before Master can be torn down
  1. get file locks before trying to bootstrap scene files
  1. clean up unused `discardProjectChanges`, `doesProjectHaveUnsavedChanges`, and friends.

The gist is: use more I/O locks on bytecode files in places where they weren't before.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
