### PR TITLE
feats: include Figma components and ids for all assets to facilitate ungroup

### DIFF
--- a/packages/haiku-serialization/src/bll/Figma.js
+++ b/packages/haiku-serialization/src/bll/Figma.js
@@ -16,11 +16,13 @@ const IS_FIGMA_FOLDER_RE = /\.figma\.contents/
 const VALID_TYPES = {
   SLICE: 'SLICE',
   GROUP: 'GROUP',
-  FRAME: 'FRAME'
+  FRAME: 'FRAME',
+  COMPONENT: 'COMPONENT'
 }
 const FOLDERS = {
   [VALID_TYPES.SLICE]: 'slices/',
   [VALID_TYPES.GROUP]: 'groups/',
+  [VALID_TYPES.COMPONENT]: 'groups/',
   [VALID_TYPES.FRAME]: 'frames/'
 }
 
@@ -150,7 +152,7 @@ class Figma {
   getSVGLinks (elements, id) {
     return new Promise((resolve, reject) => {
       const ids = elements.map((element) => element.id)
-      const params = new URLSearchParams([['format', 'svg'], ['ids', ids]])
+      const params = new URLSearchParams([['format', 'svg'], ['ids', ids], ['svg_include_id', true]])
       const uri = API_BASE + 'images/' + id + '?' + params.toString()
 
       if (ids.length === 0) {

--- a/packages/haiku-serialization/test/bll/10_Figma.test.js
+++ b/packages/haiku-serialization/test/bll/10_Figma.test.js
@@ -51,13 +51,14 @@ tape('Figma.findInstantiableElements', (t) => {
   const elements = figma.findInstantiableElements(JSON.stringify(SampleFileFixture))
 
   t.ok(Array.isArray(elements), 'returns an array of elements')
-  t.equal(elements.length, 5, 'returns an array that includes all elements required to be found')
+  t.equal(elements.length, 6, 'returns an array that includes all elements required to be found')
   t.equal(elements[0].id, groupKey, 'includes elements of type GROUP')
   t.equal(elements[1].id, subgroupKey, 'includes subgroup elements of type GROUP')
   t.equal(elements[2].id, sliceKey, 'includes elements of type SLICE')
   t.equal(elements[2].name, 'Slice', 'passes through first unique instances of element names')
   t.equal(elements[3].name, 'Slice Copy 1', 'renames duplicately named slices to allow async fetch/write')
   t.equal(elements[4].name, 'Frame', 'includes frame elements')
+  t.equal(elements[5].name, 'Component', 'includes component elements')
   t.end()
 })
 

--- a/packages/haiku-serialization/test/fixtures/figma/sample-file.json
+++ b/packages/haiku-serialization/test/fixtures/figma/sample-file.json
@@ -223,6 +223,19 @@
             },
             "constraints": { "vertical": "TOP", "horizontal": "LEFT" },
             "exportSettings": []
+          },
+          {
+            "id": "7:1",
+            "name": "Component",
+            "type": "COMPONENT",
+            "absoluteBoundingBox": {
+              "x": -574,
+              "y": -116,
+              "width": 173,
+              "height": 179
+            },
+            "constraints": { "vertical": "TOP", "horizontal": "LEFT" },
+            "exportSettings": []
           }
         ],
         "backgroundColor": {


### PR DESCRIPTION
⚠️ OK to merge when #550 is merged.

Short review.

Summary of changes:

- Include Figma components in the `/groups` folder ([task](https://app.asana.com/0/680508544654148/704595780151982))
- Include a parameter when requesting SVGs to include id attributes for all SVG elements, this should help with ungroup if I'm right (cc: @stristr)

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test covering new functionality
