### PR TITLE
Fix: haiku init issues with existing content in .npmrc

### DIFF
--- a/packages/@haiku/cli/src/haiku-cli.ts
+++ b/packages/@haiku/cli/src/haiku-cli.ts
@@ -284,7 +284,7 @@ function doInit (context: IContext) {
   if (npmrc.indexOf('@haiku') === -1) {
     prependFile.sync('.npmrc', dedent`
       //reservoir.haiku.ai:8910/:_authToken=
-      @haiku:registry=https://reservoir.haiku.ai:8910/
+      @haiku:registry=https://reservoir.haiku.ai:8910/\n
     `);
   }
 }


### PR DESCRIPTION
OK to merge, this is based against `rc-3.4.5.3` because I consider this a simple fix that we should include as soon as possible, but feel free to change the base.

Short review.

Summary of changes:

This will help to preserve original content that could be present
in the .npmrc file.

For example, an user reported 403 errors when trying to install
a haiku via npm, and their .npmrc file looked like this:

```
//reservoir.haiku.ai:8910/:_authToken=
@haiku:registry=https://reservoir.haiku.ai:8910/package-lock = false
```

(note the `package-lock = false` bit)

This adds a carriage return at the end of the prepended text in order
to avoid similar scenarios.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Wrote an automated test covering new functionality
