### PR TITLE
feat: multiple timeline features

### DIFF
--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -21,5 +21,7 @@
   "IncludeSourceInIntegrityHash": false,
   "OrderedActionStack": false,
   "CodeEditorInCreator": true,
-  "WarnOnUndefinedStateVariables": true
+  "WarnOnUndefinedStateVariables": true,
+  "NativeTimelineScroll": true,
+  "TimelineMarqueeSelection": true
 }

--- a/packages/haiku-common/src/experiments/index.ts
+++ b/packages/haiku-common/src/experiments/index.ts
@@ -30,6 +30,8 @@ export enum Experiment {
   OrderedActionStack = 'OrderedActionStack',
   CodeEditorInCreator = 'CodeEditorInCreator',
   WarnOnUndefinedStateVariables = 'WarnOnUndefinedStateVariables',
+  NativeTimelineScroll = 'NativeTimelineScroll',
+  TimelineMarqueeSelection = 'TimelineMarqueeSelection',
 }
 
 /**

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -362,6 +362,11 @@ class Keyframe extends BaseModel {
     return !next || this.getMs() >= a || next.getMs() >= a
   }
 
+  isTweenable () {
+    const value = this.getValue()
+    return typeof (value) !== 'boolean' && (typeof value === 'string' || value instanceof String)
+  }
+
   next () {
     return this._next
   }

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -28,6 +28,7 @@ class Keyframe extends BaseModel {
     this._didHandleContextMenu = false
     this._mouseDownState = {}
     this._updateReceivers = {}
+    this._viewPosition = {}
   }
 
   activate () {
@@ -395,6 +396,10 @@ class Keyframe extends BaseModel {
       throw new Error(`keyframe pixel offset left params missing`)
     }
     return (this.getFrame(mspf) - base) * pxpf
+  }
+
+  storeViewPosition (rect) {
+    this._viewPosition = rect
   }
 
   isWithinCollapsedClusterHeadingRow () {

--- a/packages/haiku-serialization/src/bll/Row.js
+++ b/packages/haiku-serialization/src/bll/Row.js
@@ -456,9 +456,13 @@ class Row extends BaseModel {
     }
 
     const keyframes = this.getKeyframes()
-    const frameInfo = this.timeline.getFrameInfo()
 
-    return keyframes.filter((keyframe) => keyframe.isVisible(frameInfo.msA, frameInfo.msB)).map(iteratee)
+    if (experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+      return keyframes.map(iteratee)
+    } else {
+      const frameInfo = this.timeline.getFrameInfo()
+      return keyframes.filter((keyframe) => keyframe.isVisible(frameInfo.msA, frameInfo.msB)).map(iteratee)
+    }
   }
 
   isState () {

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -854,10 +854,6 @@ class Timeline extends BaseModel {
     return this
   }
 
-  notifyMarqueeSelection (area) {
-    this.emit('update', 'marquee-selection', area)
-  }
-
   updateScrubberPositionByDelta (delta) {
     let currentFrame = this.getCurrentFrame() + delta
     if (currentFrame <= 0) currentFrame = 0

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -54,6 +54,7 @@ class Timeline extends BaseModel {
     this._scrollbarEnd = 0
     this._hoveredFrame = 0
     this._timeDisplayMode = Timeline.TIME_DISPLAY_MODE.FRAMES
+    this._scrollLeft = 0
 
     this.raf = null // Store raf so it can be cancelled
     this.update = this.update.bind(this)
@@ -761,6 +762,15 @@ class Timeline extends BaseModel {
       this._durationDragStart = null
       this._durationTrim = 0
     }, DURATION_MOD_TIMEOUT)
+  }
+
+  setScrollLeft (x) {
+    this._scrollLeft = x
+    this.emit('update', 'timeline-scroll')
+  }
+
+  getScrollLeft () {
+    return this._scrollLeft
   }
 
   changeVisibleFrameRange (xl, xr) {

--- a/packages/haiku-timeline/public/styles/Timeline.css
+++ b/packages/haiku-timeline/public/styles/Timeline.css
@@ -112,6 +112,10 @@
   -webkit-app-region: drag;
 }
 
+#timeline::-webkit-scrollbar {
+  width: 0;
+}
+
 button {
   -webkit-app-region: no-drag;
   cursor: pointer;

--- a/packages/haiku-timeline/src/components/ClusterInputField.js
+++ b/packages/haiku-timeline/src/components/ClusterInputField.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import lodash from 'lodash'
 import Palette from 'haiku-ui-common/lib/Palette'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 
 export default class ClusterInputField extends React.Component {
   render () {
@@ -8,7 +9,7 @@ export default class ClusterInputField extends React.Component {
       <div
         className='property-cluster-input-field no-select'
         style={{
-          width: 83,
+          width: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 82 : 83,
           margin: 0,
           color: 'transparent',
           textShadow: '0 0 0 ' + Palette.DARK_ROCK,

--- a/packages/haiku-timeline/src/components/ClusterRow.js
+++ b/packages/haiku-timeline/src/components/ClusterRow.js
@@ -7,6 +7,7 @@ import FamilySVG from 'haiku-ui-common/lib/react/icons/FamilySVG'
 import ClusterInputField from './ClusterInputField'
 import RowSegments from './RowSegments'
 import ClusterRowHeading from './ClusterRowHeading'
+import zIndex from './styles/zIndex'
 import Globals from 'haiku-ui-common/lib/Globals'
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
 
@@ -78,7 +79,7 @@ export default class ClusterRow extends React.Component {
           top: 0,
           left: 0,
           width: this.props.timeline.getPropertiesPixelWidth(),
-          zIndex: 99999,
+          zIndex: zIndex.clusterRowHeading.base,
           backgroundColor: Palette.GRAY
         } : {})}>
           <div>
@@ -143,7 +144,8 @@ export default class ClusterRow extends React.Component {
             width: experimentIsEnabled(Experiment.NativeTimelineScroll) ? undefined : this.props.timeline.getTimelinePixelWidth(),
             left: this.props.timeline.getPropertiesPixelWidth() - 4, // offset half of lone keyframe width so it lines up with the pole
             top: 0,
-            height: 'inherit'
+            height: 'inherit',
+            zIndex: experimentIsEnabled(Experiment.NativeTimelineScroll) ? zIndex.clusterRow.base : undefined
           }}>
           <RowSegments
             scope='ClusterRow'

--- a/packages/haiku-timeline/src/components/ClusterRow.js
+++ b/packages/haiku-timeline/src/components/ClusterRow.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
 import Palette from 'haiku-ui-common/lib/Palette'
 import truncate from 'haiku-ui-common/lib/helpers/truncate'
 import RightCarrotSVG from 'haiku-ui-common/lib/react/icons/RightCarrotSVG'
@@ -46,9 +47,6 @@ export default class ClusterRow extends React.Component {
 
     return (
       <div
-        ref={(ref) => {
-          this.ref = ref
-        }}
         id={`property-cluster-row-${this.props.row.getAddress()}-${componentId}-${clusterName}`}
         className='property-cluster-row'
         onClick={() => {
@@ -69,71 +67,80 @@ export default class ClusterRow extends React.Component {
         }}
         style={{
           height: this.props.rowHeight,
-          width: this.props.timeline.getPropertiesPixelWidth() + this.props.timeline.getTimelinePixelWidth(),
+          width: experimentIsEnabled(Experiment.NativeTimelineScroll) ? undefined : this.props.timeline.getPropertiesPixelWidth() + this.props.timeline.getTimelinePixelWidth(),
           left: 0,
           opacity: (this.props.row.isHidden()) ? 0.5 : 1.0,
           position: 'relative',
           cursor: 'pointer'
         }}>
-        <div>
-          <div
+        <div style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+            position: 'sticky',
+            top: 0,
+            left: 0,
+            width: this.props.timeline.getPropertiesPixelWidth(),
+            zIndex: 99999,
+            backgroundColor: Palette.GRAY
+          } : {})}>
+          <div>
+            <div
+              style={{
+                position: 'absolute',
+                left: 145,
+                width: 10,
+                height: 'inherit',
+                zIndex: 1005
+              }}>
+              <span className='utf-icon' style={{ top: -2, left: -3 }}><RightCarrotSVG /></span>
+            </div>
+            {this.maybeRenderFamilySvg()}
+            <div
+              className='property-cluster-row-label no-select'
+              style={{
+                position: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 'absolute' : 'relative',
+                right: experimentIsEnabled(Experiment.NativeTimelineScroll) ? undefined : 0,
+                width: this.props.timeline.getPropertiesPixelWidth() - (experimentIsEnabled(Experiment.NativeTimelineScroll) ? 80 : 120),
+                marginLeft: experimentIsEnabled(Experiment.NativeTimelineScroll) ? undefined : 40,
+                height: this.props.rowHeight,
+                paddingTop: 3,
+                paddingRight: 10,
+                borderTop: (this.props.row.isFirstRowOfSubElementSet()) ? `1px solid ${Palette.GRAY}` : 'none',
+                backgroundColor: (this.props.row.doesTargetHostElement()) ? Palette.GRAY : 'rgb(46, 59, 62)',
+                borderTopLeftRadius: (this.props.row.isFirstRowOfSubElementSet()) ? 4 : 0,
+                borderBottomLeftRadius: (this.props.row.isLastRowOfSubElementSet()) ? 4 : 0,
+                zIndex: 1004,
+                textAlign: 'right'
+              }}>
+              <ClusterRowHeading
+                clusterName={clusterName}
+                row={this.props.row}
+                />
+            </div>
+          </div>
+          <div className='property-cluster-input-field'
             style={{
               position: 'absolute',
-              left: 145,
-              width: 10,
-              height: 'inherit',
-              zIndex: 1005
+              left: this.props.timeline.getPropertiesPixelWidth() - 82,
+              width: 82,
+              top: 0,
+              height: 24,
+              textAlign: 'left'
             }}>
-            <span className='utf-icon' style={{ top: -2, left: -3 }}><RightCarrotSVG /></span>
-          </div>
-          {this.maybeRenderFamilySvg()}
-          <div
-            className='property-cluster-row-label no-select'
-            style={{
-              position: 'relative',
-              right: 0,
-              width: this.props.timeline.getPropertiesPixelWidth() - 120,
-              height: this.props.rowHeight,
-              paddingTop: 3,
-              paddingRight: 10,
-              borderTop: (this.props.row.isFirstRowOfSubElementSet()) ? `1px solid ${Palette.GRAY}` : 'none',
-              backgroundColor: (this.props.row.doesTargetHostElement()) ? Palette.GRAY : 'rgb(46, 59, 62)',
-              borderTopLeftRadius: (this.props.row.isFirstRowOfSubElementSet()) ? 4 : 0,
-              borderBottomLeftRadius: (this.props.row.isLastRowOfSubElementSet()) ? 4 : 0,
-              zIndex: 1004,
-              textAlign: 'right',
-              marginLeft: 40
-            }}>
-            <ClusterRowHeading
-              clusterName={clusterName}
+            <ClusterInputField
+              parent={this}
               row={this.props.row}
-              />
+              index={this.props.row.getAddress()}
+              height={this.props.rowHeight}
+              component={this.props.component}
+              timeline={this.props.timeline}
+              rowHeight={this.props.rowHeight} />
           </div>
-        </div>
-        <div className='property-cluster-input-field'
-          style={{
-            position: 'absolute',
-            left: this.props.timeline.getPropertiesPixelWidth() - 82,
-            width: 82,
-            top: 0,
-            height: 24,
-            textAlign: 'left'
-          }}>
-          <ClusterInputField
-            parent={this}
-            row={this.props.row}
-            index={this.props.row.getAddress()}
-            height={this.props.rowHeight}
-            component={this.props.component}
-            timeline={this.props.timeline}
-            rowHeight={this.props.rowHeight} />
         </div>
         <div
           className='property-cluster-timeline-segments-box'
           style={{
-            overflow: 'hidden',
+            overflow: experimentIsEnabled(Experiment.NativeTimelineScroll) ? undefined : 'hidden',
             position: 'absolute',
-            width: this.props.timeline.getTimelinePixelWidth(),
+            width: experimentIsEnabled(Experiment.NativeTimelineScroll) ? undefined : this.props.timeline.getTimelinePixelWidth(),
             left: this.props.timeline.getPropertiesPixelWidth() - 4, // offset half of lone keyframe width so it lines up with the pole
             top: 0,
             height: 'inherit'

--- a/packages/haiku-timeline/src/components/ClusterRow.js
+++ b/packages/haiku-timeline/src/components/ClusterRow.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 import Palette from 'haiku-ui-common/lib/Palette'
 import truncate from 'haiku-ui-common/lib/helpers/truncate'
 import RightCarrotSVG from 'haiku-ui-common/lib/react/icons/RightCarrotSVG'
@@ -74,13 +74,13 @@ export default class ClusterRow extends React.Component {
           cursor: 'pointer'
         }}>
         <div style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
-            position: 'sticky',
-            top: 0,
-            left: 0,
-            width: this.props.timeline.getPropertiesPixelWidth(),
-            zIndex: 99999,
-            backgroundColor: Palette.GRAY
-          } : {})}>
+          position: 'sticky',
+          top: 0,
+          left: 0,
+          width: this.props.timeline.getPropertiesPixelWidth(),
+          zIndex: 99999,
+          backgroundColor: Palette.GRAY
+        } : {})}>
           <div>
             <div
               style={{

--- a/packages/haiku-timeline/src/components/CollapsedPropertyTimelineSegments.js
+++ b/packages/haiku-timeline/src/components/CollapsedPropertyTimelineSegments.js
@@ -13,7 +13,8 @@ export default class CollapsedPropertyTimelineSegments extends React.Component {
           left: this.props.timeline.getPropertiesPixelWidth() - 4,
           height: this.props.rowHeight,
           width: '100%',
-          overflow: 'hidden'
+          overflow: 'hidden',
+          zIndex: experimentIsEnabled(Experiment.NativeTimelineScroll) ? zIndex.collapsedSegments.base : undefined
         }}>
         <RowSegments
           scope='CollapsedPropertyTimelineSegments'

--- a/packages/haiku-timeline/src/components/CollapsedPropertyTimelineSegments.js
+++ b/packages/haiku-timeline/src/components/CollapsedPropertyTimelineSegments.js
@@ -1,5 +1,8 @@
 import React from 'react'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
+import Palette from 'haiku-ui-common/lib/Palette'
 import RowSegments from './RowSegments'
+import zIndex from './styles/zIndex'
 
 export default class CollapsedPropertyTimelineSegments extends React.Component {
   render () {
@@ -14,7 +17,8 @@ export default class CollapsedPropertyTimelineSegments extends React.Component {
           height: this.props.rowHeight,
           width: '100%',
           overflow: 'hidden',
-          zIndex: experimentIsEnabled(Experiment.NativeTimelineScroll) ? zIndex.collapsedSegments.base : undefined
+          zIndex: experimentIsEnabled(Experiment.NativeTimelineScroll) ? zIndex.collapsedSegments.base : undefined,
+          backgroundColor: experimentIsEnabled(Experiment.NativeTimelineScroll) ? Palette.LIGHT_GRAY : undefined,
         }}>
         <RowSegments
           scope='CollapsedPropertyTimelineSegments'

--- a/packages/haiku-timeline/src/components/CollapsedPropertyTimelineSegments.js
+++ b/packages/haiku-timeline/src/components/CollapsedPropertyTimelineSegments.js
@@ -18,7 +18,7 @@ export default class CollapsedPropertyTimelineSegments extends React.Component {
           width: '100%',
           overflow: 'hidden',
           zIndex: experimentIsEnabled(Experiment.NativeTimelineScroll) ? zIndex.collapsedSegments.base : undefined,
-          backgroundColor: experimentIsEnabled(Experiment.NativeTimelineScroll) ? Palette.LIGHT_GRAY : undefined,
+          backgroundColor: experimentIsEnabled(Experiment.NativeTimelineScroll) ? Palette.LIGHT_GRAY : undefined
         }}>
         <RowSegments
           scope='CollapsedPropertyTimelineSegments'

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -10,6 +10,7 @@ import ComponentHeadingRowHeading from './ComponentHeadingRowHeading'
 import CollapsedPropertyTimelineSegments from './CollapsedPropertyTimelineSegments'
 import EventHandlerTriggerer from './EventHandlerTriggerer'
 import PropertyManager from './PropertyManager'
+import zIndex from './styles/zIndex'
 
 export default class ComponentHeadingRow extends React.Component {
   constructor (props) {
@@ -76,7 +77,7 @@ export default class ComponentHeadingRow extends React.Component {
           width: this.props.isExpanded ? 100 : undefined,
           top: this.props.isExpanded ? 0 : undefined,
           left: this.props.isExpanded ? 20 : undefined,
-          zIndex: 99999999,
+          zIndex: zIndex.headingRow.base,
           backgroundColor: this.props.isExpanded ? 'transparent' : Palette.LIGHT_GRAY,
           opacity: this.props.isHidden ? 0.75 : 1.0
         } : {
@@ -140,7 +141,7 @@ export default class ComponentHeadingRow extends React.Component {
               width: (this.props.row.isExpanded()) ? propertiesPixelWidth - 140 : propertiesPixelWidth,
               height: 'inherit',
               cursor: 'pointer',
-              zIndex: 9999999999999,
+              // zIndex: 9999999999999,
               backgroundColor: this.props.isExpanded ? 'transparent' : Palette.LIGHT_GRAY,
               display: 'flex',
               flexDirection: 'column'

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -77,7 +77,6 @@ export default class ComponentHeadingRow extends React.Component {
           width: this.props.isExpanded ? 100 : undefined,
           top: this.props.isExpanded ? 0 : undefined,
           left: this.props.isExpanded ? 20 : undefined,
-          zIndex: zIndex.headingRow.base,
           backgroundColor: this.props.isExpanded ? 'transparent' : Palette.LIGHT_GRAY,
           opacity: this.props.isHidden ? 0.75 : 1.0
         } : {
@@ -108,7 +107,7 @@ export default class ComponentHeadingRow extends React.Component {
           paddingLeft: this.props.isExpanded ? 0 : (this.props.row.isRootRow() ? 7 : 20),
           width: propertiesPixelWidth,
           backgroundColor: this.props.isExpanded ? 'transparent' : Palette.LIGHT_GRAY,
-          zIndex: 1006
+          zIndex: zIndex.headingRow.base,
         } : {})}>
           {!this.props.row.isRootRow() &&
             <div

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import lodash from 'lodash'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
 import DownCarrotSVG from 'haiku-ui-common/lib/react/icons/DownCarrotSVG'
 import RightCarrotSVG from 'haiku-ui-common/lib/react/icons/RightCarrotSVG'
 import DragGrip from 'haiku-ui-common/lib/react/icons/DragGrip'
@@ -57,16 +58,28 @@ export default class ComponentHeadingRow extends React.Component {
   render () {
     const componentId = this.props.row.element.getComponentId()
     const boltColor = this.props.hasAttachedActions ? Palette.LIGHT_BLUE : Palette.DARK_ROCK
+    const propertiesPixelWidth = this.props.timeline.getPropertiesPixelWidth()
 
     return (
       <div
-        ref='$row'
         id={`component-heading-row-${componentId}-${this.props.row.getAddress()}`}
         key={`component-heading-row-${componentId}-${this.props.row.getAddress()}`}
         className='component-heading-row no-select'
         onMouseOver={() => { this.throttledHandleRowHoverUnhover(true) }}
         onMouseOut={() => { this.throttledHandleRowHoverUnhover(false) }}
-        style={{
+        style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+          display: 'flex',
+          alignItems: 'top',
+          height: this.props.isExpanded ? 'auto' : this.props.rowHeight,
+          position: this.props.isExpanded ? 'sticky' : 'relative',
+          float: this.props.isExpanded ? 'left' : undefined,
+          width: this.props.isExpanded ? 100 : undefined,
+          top: this.props.isExpanded ? 0 : undefined,
+          left: this.props.isExpanded ? 20 : undefined,
+          zIndex: 99999999,
+          backgroundColor: this.props.isExpanded ? 'transparent' : Palette.LIGHT_GRAY,
+          opacity: this.props.isHidden ? 0.75 : 1.0
+        } : {
           display: 'table',
           tableLayout: 'fixed',
           height: this.props.isExpanded ? 0 : this.props.rowHeight,
@@ -76,158 +89,194 @@ export default class ComponentHeadingRow extends React.Component {
           backgroundColor: this.props.isExpanded ? 'transparent' : Palette.LIGHT_GRAY,
           verticalAlign: 'top',
           opacity: this.props.isHidden ? 0.75 : 1.0
-        }}>
-        {!this.props.isExpanded && // covers keyframe hangover at frame 0 that for uncollapsed rows is hidden by the input field
+        })}>
+        {!this.props.isExpanded && !experimentIsEnabled(Experiment.NativeTimelineScroll) && // covers keyframe hangover at frame 0 that for uncollapsed rows is hidden by the input field
           <div style={{
             position: 'absolute',
             zIndex: 1006,
-            left: this.props.timeline.getPropertiesPixelWidth() - 10,
+            left: propertiesPixelWidth - 10,
             top: 0,
             backgroundColor: Palette.LIGHT_GRAY,
             width: 10,
             height: this.props.rowHeight}} />}
-        {!this.props.row.isRootRow() &&
+        <div style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+          display: 'flex',
+          position: 'sticky',
+          top: 0,
+          left: 0,
+          paddingLeft: this.props.isExpanded ? 0: (this.props.row.isRootRow() ? 7 : 20),
+          width: propertiesPixelWidth,
+          backgroundColor: this.props.isExpanded ? 'transparent' : Palette.LIGHT_GRAY,
+          zIndex: 1006
+        } : {})}>
+          {!this.props.row.isRootRow() &&
+            <div
+              style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+                marginTop: 1,
+              } : {
+                position: 'absolute',
+                top: 3,
+                left: 12,
+                zIndex: 4
+              })}
+              className='component-heading-row-drag-handle'
+              {...this.props.dragHandleProps}>
+              <span
+                style={{transform: 'scale(0.5)', display: 'block'}}>
+                <DragGrip />
+              </span>
+            </div>
+          }
           <div
-            style={{
-              position: 'absolute',
-              top: 3,
-              left: 12,
-              zIndex: 4
-            }}
-            className='component-heading-row-drag-handle'
-            {...this.props.dragHandleProps}>
-            <span
-              style={{transform: 'scale(0.5)', display: 'block'}}>
-              <DragGrip />
-            </span>
-          </div>
-        }
-        <div
-          className='component-heading-row-inner no-select'
-          onClick={(clickEvent) => {
-            clickEvent.stopPropagation()
-            // Expand and select the entire component area when it is clicked, but note that we
-            // only collapse if the user clicked directly on the chevron.
-            Element.deselectAll({component: this.props.row.component}, {from: 'timeline'})
-            this.props.row.expandAndSelect({from: 'timeline'})
-          }}
-          style={{
-            display: 'table-cell',
-            width: (this.props.row.isExpanded()) ? this.props.timeline.getPropertiesPixelWidth() - 140 : '100%',
-            height: 'inherit',
-            position: 'absolute',
-            cursor: 'pointer',
-            zIndex: 3,
-            backgroundColor: this.props.isExpanded ? 'transparent' : Palette.LIGHT_GRAY
-          }}>
-          <div
-            className='component-heading-row-inner-r1'
-            style={{
-              height: this.props.rowHeight,
-              marginTop: -6,
-              maxWidth: (this.props.row.isRootRow()) ? '120px' : undefined
-            }}
+            className='component-heading-row-inner no-select'
             onClick={(clickEvent) => {
-              // Collapse/expand the entire component area when it is clicked
-              if (this.props.isExpanded && this.props.isSelected) {
-                clickEvent.stopPropagation()
-                this.props.row.collapseAndDeselect({ from: 'timeline' })
-              }
+              clickEvent.stopPropagation()
+              // Expand and select the entire component area when it is clicked, but note that we
+              // only collapse if the user clicked directly on the chevron.
+              Element.deselectAll({component: this.props.row.component}, {from: 'timeline'})
+              this.props.row.expandAndSelect({from: 'timeline'})
             }}
-          >
-            <span
-              className='component-heading-chevron-box'
-              style={{
-                display: 'inline-block',
-                transform: this.props.row.isRootRow() ? 'translate(0, -1px)' : 'translate(30px, -1px)'
-              }}
+            style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+              width: (this.props.row.isExpanded()) ? propertiesPixelWidth - 140 : propertiesPixelWidth,
+              height: 'inherit',
+              cursor: 'pointer',
+              zIndex: 9999999999999,
+              backgroundColor: this.props.isExpanded ? 'transparent' : Palette.LIGHT_GRAY,
+              display: 'flex',
+              flexDirection: 'column'
+            } : {
+              display: 'table-cell',
+              width: (this.props.row.isExpanded()) ? this.props.timeline.getPropertiesPixelWidth() - 140 : '100%',
+              height: 'inherit',
+              position: 'absolute',
+              cursor: 'pointer',
+              zIndex: 3,
+              backgroundColor: this.props.isExpanded ? 'transparent' : Palette.LIGHT_GRAY
+            })}>
+            <div
+              className='component-heading-row-inner-r1'
+              style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+                height: this.props.rowHeight,
+                display: 'flex',
+                alignItems: this.props.isExpanded ? 'flex-start' : 'center'
+              } : {
+                height: this.props.rowHeight,
+                marginTop: -6,
+                maxWidth: (this.props.row.isRootRow()) ? '120px' : undefined
+              })}
               onClick={(clickEvent) => {
                 // Collapse/expand the entire component area when it is clicked
-                if (this.props.isExpanded) {
+                if (this.props.isExpanded && this.props.isSelected) {
                   clickEvent.stopPropagation()
                   this.props.row.collapseAndDeselect({ from: 'timeline' })
                 }
               }}
             >
-              {this.props.isExpanded
-                  ? <span className='utf-icon'
-                    style={{
-                      top: 1,
-                      pointerEvents: 'none',
-                      left: -1
-                    }}>
-                    <DownCarrotSVG color={Palette.ROCK} />
-                  </span>
-                  : <span className='utf-icon'
-                    style={{
-                      top: 3,
-                      pointerEvents: 'none'
-                    }}>
-                    <RightCarrotSVG />
-                  </span>
-                }
-            </span>
-            <ComponentHeadingRowHeading
-              row={this.props.row}
-              isExpanded={this.props.isExpanded}
-              isSelected={this.props.isSelected}
-              isHovered={this.props.isHovered}
-              onEventHandlerTriggered={this.props.onEventHandlerTriggered}
-              onExpand={() => {
-                Element.deselectAll({component: this.props.row.component}, {from: 'timeline'})
-                this.props.row.expandAndSelect({from: 'timeline'})
-              }}
-            />
-          </div>
-          <div
-            className='component-heading-row-inner-r2'
-            style={
-              this.props.isExpanded
-                ? {
-                  marginLeft: '37px',
-                  marginTop: '4px',
-                  position: 'relative',
-                  height: '20px',
-                  maxWidth: '100px'
-                }
-                : {float: 'right', marginTop: '-15px', position: 'relative'}
-            }
-          >
+              <span
+                className='component-heading-chevron-box'
+                style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {} : {
+                  display: 'inline-block',
+                  transform: this.props.row.isRootRow() ? 'translate(0, -1px)' : 'translate(30px, -1px)'
+                })}
+                onClick={(clickEvent) => {
+                  // Collapse/expand the entire component area when it is clicked
+                  if (this.props.isExpanded) {
+                    clickEvent.stopPropagation()
+                    this.props.row.collapseAndDeselect({ from: 'timeline' })
+                  }
+                }}
+              >
+                {this.props.isExpanded
+                    ? <span className={experimentIsEnabled(Experiment.NativeTimelineScroll) ? '' : 'utf-icon'}
+                      style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+                        pointerEvents: 'none',
+                      } : {
+                        top: 1,
+                        pointerEvents: 'none',
+                        left: -1
+                      })}>
+                      <DownCarrotSVG color={Palette.ROCK} />
+                    </span>
+                    : <span className={experimentIsEnabled(Experiment.NativeTimelineScroll) ? '' : 'utf-icon'}
+                      style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+                        pointerEvents: 'none'
+                      } : {
+                        top: 3,
+                        pointerEvents: 'none'
+                      })}>
+                      <RightCarrotSVG />
+                    </span>
+                  }
+              </span>
+              <ComponentHeadingRowHeading
+                row={this.props.row}
+                isExpanded={this.props.isExpanded}
+                isSelected={this.props.isSelected}
+                isHovered={this.props.isHovered}
+                onEventHandlerTriggered={this.props.onEventHandlerTriggered}
+                onExpand={() => {
+                  Element.deselectAll({component: this.props.row.component}, {from: 'timeline'})
+                  this.props.row.expandAndSelect({from: 'timeline'})
+                }}
+              />
+            </div>
             <div
-              className='event-handler-triggerer-button'
-              style={{
-                width: 10,
-                position: 'absolute',
-                left: 0,
-                top: 0
-              }}>
-              {(this.props.isExpanded || this.props.hasAttachedActions)
-                ? <EventHandlerTriggerer
-                  element={this.props.row.element}
-                  row={this.props.row}
-                  boltColor={boltColor}
-                  onEventHandlerTriggered={this.props.onEventHandlerTriggered}
+              className='component-heading-row-inner-r2'
+              style={(
+                experimentIsEnabled(Experiment.NativeTimelineScroll) ?
+                  {
+                    display: this.props.isExpanded ? 'flex': 'none',
+                    alignItems: 'center'
+                  } : (
+                    this.props.isExpanded
+                      ? {
+                        marginLeft: '37px',
+                        marginTop: '4px',
+                        position: 'relative',
+                        height: '20px',
+                        maxWidth: '100px'
+                      }
+                      : {float: 'right', marginTop: '-15px', position: 'relative'}
+                  )
+              )}
+            >
+              <div
+                className='event-handler-triggerer-button'
+                style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {} : {
+                  width: 10,
+                  position: 'absolute',
+                  left: 0,
+                  top: 0
+                })}>
+                {(this.props.isExpanded || this.props.hasAttachedActions)
+                  ? <EventHandlerTriggerer
+                    element={this.props.row.element}
+                    row={this.props.row}
+                    boltColor={boltColor}
+                    onEventHandlerTriggered={this.props.onEventHandlerTriggered}
+                    />
+                  : ''}
+              </div>
+
+              <div
+                className='property-manager-button'
+                style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {} : {
+                  width: 10,
+                  position: 'absolute',
+                  left: 16,
+                  top: -1
+                })}>
+                {(this.props.isExpanded)
+                  ? <PropertyManager
+                    element={this.props.row.element}
                   />
-                : ''}
-            </div>
+                  : ''}
+              </div>
 
-            <div
-              className='property-manager-button'
-              style={{
-                width: 10,
-                position: 'absolute',
-                left: 16,
-                top: -1
-              }}>
-              {(this.props.isExpanded)
-                ? <PropertyManager
-                  element={this.props.row.element}
-                />
-                : ''}
             </div>
-
           </div>
         </div>
+        {!this.props.isExpanded &&
         <div
           onClick={(clickEvent) => {
             // We need this click listener here or we won't capture events that occur on
@@ -239,19 +288,22 @@ export default class ComponentHeadingRow extends React.Component {
             this.props.row.expandAndSelect({from: 'timeline'})
           }}
           className='component-collapsed-segments-box'
-          style={{
+          style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+            height: 'inherit'
+          } : {
             display: 'table-cell',
             width: this.props.timeline.getTimelinePixelWidth(),
             height: 'inherit'
-          }}>
-          {(!this.props.isExpanded)
-            ? <CollapsedPropertyTimelineSegments
+          })}>
+          {(!this.props.isExpanded) ?
+            <CollapsedPropertyTimelineSegments
               component={this.props.component}
               timeline={this.props.timeline}
               rowHeight={this.props.rowHeight}
               row={this.props.row} />
-            : ''}
+          : ''}
         </div>
+      }
       </div>
     )
   }

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -108,7 +108,7 @@ export default class ComponentHeadingRow extends React.Component {
           paddingLeft: this.props.isExpanded ? 0 : (this.props.row.isRootRow() ? 7 : 20),
           width: propertiesPixelWidth,
           backgroundColor: this.props.isExpanded ? 'transparent' : Palette.LIGHT_GRAY,
-          zIndex: zIndex.headingRow.base,
+          zIndex: zIndex.headingRow.base
         } : {})}>
           {!this.props.row.isRootRow() &&
             <div

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import lodash from 'lodash'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 import DownCarrotSVG from 'haiku-ui-common/lib/react/icons/DownCarrotSVG'
 import RightCarrotSVG from 'haiku-ui-common/lib/react/icons/RightCarrotSVG'
 import DragGrip from 'haiku-ui-common/lib/react/icons/DragGrip'
@@ -104,7 +104,7 @@ export default class ComponentHeadingRow extends React.Component {
           position: 'sticky',
           top: 0,
           left: 0,
-          paddingLeft: this.props.isExpanded ? 0: (this.props.row.isRootRow() ? 7 : 20),
+          paddingLeft: this.props.isExpanded ? 0 : (this.props.row.isRootRow() ? 7 : 20),
           width: propertiesPixelWidth,
           backgroundColor: this.props.isExpanded ? 'transparent' : Palette.LIGHT_GRAY,
           zIndex: 1006
@@ -112,7 +112,7 @@ export default class ComponentHeadingRow extends React.Component {
           {!this.props.row.isRootRow() &&
             <div
               style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
-                marginTop: 1,
+                marginTop: 1
               } : {
                 position: 'absolute',
                 top: 3,
@@ -189,7 +189,7 @@ export default class ComponentHeadingRow extends React.Component {
                 {this.props.isExpanded
                     ? <span className={experimentIsEnabled(Experiment.NativeTimelineScroll) ? '' : 'utf-icon'}
                       style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
-                        pointerEvents: 'none',
+                        pointerEvents: 'none'
                       } : {
                         top: 1,
                         pointerEvents: 'none',
@@ -223,9 +223,9 @@ export default class ComponentHeadingRow extends React.Component {
             <div
               className='component-heading-row-inner-r2'
               style={(
-                experimentIsEnabled(Experiment.NativeTimelineScroll) ?
-                  {
-                    display: this.props.isExpanded ? 'flex': 'none',
+                experimentIsEnabled(Experiment.NativeTimelineScroll)
+                  ? {
+                    display: this.props.isExpanded ? 'flex' : 'none',
                     alignItems: 'center'
                   } : (
                     this.props.isExpanded
@@ -295,8 +295,8 @@ export default class ComponentHeadingRow extends React.Component {
             width: this.props.timeline.getTimelinePixelWidth(),
             height: 'inherit'
           })}>
-          {(!this.props.isExpanded) ?
-            <CollapsedPropertyTimelineSegments
+          {(!this.props.isExpanded)
+            ? <CollapsedPropertyTimelineSegments
               component={this.props.component}
               timeline={this.props.timeline}
               rowHeight={this.props.rowHeight}

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -78,7 +78,8 @@ export default class ComponentHeadingRow extends React.Component {
           top: this.props.isExpanded ? 0 : undefined,
           left: this.props.isExpanded ? 20 : undefined,
           backgroundColor: this.props.isExpanded ? 'transparent' : Palette.LIGHT_GRAY,
-          opacity: this.props.isHidden ? 0.75 : 1.0
+          opacity: this.props.isHidden ? 0.75 : 1.0,
+          zIndex: this.props.isExpanded ? zIndex.headingRowExpanded.base : undefined
         } : {
           display: 'table',
           tableLayout: 'fixed',
@@ -141,7 +142,7 @@ export default class ComponentHeadingRow extends React.Component {
               height: 'inherit',
               cursor: 'pointer',
               // zIndex: 9999999999999,
-              backgroundColor: this.props.isExpanded ? 'transparent' : Palette.LIGHT_GRAY,
+              backgroundColor: 'transparent',
               display: 'flex',
               flexDirection: 'column'
             } : {

--- a/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Palette from 'haiku-ui-common/lib/Palette'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 import {ComponentIconSVG} from 'haiku-ui-common/lib/react/OtherIcons'
 import Color from 'color'
 
@@ -135,7 +135,7 @@ export default class ComponentHeadingRowHeading extends React.Component {
             className='component-heading-row-heading-child-icon-box'
             style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
               display: 'inline-block',
-              height: 20,
+              height: 20
             } : {
               position: 'absolute',
               display: 'inline-block',

--- a/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Palette from 'haiku-ui-common/lib/Palette'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
 import {ComponentIconSVG} from 'haiku-ui-common/lib/react/OtherIcons'
 import Color from 'color'
 
@@ -88,16 +89,26 @@ export default class ComponentHeadingRowHeading extends React.Component {
         ? (<div
           className='component-heading-row-heading-root-box'
           title={this.state.rowTitle}
-          style={{
+          style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+            height: 27,
+            display: 'inline-block'
+          } : {
             height: 27,
             display: 'inline-block',
-            transform: 'translateY(1px)'}}>
+            transform: 'translateY(1px)'
+          })}>
           <span
             className='component-heading-row-heading-root-icon-box'
-            style={{
+            style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+              marginLeft: 7,
+              marginRight: 7,
+              display: 'inline-block',
+              transform: 'translateY(4px)'
+            } : {
               marginRight: 4,
               display: 'inline-block',
-              transform: 'translateY(4px)'}}>
+              transform: 'translateY(4px)'
+            })}>
             <ComponentIconSVG />
           </span>
           {trunc(this.state.rowTitle, 12)}
@@ -105,7 +116,13 @@ export default class ComponentHeadingRowHeading extends React.Component {
         : (<span
           className='component-heading-row-heading-child-box'
           title={this.state.rowTitle}
-          style={{
+          style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+            color,
+            display: 'flex',
+            alignItems: 'center',
+            height: 25,
+            marginLeft: 5
+          } : {
             color,
             position: 'relative',
             zIndex: 1005,
@@ -113,21 +130,32 @@ export default class ComponentHeadingRowHeading extends React.Component {
             display: 'inline-block',
             width: 100,
             height: 20
-          }}>
+          })}>
           <span
             className='component-heading-row-heading-child-icon-box'
-            style={{
+            style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+              display: 'inline-block',
+              height: 20,
+            } : {
               position: 'absolute',
               display: 'inline-block',
               height: 20,
               left: 2,
               top: 8
-            }}>
+            })}>
             {(this.props.row.element.isComponent()) &&
             <ComponentIconSVG />}
           </span>
           <span
-            style={{
+            style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+              display: 'inline-block',
+              height: 20,
+              marginLeft: (this.props.row.element.isComponent())
+                  ? 5
+                  : 0,
+              overflowX: 'hidden',
+              width: 160
+            } : {
               position: 'absolute',
               display: 'inline-block',
               height: 20,
@@ -137,7 +165,7 @@ export default class ComponentHeadingRowHeading extends React.Component {
               top: 7,
               overflowX: 'hidden',
               width: 160
-            }}
+            })}
             onClick={(clickEvent) => {
               if (!this.onExpandTimeout) {
                 this.onExpandTimeout = setTimeout(this.props.onExpand, DOUBLE_CLICK_WAIT_DELAY_MS)

--- a/packages/haiku-timeline/src/components/ConstantBody.js
+++ b/packages/haiku-timeline/src/components/ConstantBody.js
@@ -58,8 +58,12 @@ export default class ConstantBody extends React.Component {
     const frameInfo = this.props.timeline.getFrameInfo()
 
     const uniqueKey = this.props.keyframe.getUniqueKey()
-    const pxOffsetLeft = this.props.keyframe.getPixelOffsetLeft(frameInfo.friA, frameInfo.pxpf, frameInfo.mspf)
-    const pxOffsetRight = this.props.keyframe.getPixelOffsetRight(frameInfo.friA, frameInfo.pxpf, frameInfo.mspf)
+    const pxOffsetLeft = experimentIsEnabled(Experiment.NativeTimelineScroll)
+      ? this.props.keyframe.getPixelOffsetLeft(0, frameInfo.pxpf, frameInfo.mspf)
+      : this.props.keyframe.getPixelOffsetLeft(frameInfo.friA, frameInfo.pxpf, frameInfo.mspf)
+    const pxOffsetRight = experimentIsEnabled(Experiment.NativeTimelineScroll)
+      ? this.props.keyframe.getPixelOffsetRight(0, frameInfo.pxpf, frameInfo.mspf)
+      : this.props.keyframe.getPixelOffsetRight(frameInfo.friA, frameInfo.pxpf, frameInfo.mspf)
 
     return (
       <span

--- a/packages/haiku-timeline/src/components/ConstantBody.js
+++ b/packages/haiku-timeline/src/components/ConstantBody.js
@@ -3,6 +3,7 @@ import Color from 'color'
 import Palette from 'haiku-ui-common/lib/Palette'
 import Globals from 'haiku-ui-common/lib/Globals'
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 
 export default class ConstantBody extends React.Component {
   constructor (props) {
@@ -64,6 +65,9 @@ export default class ConstantBody extends React.Component {
       <span
         ref={(domElement) => {
           this[uniqueKey] = domElement
+          if (experimentIsEnabled(Experiment.TimelineMarqueeSelection) && domElement) {
+            this.props.keyframe.storeViewPosition(domElement.getBoundingClientRect())
+          }
         }}
         id={`constant-body-${uniqueKey}`}
         className='constant-body'

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -1011,14 +1011,14 @@ export default class ExpressionInput extends React.Component {
       top: 0,
       visibility: 'hidden',
       width: this.props.reactParent.state.inputCellWidth,
-      zIndex: 5000
+      zIndex: 9999999999999
     })
 
     if (this.props.component.getFocusedRow()) {
       style.visibility = 'visible'
       let rect = this.getRootRect()
       style.left = rect.left
-      style.top = rect.top
+      style.top = rect.top + 10
     }
 
     return style

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -16,6 +16,7 @@ import ensureEq from 'haiku-ui-common/lib/helpers/ensureEq'
 import doesValueImplyExpression from 'haiku-ui-common/lib/helpers/doesValueImplyExpression'
 import humanizePropertyName from 'haiku-ui-common/lib/helpers/humanizePropertyName'
 import AutoCompleter from './AutoCompleter'
+import zIndex from './styles/zIndex'
 
 const HaikuMode = require('./modes/haiku')
 
@@ -1011,7 +1012,7 @@ export default class ExpressionInput extends React.Component {
       top: 0,
       visibility: 'hidden',
       width: this.props.reactParent.state.inputCellWidth,
-      zIndex: 9999999999999
+      zIndex: zIndex.expressionInput.base
     })
 
     if (this.props.component.getFocusedRow()) {

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -15,6 +15,7 @@ import ensureRet from 'haiku-ui-common/lib/helpers/ensureRet'
 import ensureEq from 'haiku-ui-common/lib/helpers/ensureEq'
 import doesValueImplyExpression from 'haiku-ui-common/lib/helpers/doesValueImplyExpression'
 import humanizePropertyName from 'haiku-ui-common/lib/helpers/humanizePropertyName'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 import AutoCompleter from './AutoCompleter'
 import zIndex from './styles/zIndex'
 
@@ -1054,7 +1055,7 @@ export default class ExpressionInput extends React.Component {
       position: 'absolute',
       textAlign: 'center',
       textTransform: 'uppercase',
-      width: 83
+      width: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 82 : 83
     }
     lodash.assign(style, this.props.component.getFocusedRow() && {
       fontSize,

--- a/packages/haiku-timeline/src/components/FrameGrid.js
+++ b/packages/haiku-timeline/src/components/FrameGrid.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Color from 'color'
 import Palette from 'haiku-ui-common/lib/Palette'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 import FrameAction from './FrameAction'
 
 export default class FrameGrid extends React.Component {

--- a/packages/haiku-timeline/src/components/FrameGrid.js
+++ b/packages/haiku-timeline/src/components/FrameGrid.js
@@ -93,7 +93,7 @@ export default class FrameGrid extends React.Component {
                 id={`frame-${frameNumber}`}
                 key={`frame-${frameNumber}`}
                 style={{
-                  height: experimentIsEnabled(Experiment.NativeTimelineScroll) ? '100vh' : 9999,
+                  height: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 'calc(100vh - 80px)' : 9999,
                   borderLeft:
                     hoveredFrame === frameNumber
                       ? borderLeftHighlighted

--- a/packages/haiku-timeline/src/components/FrameGrid.js
+++ b/packages/haiku-timeline/src/components/FrameGrid.js
@@ -74,13 +74,17 @@ export default class FrameGrid extends React.Component {
     const borderLeftNormal = '1px solid ' + Color(Palette.COAL).fade(0.65)
     const borderLeftHighlighted = '1px solid ' + Color(Palette.ROCK).fade(0.8)
     const hoveredFrame = this.props.timeline.getHoveredFrame()
+    const propertiesWidth = this.props.timeline.getPropertiesPixelWidth()
 
     return (
       <div
         id='frame-grid'
-        style={{
+        style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+          position: 'sticky',
+          top: 0
+        } : {
           overflow: 'hidden'
-        }}
+        })}
       >
         {this.props.timeline.mapVisibleFrames(
           (frameNumber, pixelOffsetLeft, pixelsPerFrame, frameModulus) => {
@@ -89,13 +93,13 @@ export default class FrameGrid extends React.Component {
                 id={`frame-${frameNumber}`}
                 key={`frame-${frameNumber}`}
                 style={{
-                  height: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 'calc(100vh - 95px)' : 9999,
+                  height: experimentIsEnabled(Experiment.NativeTimelineScroll) ? '100vh' : 9999,
                   borderLeft:
                     hoveredFrame === frameNumber
                       ? borderLeftHighlighted
                       : borderLeftNormal,
                   position: 'absolute',
-                  left: pixelOffsetLeft,
+                  left: pixelOffsetLeft + propertiesWidth,
                   top: 34
                 }}
               >

--- a/packages/haiku-timeline/src/components/FrameGrid.js
+++ b/packages/haiku-timeline/src/components/FrameGrid.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Color from 'color'
 import Palette from 'haiku-ui-common/lib/Palette'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
 import FrameAction from './FrameAction'
 
 export default class FrameGrid extends React.Component {
@@ -41,8 +42,7 @@ export default class FrameGrid extends React.Component {
 
   handleUpdate (what) {
     if (!this.mounted) return null
-
-    if (what === 'timeline-frame-range' || what === 'timeline-frame-hovered') {
+    if (what === 'timeline-frame-hovered') {
       this.forceUpdate()
     }
 
@@ -89,7 +89,7 @@ export default class FrameGrid extends React.Component {
                 id={`frame-${frameNumber}`}
                 key={`frame-${frameNumber}`}
                 style={{
-                  height: 9999,
+                  height: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 'calc(100vh - 95px)' : 9999,
                   borderLeft:
                     hoveredFrame === frameNumber
                       ? borderLeftHighlighted

--- a/packages/haiku-timeline/src/components/Gauge.js
+++ b/packages/haiku-timeline/src/components/Gauge.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
 import formatSeconds from 'haiku-ui-common/lib/helpers/formatSeconds'
 import Palette from 'haiku-ui-common/lib/Palette'
 import Timeline from 'haiku-serialization/src/bll/Timeline'
@@ -29,12 +30,18 @@ export default class Gauge extends React.Component {
 
   handleUpdate (what) {
     if (!this.mounted) return false
-    if (
-      what === 'timeline-frame-range' ||
-      what === 'timeline-frame-hovered' ||
-      what === 'time-display-mode-change'
-    ) {
-      this.forceUpdate()
+    if (experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+      if (what === 'time-display-mode-change') {
+        this.forceUpdate()
+      }
+    } else {
+      if (
+        what === 'timeline-frame-range' ||
+        what === 'timeline-frame-hovered' ||
+        what === 'time-display-mode-change'
+      ) {
+        this.forceUpdate()
+      }
     }
   }
 

--- a/packages/haiku-timeline/src/components/Gauge.js
+++ b/packages/haiku-timeline/src/components/Gauge.js
@@ -31,7 +31,11 @@ export default class Gauge extends React.Component {
   handleUpdate (what) {
     if (!this.mounted) return false
     if (experimentIsEnabled(Experiment.NativeTimelineScroll)) {
-      if (what === 'time-display-mode-change') {
+      if (
+        what === 'timeline-frame-hovered' ||
+        what === 'timeline-frame-range' ||
+        what === 'time-display-mode-change'
+      ) {
         this.forceUpdate()
       }
     } else {

--- a/packages/haiku-timeline/src/components/Gauge.js
+++ b/packages/haiku-timeline/src/components/Gauge.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 import formatSeconds from 'haiku-ui-common/lib/helpers/formatSeconds'
 import Palette from 'haiku-ui-common/lib/Palette'
 import Timeline from 'haiku-serialization/src/bll/Timeline'

--- a/packages/haiku-timeline/src/components/GaugeTimeReadout.js
+++ b/packages/haiku-timeline/src/components/GaugeTimeReadout.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import lodash from 'lodash'
 import Palette from 'haiku-ui-common/lib/Palette'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
 import formatSeconds from 'haiku-ui-common/lib/helpers/formatSeconds'
 import Timeline from 'haiku-serialization/src/bll/Timeline'
 
@@ -135,7 +136,7 @@ class FpsReadout extends React.Component {
     if (!this.mounted) return null
     if (what === 'timeline-frame') {
       this.throttledForceUpdate()
-    } else if (what === 'timeline-frame-range') {
+    } else if (what === 'timeline-frame-range' && !experimentIsEnabled(Experiment.NativeTimelineScroll)) {
       this.forceUpdate()
     }
   }
@@ -173,7 +174,7 @@ class TimeReadout extends React.Component {
     if (!this.mounted) return null
     if (what === 'timeline-frame') {
       this.throttledForceUpdate()
-    } else if (what === 'timeline-frame-range') {
+    } else if (what === 'timeline-frame-range' && !experimentIsEnabled(Experiment.NativeTimelineScroll)) {
       this.forceUpdate()
     }
   }

--- a/packages/haiku-timeline/src/components/GaugeTimeReadout.js
+++ b/packages/haiku-timeline/src/components/GaugeTimeReadout.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import lodash from 'lodash'
 import Palette from 'haiku-ui-common/lib/Palette'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 import formatSeconds from 'haiku-ui-common/lib/helpers/formatSeconds'
 import Timeline from 'haiku-serialization/src/bll/Timeline'
 

--- a/packages/haiku-timeline/src/components/GaugeTimeReadout.js
+++ b/packages/haiku-timeline/src/components/GaugeTimeReadout.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import lodash from 'lodash'
 import Palette from 'haiku-ui-common/lib/Palette'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 import formatSeconds from 'haiku-ui-common/lib/helpers/formatSeconds'
 import Timeline from 'haiku-serialization/src/bll/Timeline'
 
@@ -136,7 +135,7 @@ class FpsReadout extends React.Component {
     if (!this.mounted) return null
     if (what === 'timeline-frame') {
       this.throttledForceUpdate()
-    } else if (what === 'timeline-frame-range' && !experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+    } else if (what === 'timeline-frame-range') {
       this.forceUpdate()
     }
   }
@@ -174,7 +173,7 @@ class TimeReadout extends React.Component {
     if (!this.mounted) return null
     if (what === 'timeline-frame') {
       this.throttledForceUpdate()
-    } else if (what === 'timeline-frame-range' && !experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+    } else if (what === 'timeline-frame-range') {
       this.forceUpdate()
     }
   }

--- a/packages/haiku-timeline/src/components/HorzScrollShadow.js
+++ b/packages/haiku-timeline/src/components/HorzScrollShadow.js
@@ -1,6 +1,7 @@
 import React from 'react'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 
-export default class HorzScrollShadow extends React.Component {
+export default class HorzScrollShadow extends React.PureComponent {
   constructor (props) {
     super(props)
     this.handleUpdate = this.handleUpdate.bind(this)
@@ -26,27 +27,43 @@ export default class HorzScrollShadow extends React.Component {
 
   handleUpdate (what) {
     if (!this.mounted) return null
-    if (what === 'timeline-frame-range') this.forceUpdate()
+    if (what === 'timeline-frame-range' && !experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+      this.forceUpdate()
+    }
   }
 
   render () {
-    const frameInfo = this.props.timeline.getFrameInfo()
+    if (experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+      return (
+        <span className='no-select' style={{
+          position: 'fixed',
+          height: '100%',
+          width: 3,
+          left: 297,
+          zIndex: 99999999999,
+          top: 0,
+          boxShadow: '3px 0 6px 0 rgba(0,0,0,.22)'
+        }} />
+      )
+    } else {
+      const frameInfo = this.props.timeline.getFrameInfo()
 
-    if (frameInfo.scA < 1) {
-      return <span />
+      if (frameInfo.scA < 1) {
+        return <span />
+      }
+
+      return (
+        <span className='no-select' style={{
+          position: 'absolute',
+          height: '100%',
+          width: 3,
+          left: 297,
+          zIndex: 2003,
+          top: 0,
+          boxShadow: '3px 0 6px 0 rgba(0,0,0,.22)'
+        }} />
+      )
     }
-
-    return (
-      <span className='no-select' style={{
-        position: 'absolute',
-        height: '100%',
-        width: 3,
-        left: 297,
-        zIndex: 2003,
-        top: 0,
-        boxShadow: '3px 0 6px 0 rgba(0,0,0,.22)'
-      }} />
-    )
   }
 }
 

--- a/packages/haiku-timeline/src/components/HorzScrollShadow.js
+++ b/packages/haiku-timeline/src/components/HorzScrollShadow.js
@@ -28,7 +28,7 @@ export default class HorzScrollShadow extends React.PureComponent {
 
   handleUpdate (what) {
     if (!this.mounted) return null
-    if (what === 'timeline-frame-range' && !experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+    if (what === 'timeline-frame-range') {
       this.forceUpdate()
     }
   }

--- a/packages/haiku-timeline/src/components/HorzScrollShadow.js
+++ b/packages/haiku-timeline/src/components/HorzScrollShadow.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
+import zIndex from './styles/zIndex'
 
 export default class HorzScrollShadow extends React.PureComponent {
   constructor (props) {
@@ -40,7 +41,7 @@ export default class HorzScrollShadow extends React.PureComponent {
           height: 'calc(100% - 45px)',
           width: 3,
           left: 297,
-          zIndex: 99999999999,
+          zIndex: zIndex.scrollShadow.base,
           top: 0,
           boxShadow: '3px 0 6px 0 rgba(0,0,0,.22)'
         }} />

--- a/packages/haiku-timeline/src/components/HorzScrollShadow.js
+++ b/packages/haiku-timeline/src/components/HorzScrollShadow.js
@@ -37,7 +37,7 @@ export default class HorzScrollShadow extends React.PureComponent {
       return (
         <span className='no-select' style={{
           position: 'fixed',
-          height: '100%',
+          height: 'calc(100% - 45px)',
           width: 3,
           left: 297,
           zIndex: 99999999999,
@@ -55,7 +55,7 @@ export default class HorzScrollShadow extends React.PureComponent {
       return (
         <span className='no-select' style={{
           position: 'absolute',
-          height: '100%',
+          height: 'calc(100% - 45px)',
           width: 3,
           left: 297,
           zIndex: 2003,

--- a/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
+++ b/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
@@ -3,6 +3,7 @@ import lodash from 'lodash'
 import TimelineDraggable from './TimelineDraggable'
 import Globals from 'haiku-ui-common/lib/Globals'
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 
 const THROTTLE_TIME = 17 // ms
 
@@ -57,7 +58,9 @@ export default class InvisibleKeyframeDragger extends React.Component {
 
   render () {
     const frameInfo = this.props.timeline.getFrameInfo()
-    const pxOffsetLeft = this.props.keyframe.getPixelOffsetLeft(frameInfo.friA, frameInfo.pxpf, frameInfo.mspf)
+    const pxOffsetLeft = experimentIsEnabled(Experiment.NativeTimelineScroll)
+      ? this.props.keyframe.getPixelOffsetLeft(0, frameInfo.pxpf, frameInfo.mspf)
+      : this.props.keyframe.getPixelOffsetLeft(frameInfo.friA, frameInfo.pxpf, frameInfo.mspf)
 
     return (
       <TimelineDraggable
@@ -98,7 +101,7 @@ export default class InvisibleKeyframeDragger extends React.Component {
             // borderRight: '1px solid white',
             // opacity: '0.2',
             top: 1,
-            left: this.props.offset + this.props.keyframe.getPixelOffsetLeft(frameInfo.friA, frameInfo.pxpf, frameInfo.mspf),
+            left: this.props.offset + pxOffsetLeft,
             width: 10,
             height: 24,
             zIndex: 1003,

--- a/packages/haiku-timeline/src/components/Marquee.js
+++ b/packages/haiku-timeline/src/components/Marquee.js
@@ -22,7 +22,7 @@ class Marquee {
 
   _startUp (event) {
     // return if is right click
-    if (event.which === 3) {
+    if (event.which === 3 || this.onStart(event) === false) {
       return
     }
 
@@ -33,7 +33,6 @@ class Marquee {
     this.area.removeEventListener('mousedown', this._startUp)
     this.area.addEventListener('mousemove', this._handleMove)
     document.addEventListener('mouseup', this.reset)
-    this.onStart(event)
   }
 
   _getStartingPositions (event) {

--- a/packages/haiku-timeline/src/components/Marquee.js
+++ b/packages/haiku-timeline/src/components/Marquee.js
@@ -1,3 +1,6 @@
+import Palette from 'haiku-ui-common/lib/Palette'
+import Color from 'color'
+
 class Marquee {
   constructor ({area, callback}) {
     this.initialCursorPos = {x: 0, y: 0}
@@ -52,8 +55,8 @@ class Marquee {
   _createSelector () {
     const selector = document.createElement('div')
     selector.style.position = 'absolute'
-    selector.style.background = 'rgba(0, 0, 255, 0.1)'
-    selector.style.border = '1px solid rgba(0, 0, 255, 0.45)'
+    selector.style.background = Color(Palette.LIGHTEST_PINK).alpha(0.1)
+    selector.style.border = `1px solid ${Palette.LIGHT_PINK}`
     selector.style.display = 'none'
     selector.style.pointerEvents = 'none'
     this.area.appendChild(selector)

--- a/packages/haiku-timeline/src/components/Marquee.js
+++ b/packages/haiku-timeline/src/components/Marquee.js
@@ -1,5 +1,6 @@
 import Palette from 'haiku-ui-common/lib/Palette'
 import Color from 'color'
+import zIndex from './styles/zIndex'
 
 class Marquee {
   constructor ({area, onStart, onFinish}) {
@@ -60,6 +61,7 @@ class Marquee {
     selector.style.border = `1px solid ${Palette.LIGHT_PINK}`
     selector.style.display = 'none'
     selector.style.pointerEvents = 'none'
+    selector.style.zIndex = zIndex.marquee.base
     this.area.appendChild(selector)
     return selector
   }
@@ -147,6 +149,8 @@ class Marquee {
     this.area.removeEventListener('mousemove', this._handleMove)
     this.area.addEventListener('mousedown', this._startUp)
 
+    console.log('this.getPosition', this.getPosition())
+    console.log('getBoundingClientRect', this.selector.getBoundingClientRect())
     this.onFinish(event, this.selector.getBoundingClientRect())
 
     this.selector.style.width = '0'

--- a/packages/haiku-timeline/src/components/Marquee.js
+++ b/packages/haiku-timeline/src/components/Marquee.js
@@ -148,10 +148,11 @@ class Marquee {
     document.removeEventListener('mouseup', this.reset)
     this.area.removeEventListener('mousemove', this._handleMove)
     this.area.addEventListener('mousedown', this._startUp)
+    const selection = this.selector.getBoundingClientRect()
 
-    console.log('this.getPosition', this.getPosition())
-    console.log('getBoundingClientRect', this.selector.getBoundingClientRect())
-    this.onFinish(event, this.selector.getBoundingClientRect())
+    if (selection.x > 20 && selection.y && 20) {
+      this.onFinish(event, selection)
+    }
 
     this.selector.style.width = '0'
     this.selector.style.height = '0'

--- a/packages/haiku-timeline/src/components/Marquee.js
+++ b/packages/haiku-timeline/src/components/Marquee.js
@@ -1,23 +1,22 @@
 class Marquee {
-  constructor({area, callback}) {
+  constructor ({area, callback}) {
     this.initialCursorPos = {x: 0, y: 0}
     this.autoScrollSpeed = 1
-    this.callback = callback || function() {}
+    this.callback = callback || function () {}
     this.area = area
-    this.initialScroll
+    this.initialScroll = null
     this._startUp = this._startUp.bind(this)
     this._handleMove = this._handleMove.bind(this)
     this.reset = this.reset.bind(this)
 
     this.selector = this._createSelector()
-    this.start()
   }
 
-  start() {
+  start () {
     this.area.addEventListener('mousedown', this._startUp)
   }
 
-  _startUp(event) {
+  _startUp (event) {
     // return if is right click
     if (event.which === 3) {
       return
@@ -32,7 +31,7 @@ class Marquee {
     document.addEventListener('mouseup', this.reset)
   }
 
-  _getStartingPositions(event) {
+  _getStartingPositions (event) {
     this.initialCursorPos = this._getCursorPos(event, this.area)
     this.initialScroll = this.getScroll(this.area)
 
@@ -44,13 +43,13 @@ class Marquee {
     this.updatePos(this.selector, selectorPos)
   }
 
-  _handleMove(event) {
+  _handleMove (event) {
     const selectorPos = this.getPosition(event)
     this.selector.style.display = 'block'
     this.updatePos(this.selector, selectorPos)
   }
 
-  _createSelector() {
+  _createSelector () {
     const selector = document.createElement('div')
     selector.style.position = 'absolute'
     selector.style.background = 'rgba(0, 0, 255, 0.1)'
@@ -61,7 +60,7 @@ class Marquee {
     return selector
   }
 
-  getPosition(event) {
+  getPosition (event) {
     const cursorPosNew = this._getCursorPos(event, this.area)
     const scrollNew = this.getScroll(this.area)
 
@@ -139,7 +138,7 @@ class Marquee {
     return selectorPos
   }
 
-  reset(event) {
+  reset (event) {
     document.removeEventListener('mouseup', this.reset)
     this.area.removeEventListener('mousemove', this._handleMove)
     this.area.addEventListener('mousedown', this._startUp)
@@ -151,7 +150,7 @@ class Marquee {
     this.selector.style.display = 'none'
 
     setTimeout(
-      function() {
+      function () {
         // debounce in order "onClick" to work
         this.mouseInteraction = false
       }.bind(this),
@@ -159,13 +158,13 @@ class Marquee {
     )
   }
 
-  stop() {
+  stop () {
     this.reset()
     this.area.removeEventListener('mousedown', this._startUp)
     document.removeEventListener('mouseup', this.reset)
   }
 
-  getCursorPos(event, _area, ignoreScroll) {
+  getCursorPos (event, _area, ignoreScroll) {
     if (!event) {
       return false
     }
@@ -180,7 +179,7 @@ class Marquee {
     }
   }
 
-  _getCursorPos(event, area) {
+  _getCursorPos (event, area) {
     if (!event) {
       return {x: 0, y: 0}
     }
@@ -194,14 +193,14 @@ class Marquee {
     }
   }
 
-  getScroll(area) {
+  getScroll (area) {
     return {
       y: area.scrollTop,
       x: area.scrollLeft
     }
   }
 
-  updatePos(node, pos) {
+  updatePos (node, pos) {
     node.style.left = pos.x + 'px'
     node.style.top = pos.y + 'px'
     node.style.width = pos.w + 'px'

--- a/packages/haiku-timeline/src/components/Marquee.js
+++ b/packages/haiku-timeline/src/components/Marquee.js
@@ -2,10 +2,11 @@ import Palette from 'haiku-ui-common/lib/Palette'
 import Color from 'color'
 
 class Marquee {
-  constructor ({area, callback}) {
+  constructor ({area, onStart, onFinish}) {
     this.initialCursorPos = {x: 0, y: 0}
     this.autoScrollSpeed = 1
-    this.callback = callback || function () {}
+    this.onStart = onStart || function () {}
+    this.onFinish = onFinish || function () {}
     this.area = area
     this.initialScroll = null
     this._startUp = this._startUp.bind(this)
@@ -32,6 +33,7 @@ class Marquee {
     this.area.removeEventListener('mousedown', this._startUp)
     this.area.addEventListener('mousemove', this._handleMove)
     document.addEventListener('mouseup', this.reset)
+    this.onStart(event)
   }
 
   _getStartingPositions (event) {
@@ -146,7 +148,7 @@ class Marquee {
     this.area.removeEventListener('mousemove', this._handleMove)
     this.area.addEventListener('mousedown', this._startUp)
 
-    this.callback(event, this.selector.getBoundingClientRect())
+    this.onFinish(event, this.selector.getBoundingClientRect())
 
     this.selector.style.width = '0'
     this.selector.style.height = '0'

--- a/packages/haiku-timeline/src/components/Marquee.js
+++ b/packages/haiku-timeline/src/components/Marquee.js
@@ -5,15 +5,13 @@ import zIndex from './styles/zIndex'
 class Marquee {
   constructor ({area, onStart, onFinish}) {
     this.initialCursorPos = {x: 0, y: 0}
-    this.autoScrollSpeed = 1
     this.onStart = onStart || function () {}
     this.onFinish = onFinish || function () {}
     this.area = area
     this.initialScroll = null
     this._startUp = this._startUp.bind(this)
     this._handleMove = this._handleMove.bind(this)
-    this.reset = this.reset.bind(this)
-
+    this._reset = this._reset.bind(this)
     this.selector = this._createSelector()
   }
 
@@ -22,7 +20,6 @@ class Marquee {
   }
 
   _startUp (event) {
-    // return if is right click
     if (event.which === 3 || this.onStart(event) === false) {
       return
     }
@@ -33,25 +30,25 @@ class Marquee {
     this.selector.style.display = 'none'
     this.area.removeEventListener('mousedown', this._startUp)
     this.area.addEventListener('mousemove', this._handleMove)
-    document.addEventListener('mouseup', this.reset)
+    document.addEventListener('mouseup', this._reset)
   }
 
   _getStartingPositions (event) {
     this.initialCursorPos = this._getCursorPos(event, this.area)
-    this.initialScroll = this.getScroll(this.area)
+    this.initialScroll = this._getScroll(this.area)
 
     const selectorPos = {}
     selectorPos.x = this.initialCursorPos.x + this.initialScroll.x
     selectorPos.y = this.initialCursorPos.y + this.initialScroll.y
     selectorPos.w = 0
     selectorPos.h = 0
-    this.updatePos(this.selector, selectorPos)
+    this._updatePos(this.selector, selectorPos)
   }
 
   _handleMove (event) {
     const selectorPos = this.getPosition(event)
     this.selector.style.display = 'block'
-    this.updatePos(this.selector, selectorPos)
+    this._updatePos(this.selector, selectorPos)
   }
 
   _createSelector () {
@@ -68,7 +65,7 @@ class Marquee {
 
   getPosition (event) {
     const cursorPosNew = this._getCursorPos(event, this.area)
-    const scrollNew = this.getScroll(this.area)
+    const scrollNew = this._getScroll(this.area)
 
     // if area or document is scrolled those values have to be included aswell
     const scrollAmount = {
@@ -144,8 +141,8 @@ class Marquee {
     return selectorPos
   }
 
-  reset (event) {
-    document.removeEventListener('mouseup', this.reset)
+  _reset (event) {
+    document.removeEventListener('mouseup', this._reset)
     this.area.removeEventListener('mousemove', this._handleMove)
     this.area.addEventListener('mousedown', this._startUp)
     const selection = this.selector.getBoundingClientRect()
@@ -168,24 +165,9 @@ class Marquee {
   }
 
   stop () {
-    this.reset()
+    this._reset()
     this.area.removeEventListener('mousedown', this._startUp)
-    document.removeEventListener('mouseup', this.reset)
-  }
-
-  getCursorPos (event, _area, ignoreScroll) {
-    if (!event) {
-      return false
-    }
-
-    const area = _area || (_area !== false && this.area)
-    const pos = this._getCursorPos(event, area)
-    const scroll = this.getScroll(area)
-
-    return {
-      x: pos.x + scroll.x,
-      y: pos.y + scroll.y
-    }
+    document.removeEventListener('mouseup', this._reset)
   }
 
   _getCursorPos (event, area) {
@@ -202,14 +184,14 @@ class Marquee {
     }
   }
 
-  getScroll (area) {
+  _getScroll (area) {
     return {
       y: area.scrollTop,
       x: area.scrollLeft
     }
   }
 
-  updatePos (node, pos) {
+  _updatePos (node, pos) {
     node.style.left = pos.x + 'px'
     node.style.top = pos.y + 'px'
     node.style.width = pos.w + 'px'

--- a/packages/haiku-timeline/src/components/PropertyInputField.js
+++ b/packages/haiku-timeline/src/components/PropertyInputField.js
@@ -2,8 +2,9 @@ import React from 'react'
 import lodash from 'lodash'
 import Color from 'color'
 import Palette from 'haiku-ui-common/lib/Palette'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 
-const CELL_WIDTH = 83
+const CELL_WIDTH = experimentIsEnabled(Experiment.NativeTimelineScroll) ? 82 : 83
 
 export default class PropertyInputField extends React.Component {
   constructor (props) {

--- a/packages/haiku-timeline/src/components/PropertyManager.js
+++ b/packages/haiku-timeline/src/components/PropertyManager.js
@@ -2,6 +2,7 @@ import React from 'react'
 import CirclePlusSVG from 'haiku-ui-common/lib/react/icons/CirclePlusSVG'
 import Palette from 'haiku-ui-common/lib/Palette'
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
 
 export default class PropertyManager extends React.Component {
   constructor (props) {
@@ -26,21 +27,23 @@ export default class PropertyManager extends React.Component {
     return (
       <div
         className='property-manager'
-        style={{
+        style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {} : {
           width: 10,
           position: 'absolute',
           left: 0,
           top: 0
-        }}>
+        })}>
         <div
           onClick={this.launchMenu}
           className='menu-trigger'
-          style={{
+          style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+            transform: 'scale(0.75)',
+          } : {
             position: 'absolute',
             transform: 'scale(0.75)',
             top: -1,
             left: -1
-          }}>
+          })}>
           <CirclePlusSVG
             color={this.getIconColor()} />
         </div>

--- a/packages/haiku-timeline/src/components/PropertyManager.js
+++ b/packages/haiku-timeline/src/components/PropertyManager.js
@@ -2,7 +2,7 @@ import React from 'react'
 import CirclePlusSVG from 'haiku-ui-common/lib/react/icons/CirclePlusSVG'
 import Palette from 'haiku-ui-common/lib/Palette'
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 
 export default class PropertyManager extends React.Component {
   constructor (props) {
@@ -37,7 +37,7 @@ export default class PropertyManager extends React.Component {
           onClick={this.launchMenu}
           className='menu-trigger'
           style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
-            transform: 'scale(0.75)',
+            transform: 'scale(0.75)'
           } : {
             position: 'absolute',
             transform: 'scale(0.75)',

--- a/packages/haiku-timeline/src/components/PropertyRow.js
+++ b/packages/haiku-timeline/src/components/PropertyRow.js
@@ -10,6 +10,7 @@ import Globals from 'haiku-ui-common/lib/Globals'
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
 import PropertyTimelineSegments from './PropertyTimelineSegments'
 import PropertyRowHeading from './PropertyRowHeading'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 
 export default class PropertyRow extends React.Component {
   constructor (props) {
@@ -70,82 +71,84 @@ export default class PropertyRow extends React.Component {
         onMouseLeave={this.throttledHandleRowUnhovered}
         style={{
           height: this.props.rowHeight,
-          width: this.props.timeline.getPropertiesPixelWidth() + this.props.timeline.getTimelinePixelWidth(),
+          width: experimentIsEnabled(Experiment.NativeTimelineScroll) ? undefined : this.props.timeline.getPropertiesPixelWidth() + this.props.timeline.getTimelinePixelWidth(),
           left: 0,
           opacity: (this.props.row.isHidden()) ? 0.5 : 1.0,
           position: 'relative'
         }}>
-        <div
-          onClick={(clickEvent) => {
-            // Allow clicking the subproperty of a cluster to collapse the parent row,
-            // which 'contains' the rows of the cluster as children
-            if (this.props.row.isCluster()) {
-              this.props.row.parent.collapse()
-            }
-          }}>
-          {(this.props.row.isFirstRowOfPropertyCluster()) &&
-            <div
-              style={{
-                position: 'absolute',
-                width: 14,
-                left: 136,
-                top: -2,
-                zIndex: 1006,
-                textAlign: 'right',
-                height: 'inherit'
-              }}>
-              <span className='utf-icon' style={{ top: -4, left: -3 }}><DownCarrotSVG /></span>
-            </div>}
-          {this.maybeRenderFamilySvg()}
+        <div style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? { position: 'sticky', top: 0, left: 0, width: this.props.timeline.getPropertiesPixelWidth(), zIndex: 99999, backgroundColor: Palette.GRAY } : {})}>
           <div
-            className='property-row-label no-select'
-            style={{
-              right: 0,
-              width: this.props.timeline.getPropertiesPixelWidth() - 120,
-              height: this.props.rowHeight,
-              textAlign: 'right',
-              borderTop: (this.props.row.isFirstRowOfSubElementSet()) ? `1px solid ${Palette.GRAY}` : 'none',
-              backgroundColor: (this.props.row.doesTargetHostElement()) ? Palette.GRAY : 'rgb(46, 59, 62)',
-              borderTopLeftRadius: (this.props.row.isFirstRowOfSubElementSet()) ? 4 : 0,
-              borderBottomLeftRadius: (this.props.row.isLastRowOfSubElementSet()) ? 4 : 0,
-              zIndex: 1004,
-              position: 'relative',
-              paddingTop: 6,
-              paddingRight: 10,
-              marginLeft: 40
+            onClick={(clickEvent) => {
+              // Allow clicking the subproperty of a cluster to collapse the parent row,
+              // which 'contains' the rows of the cluster as children
+              if (this.props.row.isCluster()) {
+                this.props.row.parent.collapse()
+              }
             }}>
+            {(this.props.row.isFirstRowOfPropertyCluster()) &&
+              <div
+                style={{
+                  position: 'absolute',
+                  width: 14,
+                  left: 136,
+                  top: -2,
+                  zIndex: 1006,
+                  textAlign: 'right',
+                  height: 'inherit'
+                }}>
+                <span className='utf-icon' style={{ top: -4, left: -3 }}><DownCarrotSVG /></span>
+              </div>}
+            {this.maybeRenderFamilySvg()}
             <div
-              className='hacky-property-row-coverup'
+              className='property-row-label no-select'
               style={{
-                position: 'absolute',
-                left: -40,
-                height: '100%',
-                width: 40,
-                backgroundColor: Palette.GRAY
-              }} />
-            <PropertyRowHeading
-              row={this.props.row}
-              humanName={humanName} />
+                right: 0,
+                width: this.props.timeline.getPropertiesPixelWidth() - 120,
+                height: this.props.rowHeight,
+                textAlign: 'right',
+                borderTop: (this.props.row.isFirstRowOfSubElementSet()) ? `1px solid ${Palette.GRAY}` : 'none',
+                backgroundColor: (this.props.row.doesTargetHostElement()) ? Palette.GRAY : 'rgb(46, 59, 62)',
+                borderTopLeftRadius: (this.props.row.isFirstRowOfSubElementSet()) ? 4 : 0,
+                borderBottomLeftRadius: (this.props.row.isLastRowOfSubElementSet()) ? 4 : 0,
+                zIndex: 1004,
+                position: 'relative',
+                paddingTop: 6,
+                paddingRight: 10,
+                marginLeft: 40
+              }}>
+              <div
+                className='hacky-property-row-coverup'
+                style={{
+                  position: 'absolute',
+                  left: -40,
+                  height: '100%',
+                  width: 40,
+                  backgroundColor: Palette.GRAY
+                }} />
+              <PropertyRowHeading
+                row={this.props.row}
+                humanName={humanName} />
+            </div>
           </div>
-        </div>
-        <div className='property-input-field-row'
-          style={{
-            position: 'absolute',
-            left: this.props.timeline.getPropertiesPixelWidth() - 82,
-            width: 82,
-            top: 0,
-            height: this.props.rowHeight - 1,
-            textAlign: 'left'
-          }}>
-          <PropertyInputField
-            parent={this}
-            row={this.props.row}
-            index={this.props.row.getAddress()}
-            height={this.props.rowHeight}
-            component={this.component}
-            timeline={this.props.timeline}
-            timelineName={this.props.timeline.getName()}
-            rowHeight={this.props.rowHeight} />
+          <div className='property-input-field-row'
+            style={{
+              position: 'absolute',
+              left: this.props.timeline.getPropertiesPixelWidth() - 82,
+              width: 82,
+              top: 0,
+              height: this.props.rowHeight - 1,
+              textAlign: 'left'
+            }}>
+            <PropertyInputField
+              parent={this}
+              row={this.props.row}
+              index={this.props.row.getAddress()}
+              height={this.props.rowHeight}
+              component={this.component}
+              timeline={this.props.timeline}
+              timelineName={this.props.timeline.getName()}
+              rowHeight={this.props.rowHeight} />
+          </div>
         </div>
         <div
           onContextMenu={(ctxMenuEvent) => {
@@ -167,7 +170,7 @@ export default class PropertyRow extends React.Component {
           }}
           style={{
             position: 'absolute',
-            width: this.props.timeline.getTimelinePixelWidth(),
+            width: experimentIsEnabled(Experiment.NativeTimelineScroll) ? undefined : this.props.timeline.getTimelinePixelWidth(),
             left: this.props.timeline.getPropertiesPixelWidth() - 4, // offset half of lone keyframe width so it lines up with the pole
             top: 0,
             height: 'inherit'

--- a/packages/haiku-timeline/src/components/PropertyRow.js
+++ b/packages/haiku-timeline/src/components/PropertyRow.js
@@ -11,6 +11,7 @@ import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
 import PropertyTimelineSegments from './PropertyTimelineSegments'
 import PropertyRowHeading from './PropertyRowHeading'
 import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
+import zIndex from './styles/zIndex'
 
 export default class PropertyRow extends React.Component {
   constructor (props) {
@@ -76,7 +77,7 @@ export default class PropertyRow extends React.Component {
           opacity: (this.props.row.isHidden()) ? 0.5 : 1.0,
           position: 'relative'
         }}>
-        <div style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? { position: 'sticky', top: 0, left: 0, width: this.props.timeline.getPropertiesPixelWidth(), zIndex: 99999, backgroundColor: Palette.GRAY } : {})}>
+        <div style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? { position: 'sticky', top: 0, left: 0, width: this.props.timeline.getPropertiesPixelWidth(), zIndex: zIndex.propertyRowHeading.base, backgroundColor: Palette.GRAY } : {})}>
           <div
             onClick={(clickEvent) => {
               // Allow clicking the subproperty of a cluster to collapse the parent row,
@@ -173,7 +174,8 @@ export default class PropertyRow extends React.Component {
             width: experimentIsEnabled(Experiment.NativeTimelineScroll) ? '100%' : this.props.timeline.getTimelinePixelWidth(),
             left: this.props.timeline.getPropertiesPixelWidth() - 4, // offset half of lone keyframe width so it lines up with the pole
             top: 0,
-            height: 'inherit'
+            height: 'inherit',
+            zIndex: experimentIsEnabled(Experiment.NativeTimelineScroll) ? zIndex.propertyRow.base : undefined
           }}>
           <PropertyTimelineSegments
             component={this.props.component}

--- a/packages/haiku-timeline/src/components/PropertyRow.js
+++ b/packages/haiku-timeline/src/components/PropertyRow.js
@@ -170,7 +170,7 @@ export default class PropertyRow extends React.Component {
           }}
           style={{
             position: 'absolute',
-            width: experimentIsEnabled(Experiment.NativeTimelineScroll) ? undefined : this.props.timeline.getTimelinePixelWidth(),
+            width: experimentIsEnabled(Experiment.NativeTimelineScroll) ? '100%' : this.props.timeline.getTimelinePixelWidth(),
             left: this.props.timeline.getPropertiesPixelWidth() - 4, // offset half of lone keyframe width so it lines up with the pole
             top: 0,
             height: 'inherit'

--- a/packages/haiku-timeline/src/components/PropertyRowHeading.js
+++ b/packages/haiku-timeline/src/components/PropertyRowHeading.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Palette from 'haiku-ui-common/lib/Palette'
 import StatesSVG from 'haiku-ui-common/lib/react/icons/StatesSVG'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 
 export default class PropertyRowHeading extends React.Component {
   constructor (props) {

--- a/packages/haiku-timeline/src/components/PropertyRowHeading.js
+++ b/packages/haiku-timeline/src/components/PropertyRowHeading.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Palette from 'haiku-ui-common/lib/Palette'
 import StatesSVG from 'haiku-ui-common/lib/react/icons/StatesSVG'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
 
 export default class PropertyRowHeading extends React.Component {
   constructor (props) {
@@ -72,7 +73,7 @@ export default class PropertyRowHeading extends React.Component {
         <span
           style={{
             display: 'inline-block',
-            width: 55,
+            width: experimentIsEnabled(Experiment.NativeTimelineScroll) ? undefined : 55,
             textAlign: 'right',
             marginTop
           }}>

--- a/packages/haiku-timeline/src/components/RowSegments.js
+++ b/packages/haiku-timeline/src/components/RowSegments.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import lodash from 'lodash'
 import mixpanel from 'haiku-serialization/src/utils/Mixpanel'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 import TransitionBody from './TransitionBody'
 import ConstantBody from './ConstantBody'
 import SoloKeyframe from './SoloKeyframe'
@@ -57,7 +57,6 @@ export default class RowSegments extends React.Component {
         return
       }
     }
-
 
     if (
       what === 'keyframe-create' ||

--- a/packages/haiku-timeline/src/components/RowSegments.js
+++ b/packages/haiku-timeline/src/components/RowSegments.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import lodash from 'lodash'
 import mixpanel from 'haiku-serialization/src/utils/Mixpanel'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
 import TransitionBody from './TransitionBody'
 import ConstantBody from './ConstantBody'
 import SoloKeyframe from './SoloKeyframe'
@@ -42,13 +43,21 @@ export default class RowSegments extends React.Component {
       return
     }
 
-    if (
-      what === 'timeline-frame-range' ||
-      what === 'timeline-timeline-pixel-width'
-    ) {
-      this.forceUpdate()
-      return
+    if (experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+      if (what === 'timeline-timeline-pixel-width') {
+        this.forceUpdate()
+        return
+      }
+    } else {
+      if (
+        what === 'timeline-frame-range' ||
+        what === 'timeline-timeline-pixel-width'
+      ) {
+        this.forceUpdate()
+        return
+      }
     }
+
 
     if (
       what === 'keyframe-create' ||

--- a/packages/haiku-timeline/src/components/RowSegments.js
+++ b/packages/haiku-timeline/src/components/RowSegments.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import lodash from 'lodash'
 import mixpanel from 'haiku-serialization/src/utils/Mixpanel'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 import TransitionBody from './TransitionBody'
 import ConstantBody from './ConstantBody'
 import SoloKeyframe from './SoloKeyframe'
@@ -43,19 +42,12 @@ export default class RowSegments extends React.Component {
       return
     }
 
-    if (experimentIsEnabled(Experiment.NativeTimelineScroll)) {
-      if (what === 'timeline-timeline-pixel-width') {
-        this.forceUpdate()
-        return
-      }
-    } else {
-      if (
+    if (
         what === 'timeline-frame-range' ||
         what === 'timeline-timeline-pixel-width'
       ) {
-        this.forceUpdate()
-        return
-      }
+      this.forceUpdate()
+      return
     }
 
     if (

--- a/packages/haiku-timeline/src/components/ScrubberInterior.js
+++ b/packages/haiku-timeline/src/components/ScrubberInterior.js
@@ -60,6 +60,7 @@ export default class ScrubberInterior extends React.Component {
 
     return (
       <div
+        onMouseDown={this.props.onMouseDown}
         style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
           position: 'sticky',
           top: 0,
@@ -132,5 +133,6 @@ export default class ScrubberInterior extends React.Component {
 
 ScrubberInterior.propTypes = {
   isScrubbing: React.PropTypes.bool.isRequired,
-  timeline: React.PropTypes.object.isRequired
+  timeline: React.PropTypes.object.isRequired,
+  onMouseDown: React.PropTypes.func.isRequired,
 }

--- a/packages/haiku-timeline/src/components/ScrubberInterior.js
+++ b/packages/haiku-timeline/src/components/ScrubberInterior.js
@@ -56,12 +56,18 @@ export default class ScrubberInterior extends React.Component {
     const currFrame = this.props.timeline.getCurrentFrame()
     const frameOffset = currFrame - frameInfo.friA
     const pxOffset = frameOffset * frameInfo.pxpf
+    const propertiesWidth = this.props.timeline.getPropertiesPixelWidth()
 
     return (
       <div
-        style={{
+        style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+          position: 'sticky',
+          top: 0,
+          marginTop: -45,
+          zIndex: 99999
+        } : {
           overflow: 'hidden'
-        }}>
+        })}>
         <div
           style={{
             position: 'absolute',
@@ -71,11 +77,11 @@ export default class ScrubberInterior extends React.Component {
             height: 19,
             width: 19,
             top: 13,
-            left: pxOffset - 9,
+            left: propertiesWidth + pxOffset - 9,
             borderRadius: '50%',
             cursor: 'move',
             boxShadow: '0 0 2px 0 rgba(0, 0, 0, .9)',
-            zIndex: 2006
+            zIndex: 999999
           }}>
           <span style={{
             position: 'absolute',
@@ -87,7 +93,7 @@ export default class ScrubberInterior extends React.Component {
           </span>
           <span style={{
             position: 'absolute',
-            zIndex: 2006,
+            zIndex: 999999,
             width: 0,
             height: 0,
             top: 15,
@@ -98,7 +104,7 @@ export default class ScrubberInterior extends React.Component {
           }} />
           <span style={{
             position: 'absolute',
-            zIndex: 2006,
+            zIndex: 999999,
             width: 0,
             height: 0,
             left: 2,
@@ -113,10 +119,10 @@ export default class ScrubberInterior extends React.Component {
             position: 'absolute',
             zIndex: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 999999999 : 2006,
             backgroundColor: Palette.SUNSTONE,
-            height: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 'calc(100vh - 95px)' : 9999,
+            height: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 'calc(100vh - 80px)' : 9999,
             width: 1,
             top: 35,
-            left: pxOffset,
+            left: pxOffset + propertiesWidth,
             pointerEvents: 'none'
           }} />
       </div>

--- a/packages/haiku-timeline/src/components/ScrubberInterior.js
+++ b/packages/haiku-timeline/src/components/ScrubberInterior.js
@@ -82,7 +82,7 @@ export default class ScrubberInterior extends React.Component {
             left: propertiesWidth + pxOffset - 9,
             borderRadius: '50%',
             cursor: 'move',
-            boxShadow: '0 0 2px 0 rgba(0, 0, 0, .9)',
+            boxShadow: '0 0 2px 0 rgba(0, 0, 0, .9)'
             // zIndex: 999999
           }}>
           <span style={{

--- a/packages/haiku-timeline/src/components/ScrubberInterior.js
+++ b/packages/haiku-timeline/src/components/ScrubberInterior.js
@@ -134,5 +134,5 @@ export default class ScrubberInterior extends React.Component {
 ScrubberInterior.propTypes = {
   isScrubbing: React.PropTypes.bool.isRequired,
   timeline: React.PropTypes.object.isRequired,
-  onMouseDown: React.PropTypes.func.isRequired,
+  onMouseDown: React.PropTypes.func.isRequired
 }

--- a/packages/haiku-timeline/src/components/ScrubberInterior.js
+++ b/packages/haiku-timeline/src/components/ScrubberInterior.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import lodash from 'lodash'
 import Palette from 'haiku-ui-common/lib/Palette'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
 
 export default class ScrubberInterior extends React.Component {
   constructor (props) {
@@ -29,9 +30,10 @@ export default class ScrubberInterior extends React.Component {
 
   handleUpdate (what) {
     if (!this.mounted) return null
+
     if (what === 'timeline-frame') {
       this.forceUpdate()
-    } else if (what === 'timeline-frame-range') {
+    } else if (what === 'timeline-frame-range' && !experimentIsEnabled(Experiment.NativeTimelineScroll)) {
       this.forceUpdate()
     } else if (what === 'time-display-mode-change') {
       this.forceUpdate()
@@ -41,16 +43,17 @@ export default class ScrubberInterior extends React.Component {
   render () {
     const frameInfo = this.props.timeline.getFrameInfo()
 
-    if (this.props.timeline.getCurrentFrame() < frameInfo.friA) {
-      return <span />
-    }
+    if (!experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+      if (this.props.timeline.getCurrentFrame() < frameInfo.friA) {
+        return <span />
+      }
 
-    if (this.props.timeline.getCurrentFrame() > frameInfo.friB) {
-      return <span />
+      if (this.props.timeline.getCurrentFrame() > frameInfo.friB) {
+        return <span />
+      }
     }
 
     const currFrame = this.props.timeline.getCurrentFrame()
-
     const frameOffset = currFrame - frameInfo.friA
     const pxOffset = frameOffset * frameInfo.pxpf
 
@@ -108,9 +111,9 @@ export default class ScrubberInterior extends React.Component {
         <div
           style={{
             position: 'absolute',
-            zIndex: 2006,
+            zIndex: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 999999999 : 2006,
             backgroundColor: Palette.SUNSTONE,
-            height: 9999,
+            height: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 'calc(100vh - 95px)' : 9999,
             width: 1,
             top: 35,
             left: pxOffset,

--- a/packages/haiku-timeline/src/components/ScrubberInterior.js
+++ b/packages/haiku-timeline/src/components/ScrubberInterior.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import lodash from 'lodash'
 import Palette from 'haiku-ui-common/lib/Palette'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 
 export default class ScrubberInterior extends React.Component {
   constructor (props) {

--- a/packages/haiku-timeline/src/components/ScrubberInterior.js
+++ b/packages/haiku-timeline/src/components/ScrubberInterior.js
@@ -2,6 +2,7 @@ import React from 'react'
 import lodash from 'lodash'
 import Palette from 'haiku-ui-common/lib/Palette'
 import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
+import zIndex from './styles/zIndex'
 
 export default class ScrubberInterior extends React.Component {
   constructor (props) {
@@ -65,7 +66,7 @@ export default class ScrubberInterior extends React.Component {
           position: 'sticky',
           top: 0,
           marginTop: -45,
-          zIndex: 99999
+          zIndex: zIndex.scrubber.base
         } : {
           overflow: 'hidden'
         })}>
@@ -82,7 +83,7 @@ export default class ScrubberInterior extends React.Component {
             borderRadius: '50%',
             cursor: 'move',
             boxShadow: '0 0 2px 0 rgba(0, 0, 0, .9)',
-            zIndex: 999999
+            // zIndex: 999999
           }}>
           <span style={{
             position: 'absolute',
@@ -94,7 +95,7 @@ export default class ScrubberInterior extends React.Component {
           </span>
           <span style={{
             position: 'absolute',
-            zIndex: 999999,
+            // zIndex: 999999,
             width: 0,
             height: 0,
             top: 15,
@@ -105,7 +106,7 @@ export default class ScrubberInterior extends React.Component {
           }} />
           <span style={{
             position: 'absolute',
-            zIndex: 999999,
+            // zIndex: 999999,
             width: 0,
             height: 0,
             left: 2,
@@ -118,7 +119,7 @@ export default class ScrubberInterior extends React.Component {
         <div
           style={{
             position: 'absolute',
-            zIndex: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 999999999 : 2006,
+            zIndex: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 1 : 2006,
             backgroundColor: Palette.SUNSTONE,
             height: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 'calc(100vh - 80px)' : 9999,
             width: 1,

--- a/packages/haiku-timeline/src/components/ScrubberInterior.js
+++ b/packages/haiku-timeline/src/components/ScrubberInterior.js
@@ -34,7 +34,7 @@ export default class ScrubberInterior extends React.Component {
 
     if (what === 'timeline-frame') {
       this.forceUpdate()
-    } else if (what === 'timeline-frame-range' && !experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+    } else if (what === 'timeline-frame-range') {
       this.forceUpdate()
     } else if (what === 'time-display-mode-change') {
       this.forceUpdate()

--- a/packages/haiku-timeline/src/components/ScrubberInterior.js
+++ b/packages/haiku-timeline/src/components/ScrubberInterior.js
@@ -55,7 +55,9 @@ export default class ScrubberInterior extends React.Component {
     }
 
     const currFrame = this.props.timeline.getCurrentFrame()
-    const frameOffset = currFrame - frameInfo.friA
+    const frameOffset = experimentIsEnabled(Experiment.NativeTimelineScroll)
+      ? currFrame
+      : currFrame - frameInfo.friA
     const pxOffset = frameOffset * frameInfo.pxpf
     const propertiesWidth = this.props.timeline.getPropertiesPixelWidth()
 

--- a/packages/haiku-timeline/src/components/SoloKeyframe.js
+++ b/packages/haiku-timeline/src/components/SoloKeyframe.js
@@ -1,10 +1,12 @@
 import React from 'react'
 import Palette from 'haiku-ui-common/lib/Palette'
 import KeyframeSVG from 'haiku-ui-common/lib/react/icons/KeyframeSVG'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
 
 export default class SoloKeyframe extends React.Component {
   constructor (props) {
     super(props)
+    this.handleUpdate = this.handleUpdate.bind(this)
     this.handleProps(props)
   }
 
@@ -28,15 +30,37 @@ export default class SoloKeyframe extends React.Component {
 
   componentDidMount () {
     this.mounted = true
+    if (experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
+      this.props.timeline.on('update', this.handleUpdate)
+    }
   }
 
   componentWillUnmount () {
     this.mounted = false
     this.teardownKeyframeUpdateReceiver()
+    if (experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
+      this.props.timeline.removeListener('update', this.handleUpdate)
+    }
   }
 
-  handleUpdate (what) {
+  handleUpdate (what, ...args) {
     if (!this.mounted) return null
+    if (experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
+      if (what === 'marquee-selection') {
+        const containerRect = this.position
+        const elementRect = args[0]
+        if (
+          containerRect.x < elementRect.x + elementRect.width &&
+          containerRect.x + containerRect.width > elementRect.x &&
+          containerRect.y < elementRect.y + elementRect.height &&
+          containerRect.height + containerRect.y > elementRect.y
+        ) {
+          this.props.keyframe.select()
+          this.props.keyframe.activate()
+        }
+      }
+    }
+
     if (
       what === 'keyframe-activated' ||
       what === 'keyframe-deactivated' ||
@@ -54,6 +78,11 @@ export default class SoloKeyframe extends React.Component {
     const leftPx = this.props.keyframe.getPixelOffsetLeft(frameInfo.friA, frameInfo.pxpf, frameInfo.mspf)
     return (
       <span
+        ref={(el) => {
+          if (el && experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
+            this.position = el.getBoundingClientRect()
+          }
+        }}
         id={`solo-keyframe-${this.props.keyframe.getUniqueKey()}`}
         style={{
           position: 'absolute',

--- a/packages/haiku-timeline/src/components/SoloKeyframe.js
+++ b/packages/haiku-timeline/src/components/SoloKeyframe.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Palette from 'haiku-ui-common/lib/Palette'
 import KeyframeSVG from 'haiku-ui-common/lib/react/icons/KeyframeSVG'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 
 export default class SoloKeyframe extends React.Component {
   constructor (props) {

--- a/packages/haiku-timeline/src/components/SoloKeyframe.js
+++ b/packages/haiku-timeline/src/components/SoloKeyframe.js
@@ -53,7 +53,10 @@ export default class SoloKeyframe extends React.Component {
 
   render () {
     const frameInfo = this.props.timeline.getFrameInfo()
-    const leftPx = this.props.keyframe.getPixelOffsetLeft(frameInfo.friA, frameInfo.pxpf, frameInfo.mspf)
+    const leftPx = experimentIsEnabled(Experiment.TimelineMarqueeSelection)
+      ? this.props.keyframe.getPixelOffsetLeft(0, frameInfo.pxpf, frameInfo.mspf)
+      : this.props.keyframe.getPixelOffsetLeft(frameInfo.friA, frameInfo.pxpf, frameInfo.mspf)
+
     return (
       <span
         ref={(el) => {

--- a/packages/haiku-timeline/src/components/SoloKeyframe.js
+++ b/packages/haiku-timeline/src/components/SoloKeyframe.js
@@ -6,7 +6,6 @@ import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 export default class SoloKeyframe extends React.Component {
   constructor (props) {
     super(props)
-    this.handleUpdate = this.handleUpdate.bind(this)
     this.handleProps(props)
   }
 
@@ -30,36 +29,15 @@ export default class SoloKeyframe extends React.Component {
 
   componentDidMount () {
     this.mounted = true
-    if (experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
-      this.props.timeline.on('update', this.handleUpdate)
-    }
   }
 
   componentWillUnmount () {
     this.mounted = false
     this.teardownKeyframeUpdateReceiver()
-    if (experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
-      this.props.timeline.removeListener('update', this.handleUpdate)
-    }
   }
 
   handleUpdate (what, ...args) {
     if (!this.mounted) return null
-    if (experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
-      if (what === 'marquee-selection') {
-        const containerRect = this.position
-        const elementRect = args[0]
-        if (
-          containerRect.x < elementRect.x + elementRect.width &&
-          containerRect.x + containerRect.width > elementRect.x &&
-          containerRect.y < elementRect.y + elementRect.height &&
-          containerRect.height + containerRect.y > elementRect.y
-        ) {
-          this.props.keyframe.select()
-          this.props.keyframe.activate()
-        }
-      }
-    }
 
     if (
       what === 'keyframe-activated' ||
@@ -80,7 +58,7 @@ export default class SoloKeyframe extends React.Component {
       <span
         ref={(el) => {
           if (el && experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
-            this.position = el.getBoundingClientRect()
+            this.props.keyframe.storeViewPosition(el.getBoundingClientRect())
           }
         }}
         id={`solo-keyframe-${this.props.keyframe.getUniqueKey()}`}

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -165,13 +165,13 @@ class Timeline extends React.Component {
           // This event triggers on `mousedown`, we make the assumption that a
           // mousedown + mouse movement on one of the elements below is a drag,
           // therefore we stop the marquee selection by returning `false`.
-          return (
+          return !(
             // Keyframe
-            !event.target.id.includes('keyframe-dragger') ||
+            event.target.id.includes('keyframe-dragger') ||
             // Constant Body
-            !event.target.id.includes('constant-body') ||
+            event.target.id.includes('constant-body') ||
             // Tween
-            !event.target.className.includes('pill')
+            event.target.className.includes('pill')
           )
         },
         onFinish: (event, area) => {

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -155,12 +155,15 @@ class Timeline extends React.Component {
     this.project.getEnvoyClient().closeConnection()
   }
 
-  componentDidMount () {
-    this.mounted = true
-
+  instantiateMarquee () {
     if (experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
+      const area = document.querySelector('#property-rows')
+      if (!area) {
+        return setTimeout(this.instantiateMarquee.bind(this), 100)
+      }
+
       const marquee = new Marquee({
-        area: document.querySelector('#property-rows'),
+        area,
         onStart: (event) => {
           // This event triggers on `mousedown`, we make the assumption that a
           // mousedown + mouse movement on one of the elements below is a drag,
@@ -207,6 +210,12 @@ class Timeline extends React.Component {
 
       marquee.start()
     }
+  }
+
+  componentDidMount () {
+    this.mounted = true
+
+    this.instantiateMarquee()
 
     const resetKeyStates = () => {
       Globals.allKeysUp()

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -168,19 +168,27 @@ class Timeline extends React.Component {
           )
         },
         onFinish: (event, area) => {
-          Keyframe.all().forEach(keyframe => {
+          const timelineEl = document.getElementById('timeline')
+
+          Keyframe.all().forEach((keyframe) => {
             const keyframeView = keyframe._viewPosition
 
             if (
               keyframeView.x < area.x + area.width &&
-              keyframeView.x + keyframeView.width > area.x &&
-              keyframeView.y < area.y + area.height &&
-              keyframeView.height + keyframeView.y > area.y
+              keyframeView.x + keyframeView.width > area.x
             ) {
-              keyframe.select()
-              keyframe.activate()
-              keyframe.setBodySelected()
-              keyframe.row.expand({from: 'timeline'})
+              const keyframeViewEl = document.getElementById(`keyframe-container-${keyframe.getUniqueKey()}`)
+              const {y, height} = keyframeViewEl.getBoundingClientRect()
+
+              if (
+                y < area.y + area.height &&
+                height + y > area.y
+              ) {
+                keyframe.select()
+                keyframe.activate()
+                keyframe.setBodySelected()
+                keyframe.row.expand({from: 'timeline'})
+              }
             }
           })
         }

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -28,6 +28,7 @@ import {InteractionMode, isPreviewMode} from '@haiku/core/lib/helpers/interactio
 import { USER_CHANNEL, UserSettings } from 'haiku-sdk-creator/lib/bll/User'
 import logger from 'haiku-serialization/src/utils/LoggerInstance'
 import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
+import zIndex from './styles/zIndex'
 
 const Globals = require('haiku-ui-common/lib/Globals').default // Sorry, hack
 
@@ -1070,7 +1071,7 @@ class Timeline extends React.Component {
               .getCurrentTimeline()
               .getPropertiesPixelWidth(),
             backgroundColor: Palette.COAL,
-            zIndex: 999999999,
+            zIndex: zIndex.timekeepingWrapper.base,
             fontSize: 10
           }}
         >
@@ -1091,7 +1092,7 @@ class Timeline extends React.Component {
             top: 0,
             marginLeft: this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth(),
             width: '500vw',
-            zIndex: '9999',
+            zIndex: zIndex.gauge.base,
             fontSize: 10,
             borderBottom: '1px solid ' + Palette.FATHER_COAL,
             color: Palette.ROCK_MUTED
@@ -1409,7 +1410,7 @@ class Timeline extends React.Component {
                 left: 0,
                 right: 0,
                 bottom: 0,
-                zIndex: 999999,
+                zIndex: zIndex.previewModeBlocker.base,
                 backgroundColor: Palette.COAL
               }}
               onClick={() => {

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -175,9 +175,14 @@ class Timeline extends React.Component {
           )
         },
         onFinish: (event, area) => {
-          Keyframe.all().forEach((keyframe) => {
+          const selected = Keyframe.all().filter((keyframe) => {
             const keyframeView = keyframe._viewPosition
 
+            // First, check if the keyframe is contained in the marquee horizontally,
+            // we perform this check first because we can't rely on the cached `y` value due
+            // to the rows expanding/collapsing. Since we don't have a similar behavior that
+            // modifies the `x` position of a keyframe post-render this is a safe filter to
+            // avoid performing the expensive `getBoundingClientRect` calculation on all keyframes
             if (
               keyframeView.x < area.x + area.width &&
               keyframeView.x + keyframeView.width > area.x
@@ -185,16 +190,17 @@ class Timeline extends React.Component {
               const keyframeViewEl = document.getElementById(`keyframe-container-${keyframe.getUniqueKey()}`)
               const {y, height} = keyframeViewEl.getBoundingClientRect()
 
-              if (
-                y < area.y + area.height &&
-                height + y > area.y
-              ) {
-                keyframe.select()
-                keyframe.activate()
-                keyframe.setBodySelected()
-                keyframe.row.expand({from: 'timeline'})
-              }
+              return (y < area.y + area.height && height + y > area.y)
             }
+          })
+
+          // We perform this logic once we determined the selection, because
+          // expanding a row modifies its coordinates.
+          selected.forEach((keyframe) => {
+            keyframe.select()
+            keyframe.activate()
+            keyframe.setBodySelected()
+            keyframe.row.expand({from: 'timeline'})
           })
         }
       })

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -798,8 +798,8 @@ class Timeline extends React.Component {
   }
 
   handleHorizontalScroll (origDelta) {
-    const motionDelta = Math.round((origDelta ? origDelta < 0 ? -1 : 1 : 0) * (Math.log(Math.abs(origDelta) + 1) * 2))
-    this.getActiveComponent().getCurrentTimeline().updateVisibleFrameRangeByDelta(motionDelta)
+    // const motionDelta = Math.round((origDelta ? origDelta < 0 ? -1 : 1 : 0) * (Math.log(Math.abs(origDelta) + 1) * 2))
+    // this.getActiveComponent().getCurrentTimeline().updateVisibleFrameRangeByDelta(motionDelta)
   }
 
   handleRequestElementCoordinates ({ selector, webview }) {

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -95,6 +95,7 @@ class Timeline extends React.Component {
     this.showFrameActionsEditor = this.showFrameActionsEditor.bind(this)
     this.mouseMoveListener = this.mouseMoveListener.bind(this)
     this.mouseUpListener = this.mouseUpListener.bind(this)
+    this.onGaugeMouseDown = this.onGaugeMouseDown.bind(this)
 
     this.handleCutDebounced = lodash.debounce(this.handleCut.bind(this), MENU_ACTION_DEBOUNCE_TIME, {leading: true, trailing: false})
     this.handleCopyDebounced = lodash.debounce(this.handleCopy.bind(this), MENU_ACTION_DEBOUNCE_TIME, {leading: true, trailing: false})
@@ -1051,33 +1052,30 @@ class Timeline extends React.Component {
           timeline={this.getActiveComponent().getCurrentTimeline()}
           onShowFrameActionsEditor={this.showFrameActionsEditor}
         />,
-        <div key='gauge' style={{
-          height: 35,
-          backgroundColor: Palette.COAL,
-          paddingTop: 12,
-          position: 'sticky',
-          top: 0,
-          marginLeft: this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth(),
-          width: '500vw',
-          zIndex: '9999',
-          fontSize: 10,
-          borderBottom: '1px solid ' + Palette.FATHER_COAL,
-          color: Palette.ROCK_MUTED
-        }}
-          onMouseDown={(event) => {
-            event.persist()
-
-            this._doHandleMouseMovesInGauge = true
-            this.disableTimelinePointerEvents()
-            this.mouseMoveListener(event)
-          }}>
+        <div
+          key='gauge'
+          style={{
+            height: 35,
+            backgroundColor: Palette.COAL,
+            paddingTop: 12,
+            position: 'sticky',
+            top: 0,
+            marginLeft: this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth(),
+            width: '500vw',
+            zIndex: '9999',
+            fontSize: 10,
+            borderBottom: '1px solid ' + Palette.FATHER_COAL,
+            color: Palette.ROCK_MUTED
+          }}
+          onMouseDown={this.onGaugeMouseDown}
+        >
           <Gauge timeline={this.getActiveComponent().getCurrentTimeline()} />
         </div>,
         <ScrubberInterior
           key='scrubber'
-          reactParent={this}
           isScrubbing={this.getActiveComponent().getCurrentTimeline().isScrubberDragging()}
           timeline={this.getActiveComponent().getCurrentTimeline()}
+          onMouseDown={this.onGaugeMouseDown}
         />,
         <div key='durationModifier'>
           {this.renderDurationModifier()}
@@ -1163,6 +1161,14 @@ class Timeline extends React.Component {
         </div>
       )
     }
+  }
+
+  onGaugeMouseDown (event) {
+    event.persist()
+
+    this._doHandleMouseMovesInGauge = true
+    this.disableTimelinePointerEvents()
+    this.mouseMoveListener(event)
   }
 
   mouseMoveListener (evt) {

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -464,14 +464,27 @@ class Timeline extends React.Component {
       }
 
       const timeline = this.getActiveComponent().getCurrentTimeline()
+      let pxInTimeline
+      let frameForPx
 
       if (timeline) {
         const frameInfo = timeline.getFrameInfo()
-        let pxInTimeline = mouseMoveEvent.clientX - timeline.getPropertiesPixelWidth()
+        if (experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+          pxInTimeline = mouseMoveEvent.layerX - timeline.getPropertiesPixelWidth()
+        } else {
+          pxInTimeline = mouseMoveEvent.clientX - timeline.getPropertiesPixelWidth()
+        }
+
         if (pxInTimeline < 0) {
           pxInTimeline = 0
         }
-        const frameForPx = frameInfo.friA + Math.round(pxInTimeline / frameInfo.pxpf)
+
+        if (experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+          frameForPx = Math.round(pxInTimeline / frameInfo.pxpf)
+        } else {
+          frameForPx = frameInfo.friA + Math.round(pxInTimeline / frameInfo.pxpf)
+        }
+
         timeline.hoverFrame(frameForPx)
       }
     })

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -153,8 +153,18 @@ class Timeline extends React.Component {
     if (experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
       const marquee = new Marquee({
         area: document.querySelector('#property-rows'),
-        onStart: event => {
-          // this.onGaugeMouseDown(event)
+        onStart: (event) => {
+          // This event triggers on `mousedown`, we make the assumption that a
+          // mousedown + mouse movement on one of the elements below is a drag,
+          // therefore we stop the marquee selection by returning `false`.
+          return (
+            // Keyframe
+            !event.target.id.includes('keyframe-dragger') ||
+            // Constant Body
+            !event.target.id.includes('constant-body') ||
+            // Tween
+            !event.target.className.includes('pill')
+          )
         },
         onFinish: (event, area) => {
           Keyframe.all().forEach(keyframe => {

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -27,7 +27,7 @@ import Marquee from './Marquee'
 import {InteractionMode, isPreviewMode} from '@haiku/core/lib/helpers/interactionModes'
 import { USER_CHANNEL, UserSettings } from 'haiku-sdk-creator/lib/bll/User'
 import logger from 'haiku-serialization/src/utils/LoggerInstance'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 
 const Globals = require('haiku-ui-common/lib/Globals').default // Sorry, hack
 
@@ -150,9 +150,12 @@ class Timeline extends React.Component {
     this.mounted = true
 
     if (experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
-      new Marquee({area: document.querySelector('#timeline'), callback: (event, area) => {
-        this.getActiveComponent().getCurrentTimeline().notifyMarqueeSelection(area)
-      }})
+      const marquee = new Marquee({area: document.querySelector('#timeline'),
+        callback: (event, area) => {
+          this.getActiveComponent().getCurrentTimeline().notifyMarqueeSelection(area)
+        }})
+
+      marquee.start()
     }
 
     const resetKeyStates = () => {
@@ -1049,7 +1052,7 @@ class Timeline extends React.Component {
         })}>
         <div
           className='gauge-timekeeping-wrapper'
-          style={( experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+          style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
             position: 'fixed',
             top: 0,
             left: 0,
@@ -1334,7 +1337,7 @@ class Timeline extends React.Component {
             width: '500vw',
             pointerEvents: 'auto',
             WebkitUserSelect: 'auto',
-            bottom: 0,
+            bottom: 0
           } : {
             position: 'absolute',
             top: 35,

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -175,8 +175,6 @@ class Timeline extends React.Component {
           )
         },
         onFinish: (event, area) => {
-          const timelineEl = document.getElementById('timeline')
-
           Keyframe.all().forEach((keyframe) => {
             const keyframeView = keyframe._viewPosition
 
@@ -809,7 +807,7 @@ class Timeline extends React.Component {
       // case 32: //space
       case 37: // left
         if (this.state.isCommandKeyDown || (experimentIsEnabled(Experiment.NativeTimelineScroll) && this.isCommandKeyDown)) {
-          if (this.state.isShiftKeyDown || (experimentIsEnabled(Experiment.NativeTimelineScroll) && this.isShiftKeyDown))
+          if (this.state.isShiftKeyDown || (experimentIsEnabled(Experiment.NativeTimelineScroll) && this.isShiftKeyDown)) {
             this.getActiveComponent().getCurrentTimeline().setVisibleFrameRange(0, this.getActiveComponent().getCurrentTimeline().getRightFrameEndpoint())
             this.getActiveComponent().getCurrentTimeline().updateCurrentFrame(0)
           } else {
@@ -865,8 +863,8 @@ class Timeline extends React.Component {
 
   updateKeyboardState (updates) {
     if (experimentIsEnabled(Experiment.NativeTimelineScroll)) {
-      for (var key in updates) {
-        this.[key] = updates[key]
+      for (const key in updates) {
+        this[key] = updates[key]
       }
     } else {
       // If the input is focused, don't allow keyboard state changes to cause a re-render, otherwise
@@ -874,7 +872,7 @@ class Timeline extends React.Component {
       if (!this.getActiveComponent().getFocusedRow()) {
         return this.setState(updates)
       } else {
-        for (var key in updates) {
+        for (const key in updates) {
           this.state[key] = updates[key]
         }
       }
@@ -1485,7 +1483,7 @@ class Timeline extends React.Component {
             width: this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth(),
             backgroundColor: Palette.GRAY,
             zIndex: zIndex.backgroundHelper.base
-          }}></div>
+          }} />
         }
         {this.renderBottomControls()}
         <ExpressionInput

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -150,7 +150,7 @@ class Timeline extends React.Component {
     this.mounted = true
 
     if (experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
-      const marquee = new Marquee({area: document.querySelector('#timeline'),
+      const marquee = new Marquee({area: document.querySelector('#property-rows'),
         callback: (event, area) => {
           this.getActiveComponent().getCurrentTimeline().notifyMarqueeSelection(area)
         }})

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1404,7 +1404,7 @@ class Timeline extends React.Component {
           color: Palette.ROCK,
           top: 0,
           left: 0,
-          height: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 'calc(100% - 25px)' : 'calc(100% - 45px)',
+          height: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 'calc(100% - 30px)' : 'calc(100% - 45px)',
           width: '100%',
           overflow: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 'auto' : 'hidden'
         }}>

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -530,6 +530,7 @@ class Timeline extends React.Component {
   }
 
   handleActiveComponentReady () {
+    const timeline = this.getActiveComponent().getCurrentTimeline()
     this.mountHaikuComponent()
 
     ipcRenderer.send('topmenu:update', {
@@ -537,10 +538,18 @@ class Timeline extends React.Component {
     })
 
     this.loadUserSettings()
-    this.getActiveComponent().getCurrentTimeline().setTimelinePixelWidth(document.body.clientWidth - this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth() + 20)
+    timeline.setTimelinePixelWidth(document.body.clientWidth - timeline.getPropertiesPixelWidth() + 20)
 
     if (this.mounted) {
       this.forceUpdate()
+    }
+
+    if (experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+      this.addEmitterListenerIfNotAlreadyRegistered(timeline, 'update', (what, ...args) => {
+        if (what === 'timeline-scroll') {
+          this.refs.container.scrollLeft = timeline.getScrollLeft()
+        }
+      })
     }
 
     this.project.broadcastPayload({

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1245,11 +1245,17 @@ class Timeline extends React.Component {
     }
 
     const frameInfo = this.getActiveComponent().getCurrentTimeline().getFrameInfo()
-    const leftX = evt.clientX - this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth()
+    const leftX = experimentIsEnabled(Experiment.NativeTimelineScroll)
+      ? (evt.layerX || evt.nativeEvent.layerX)
+      : evt.clientX - this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth()
+
     const frameX = Math.round(leftX / frameInfo.pxpf)
 
     // Allow the scrubber to be dragged past 0 in order to reach 0
-    let newFrame = frameInfo.friA + frameX
+    let newFrame = experimentIsEnabled(Experiment.NativeTimelineScroll)
+      ? frameX
+      : frameInfo.friA + frameX
+
     if (newFrame < 0) {
       newFrame = 0
     }
@@ -1259,14 +1265,16 @@ class Timeline extends React.Component {
       return
     }
 
-    const pageFrameLength = this.getActiveComponent().getCurrentTimeline().getVisibleFrameRangeLength()
+    if (!experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+      const pageFrameLength = this.getActiveComponent().getCurrentTimeline().getVisibleFrameRangeLength()
 
-    // If the frame clicked exceeds the virtual or explicit max, allocate additional
-    // virtual frames in the view and jump the user to the new page
-    if (newFrame > frameInfo.friB) {
-      const newMaxFrame = newFrame + pageFrameLength
-      this.getActiveComponent().getCurrentTimeline().setMaxFrame(newMaxFrame)
-      this.getActiveComponent().getCurrentTimeline().setVisibleFrameRange(newFrame, newMaxFrame)
+      // If the frame clicked exceeds the virtual or explicit max, allocate additional
+      // virtual frames in the view and jump the user to the new page
+      if (newFrame > frameInfo.friB) {
+        const newMaxFrame = newFrame + pageFrameLength
+        this.getActiveComponent().getCurrentTimeline().setMaxFrame(newMaxFrame)
+        this.getActiveComponent().getCurrentTimeline().setVisibleFrameRange(newFrame, newMaxFrame)
+      }
     }
 
     this.getActiveComponent().getCurrentTimeline().seek(newFrame)

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1464,6 +1464,16 @@ class Timeline extends React.Component {
           }}>
           {this.renderComponentRows()}
         </div>
+        {experimentIsEnabled(Experiment.NativeTimelineScroll) &&
+          <div style={{
+            position: 'fixed',
+            top: 0,
+            bottom: 0,
+            width: this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth(),
+            backgroundColor: Palette.GRAY,
+            zIndex: zIndex.backgroundHelper.base
+          }}></div>
+        }
         {this.renderBottomControls()}
         <ExpressionInput
           ref='expressionInput'

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1026,83 +1026,143 @@ class Timeline extends React.Component {
   }
 
   renderTopControls () {
-    return (
-      <div
-        className='top-controls no-select'
-        style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
-          position: 'sticky',
-          top: 0,
-          height: this.state.rowHeight + 10,
-          width: '500vw',
-          verticalAlign: 'top',
-          fontSize: 10,
-          borderBottom: '1px solid ' + Palette.FATHER_COAL,
-          backgroundColor: Palette.COAL,
-          zIndex: 9999999999999
-        } : {
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          height: this.state.rowHeight + 10,
-          width: this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth() + this.getActiveComponent().getCurrentTimeline().getTimelinePixelWidth(),
-          verticalAlign: 'top',
-          fontSize: 10,
-          borderBottom: '1px solid ' + Palette.FATHER_COAL,
-          backgroundColor: Palette.COAL
-        })}>
+    if (experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+      return [
         <div
+          key='gauge-timekeeping-wrapper'
           className='gauge-timekeeping-wrapper'
-          style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
+          style={{
             position: 'fixed',
             top: 0,
             left: 0,
-            height: 'inherit',
-            width: this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth(),
+            height: 35,
+            width: this.getActiveComponent()
+              .getCurrentTimeline()
+              .getPropertiesPixelWidth(),
             backgroundColor: Palette.COAL,
-            zIndex: 99999999
-          } : {
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            height: 'inherit',
-            width: this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth()
-          })}>
-          <GaugeTimeReadout
-            reactParent={this}
-            timeline={this.getActiveComponent().getCurrentTimeline()} />
-        </div>
-        <div
-          id='gauge-box'
-          className='gauge-box'
+            zIndex: 999999999,
+            fontSize: 10
+          }}
+        >
+          <GaugeTimeReadout reactParent={this} timeline={this.getActiveComponent().getCurrentTimeline()} />
+        </div>,
+        <FrameGrid
+          key='frame-grid'
+          timeline={this.getActiveComponent().getCurrentTimeline()}
+          onShowFrameActionsEditor={this.showFrameActionsEditor}
+        />,
+        <div key='gauge' style={{
+          height: 35,
+          backgroundColor: Palette.COAL,
+          paddingTop: 12,
+          position: 'sticky',
+          top: 0,
+          marginLeft: this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth(),
+          width: '500vw',
+          zIndex: '9999',
+          fontSize: 10,
+          borderBottom: '1px solid ' + Palette.FATHER_COAL,
+          color: Palette.ROCK_MUTED
+        }}
           onMouseDown={(event) => {
             event.persist()
 
             this._doHandleMouseMovesInGauge = true
             this.disableTimelinePointerEvents()
             this.mouseMoveListener(event)
-          }}
+          }}>
+          <Gauge timeline={this.getActiveComponent().getCurrentTimeline()} />
+        </div>,
+        <ScrubberInterior
+          key='scrubber'
+          reactParent={this}
+          isScrubbing={this.getActiveComponent().getCurrentTimeline().isScrubberDragging()}
+          timeline={this.getActiveComponent().getCurrentTimeline()}
+        />,
+        <div key='durationModifier'>
+          {this.renderDurationModifier()}
+        </div>
+      ]
+    } else {
+      return (
+        <div
+          className='top-controls no-select'
           style={{
             position: 'absolute',
             top: 0,
-            left: this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth(),
-            width: experimentIsEnabled(Experiment.NativeTimelineScroll) ? undefined : this.getActiveComponent().getCurrentTimeline().getTimelinePixelWidth(),
-            height: 'inherit',
+            left: 0,
+            height: this.state.rowHeight + 10,
+            width:
+              this.getActiveComponent()
+                .getCurrentTimeline()
+                .getPropertiesPixelWidth() +
+              this.getActiveComponent()
+                .getCurrentTimeline()
+                .getTimelinePixelWidth(),
             verticalAlign: 'top',
-            paddingTop: 12,
-            color: Palette.ROCK_MUTED }}>
-          <FrameGrid
-            timeline={this.getActiveComponent().getCurrentTimeline()}
-            onShowFrameActionsEditor={this.showFrameActionsEditor} />
-          <Gauge
-            timeline={this.getActiveComponent().getCurrentTimeline()} />
-          <ScrubberInterior
-            reactParent={this}
-            isScrubbing={this.getActiveComponent().getCurrentTimeline().isScrubberDragging()}
-            timeline={this.getActiveComponent().getCurrentTimeline()} />
+            fontSize: 10,
+            borderBottom: '1px solid ' + Palette.FATHER_COAL,
+            backgroundColor: Palette.COAL
+          }}
+        >
+          <div
+            className='gauge-timekeeping-wrapper'
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              height: 'inherit',
+              width: this.getActiveComponent()
+                .getCurrentTimeline()
+                .getPropertiesPixelWidth()
+            }}
+          >
+            <GaugeTimeReadout reactParent={this} timeline={this.getActiveComponent().getCurrentTimeline()} />
+          </div>
+          <div>
+            <div
+              id='gauge-box'
+              className='gauge-box'
+              onMouseDown={(event) => {
+                event.persist()
+
+                this._doHandleMouseMovesInGauge = true
+                this.disableTimelinePointerEvents()
+                this.mouseMoveListener(event)
+              }}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: this.getActiveComponent()
+                  .getCurrentTimeline()
+                  .getPropertiesPixelWidth(),
+                width: this.getActiveComponent()
+                  .getCurrentTimeline()
+                  .getTimelinePixelWidth(),
+                height: 'inherit',
+                verticalAlign: 'top',
+                paddingTop: 12,
+                color: Palette.ROCK_MUTED
+              }}
+            >
+              <FrameGrid
+                timeline={this.getActiveComponent().getCurrentTimeline()}
+                onShowFrameActionsEditor={this.showFrameActionsEditor}
+              />
+              <Gauge timeline={this.getActiveComponent().getCurrentTimeline()} />
+              <ScrubberInterior
+                reactParent={this}
+                isScrubbing={this.getActiveComponent()
+                  .getCurrentTimeline()
+                  .isScrubberDragging()}
+                timeline={this.getActiveComponent().getCurrentTimeline()}
+              />
+            </div>
+          </div>
+          {this.renderDurationModifier()}
         </div>
-        {this.renderDurationModifier()}
-      </div>
-    )
+      )
+    }
   }
 
   mouseMoveListener (evt) {
@@ -1300,7 +1360,7 @@ class Timeline extends React.Component {
           color: Palette.ROCK,
           top: 0,
           left: 0,
-          height: 'calc(100% - 45px)',
+          height: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 'calc(100% - 25px)' : 'calc(100% - 45px)',
           width: '100%',
           overflow: experimentIsEnabled(Experiment.NativeTimelineScroll) ? 'auto' : 'hidden'
         }}>

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -545,7 +545,7 @@ class Timeline extends React.Component {
 
     items.push({
       label: (numSelectedKeyframes < 3) ? 'Make Tween' : 'Make Tweens',
-      enabled: type === 'keyframe-segment',
+      enabled: type === 'keyframe-segment' && (model && model.isTweenable()),
       submenu: (type === 'keyframe-segment') && this.curvesMenu(curve, (event, curveName) => {
         this.getActiveComponent().joinSelectedKeyframes(curveName, { from: 'timeline' })
       })

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -151,10 +151,29 @@ class Timeline extends React.Component {
     this.mounted = true
 
     if (experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
-      const marquee = new Marquee({area: document.querySelector('#property-rows'),
-        callback: (event, area) => {
-          this.getActiveComponent().getCurrentTimeline().notifyMarqueeSelection(area)
-        }})
+      const marquee = new Marquee({
+        area: document.querySelector('#property-rows'),
+        onStart: event => {
+          // this.onGaugeMouseDown(event)
+        },
+        onFinish: (event, area) => {
+          Keyframe.all().forEach(keyframe => {
+            const keyframeView = keyframe._viewPosition
+
+            if (
+              keyframeView.x < area.x + area.width &&
+              keyframeView.x + keyframeView.width > area.x &&
+              keyframeView.y < area.y + area.height &&
+              keyframeView.height + keyframeView.y > area.y
+            ) {
+              keyframe.select()
+              keyframe.activate()
+              keyframe.setBodySelected()
+              keyframe.row.expand({from: 'timeline'})
+            }
+          })
+        }
+      })
 
       marquee.start()
     }
@@ -1313,7 +1332,7 @@ class Timeline extends React.Component {
                                 showEventHandlersEditor={(...args) => {
                                   this.showEventHandlersEditor(...args)
                                 }}
-                                />
+                              />
                             </div>
                             {provided.placeholder}
                           </div>

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -807,8 +807,13 @@ class Timeline extends React.Component {
   }
 
   handleHorizontalScroll (origDelta) {
-    // const motionDelta = Math.round((origDelta ? origDelta < 0 ? -1 : 1 : 0) * (Math.log(Math.abs(origDelta) + 1) * 2))
-    // this.getActiveComponent().getCurrentTimeline().updateVisibleFrameRangeByDelta(motionDelta)
+    if (experimentIsEnabled(Experiment.NativeTimelineScroll)) {
+      const timeline = this.getActiveComponent().getCurrentTimeline()
+      timeline.setScrollLeft(timeline.getScrollLeft() + origDelta)
+    } else {
+      const motionDelta = Math.round((origDelta ? origDelta < 0 ? -1 : 1 : 0) * (Math.log(Math.abs(origDelta) + 1) * 2))
+      this.getActiveComponent().getCurrentTimeline().updateVisibleFrameRangeByDelta(motionDelta)
+    }
   }
 
   handleRequestElementCoordinates ({ selector, webview }) {

--- a/packages/haiku-timeline/src/components/TimelineRangeScrollbarPlayheadIndicator.js
+++ b/packages/haiku-timeline/src/components/TimelineRangeScrollbarPlayheadIndicator.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import Palette from 'haiku-ui-common/lib/Palette'
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
 import lodash from 'lodash'
 
 const KNOB_RADIUS = 5
@@ -50,7 +51,7 @@ export default class TimelineRangeScrollbarPlayheadIndicator extends React.Compo
       <div
         id='timeline-playhead-indicator-container'
         style={{
-          width: this.props.timeline.getPropertiesPixelWidth() + this.props.timeline.getTimelinePixelWidth() - 35,
+          width: experimentIsEnabled(Experiment.NativeTimelineScroll) ? undefined : this.props.timeline.getPropertiesPixelWidth() + this.props.timeline.getTimelinePixelWidth() - 35,
           left: 10,
           position: 'relative'
         }}>

--- a/packages/haiku-timeline/src/components/TimelineRangeScrollbarPlayheadIndicator.js
+++ b/packages/haiku-timeline/src/components/TimelineRangeScrollbarPlayheadIndicator.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Palette from 'haiku-ui-common/lib/Palette'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 import lodash from 'lodash'
 
 const KNOB_RADIUS = 5

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -100,6 +100,9 @@ export default class TransitionBody extends React.Component {
       this.teardownKeyframeUpdateReceiver = keyframe.registerUpdateReceiver(this.props.id, (what) => {
         this.handleUpdate(what)
       })
+      this.teardownNextKeyframeUpdateReceiver = keyframe.next().registerUpdateReceiver(this.props.id, (what) => {
+        this.handleUpdate(what)
+      })
     }
   }
 
@@ -110,6 +113,7 @@ export default class TransitionBody extends React.Component {
   componentWillUnmount () {
     this.mounted = false
     this.teardownKeyframeUpdateReceiver()
+    this.teardownNextKeyframeUpdateReceiver()
   }
 
   handleUpdate (what, ...args) {

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -105,37 +105,15 @@ export default class TransitionBody extends React.Component {
 
   componentDidMount () {
     this.mounted = true
-    if (experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
-      this.props.timeline.on('update', this.handleUpdate)
-    }
   }
 
   componentWillUnmount () {
     this.mounted = false
     this.teardownKeyframeUpdateReceiver()
-    if (experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
-      this.props.timeline.removeListener('update', this.handleUpdate)
-    }
   }
 
   handleUpdate (what, ...args) {
     if (!this.mounted) return null
-    if (experimentIsEnabled(Experiment.TimelineMarqueeSelection)) {
-      if (what === 'marquee-selection') {
-        const containerRect = this.position
-        const elementRect = args[0]
-        if (
-          containerRect.x < elementRect.x + elementRect.width &&
-          containerRect.x + containerRect.width > elementRect.x &&
-          containerRect.y < elementRect.y + elementRect.height &&
-          containerRect.height + containerRect.y > elementRect.y
-        ) {
-          this.props.keyframe.select()
-          this.props.keyframe.activate()
-          this.props.keyframe.setBodySelected()
-        }
-      }
-    }
     if (
       what === 'keyframe-activated' ||
       what === 'keyframe-deactivated' ||
@@ -196,7 +174,7 @@ export default class TransitionBody extends React.Component {
           ref={(domElement) => {
             this[uniqueKey] = domElement
             if (experimentIsEnabled(Experiment.TimelineMarqueeSelection) && domElement) {
-              this.position = domElement.getBoundingClientRect()
+              this.props.keyframe.storeViewPosition(domElement.getBoundingClientRect())
             }
           }}
           onContextMenu={(ctxMenuEvent) => {

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -249,7 +249,8 @@ export default class TransitionBody extends React.Component {
             height: '100%',
             borderRadius: 5,
             paddingTop: 6,
-            overflow: breakingBounds ? 'visible' : 'hidden'
+            overflow: breakingBounds ? 'visible' : 'hidden',
+            pointerEvents: 'none'
           }}>
             <CurveSVG
               id={uniqueKey}

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -136,8 +136,12 @@ export default class TransitionBody extends React.Component {
     const frameInfo = this.props.timeline.getFrameInfo()
 
     const uniqueKey = this.props.keyframe.getUniqueKey()
-    const pxOffsetLeft = this.props.keyframe.getPixelOffsetLeft(frameInfo.friA, frameInfo.pxpf, frameInfo.mspf)
-    const pxOffsetRight = this.props.keyframe.getPixelOffsetRight(frameInfo.friA, frameInfo.pxpf, frameInfo.mspf)
+    const pxOffsetLeft = experimentIsEnabled(Experiment.NativeTimelineScroll)
+      ? this.props.keyframe.getPixelOffsetLeft(0, frameInfo.pxpf, frameInfo.mspf)
+      : this.props.keyframe.getPixelOffsetLeft(frameInfo.friA, frameInfo.pxpf, frameInfo.mspf)
+    const pxOffsetRight = experimentIsEnabled(Experiment.NativeTimelineScroll)
+      ? this.props.keyframe.getPixelOffsetRight(0, frameInfo.pxpf, frameInfo.mspf)
+      : this.props.keyframe.getPixelOffsetRight(frameInfo.friA, frameInfo.pxpf, frameInfo.mspf)
 
     const curve = this.props.keyframe.getCurveCapitalized()
 

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -6,7 +6,7 @@ import TimelineDraggable from './TimelineDraggable'
 import KeyframeSVG from 'haiku-ui-common/lib/react/icons/KeyframeSVG'
 import Globals from 'haiku-ui-common/lib/Globals'
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu'
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments'
 
 import {
   EaseInBackSVG,

--- a/packages/haiku-timeline/src/components/styles/zIndex.js
+++ b/packages/haiku-timeline/src/components/styles/zIndex.js
@@ -28,6 +28,9 @@ const zIndex = {
   timekeepingWrapper: {
     base: 11
   },
+  backgroundHelper: {
+    base: 4
+  },
 
   // Heading row (name of the row, drag handler, etc)
   headingRow: {
@@ -47,7 +50,7 @@ const zIndex = {
 
   // Property row
   propertyRowHeading: {
-    base: 4
+    base: 5
   },
   propertyRow: {
     base: 1

--- a/packages/haiku-timeline/src/components/styles/zIndex.js
+++ b/packages/haiku-timeline/src/components/styles/zIndex.js
@@ -1,0 +1,62 @@
+const zIndex = {
+  // Top controls
+  gauge: {
+    base: 2
+  },
+  scrubber: {
+    base: 1
+  },
+
+  // Heading row (name of the row, drag handler, etc)
+  headingRow: {
+    base: 3
+  },
+
+  // Cluster row (a row with sub-items that is collapsed)
+  clusterRowHeading: {
+    base: 2
+  },
+  clusterRow: {
+    base: 1
+  },
+
+  // Property row
+  propertyRowHeading: {
+    base: 2
+  },
+  propertyRow: {
+    base: 1
+  },
+
+  //
+  segmentsBox: {
+    base: 1
+  },
+
+  // Frames/seconds switcher block
+  timekeepingWrapper: {
+    base: 4
+  },
+
+  // Vertial line simulating a shadow between the properties and the tweens
+  scrollShadow: {
+    base: 1
+  },
+
+  // Box with the expression input
+  expressionInput: {
+    base: 10
+  },
+
+  // Box with the marquee
+  marquee: {
+    base: 10
+  },
+
+  // Overlay blocking all actions if preview mode is enabled
+  previewModeBlocker: {
+    base: 20
+  }
+}
+
+export default zIndex

--- a/packages/haiku-timeline/src/components/styles/zIndex.js
+++ b/packages/haiku-timeline/src/components/styles/zIndex.js
@@ -37,7 +37,7 @@ const zIndex = {
     base: 10
   },
   headingRowExpanded: {
-    base: 10,
+    base: 10
   },
 
   // Cluster row (a row with sub-items that is collapsed)

--- a/packages/haiku-timeline/src/components/styles/zIndex.js
+++ b/packages/haiku-timeline/src/components/styles/zIndex.js
@@ -1,3 +1,22 @@
+/*
+ * This object tries to be a canonical source for z-index management
+ * in the timeline.
+ *
+  * Since z-index tends to be a mess because we can have different
+  * [stacking contexts][1], the idea is to add a new key for every stacking context,
+  * with a `base` z-index. Elements contained inside of a stacking context should
+  * keys of a nested object, for example:
+  *
+  * ```
+  * stackingContext: {
+  *   base: 1,
+  *   elementInsideStackingContext: 11,
+  *   nestedStackingContext: {
+  *     base: 12
+  *   }
+  * }
+ */
+
 const zIndex = {
   // Top controls
   gauge: {
@@ -7,12 +26,15 @@ const zIndex = {
     base: 4
   },
   timekeepingWrapper: {
-    base: 6
+    base: 11
   },
 
   // Heading row (name of the row, drag handler, etc)
   headingRow: {
     base: 10
+  },
+  headingRowExpanded: {
+    base: 10,
   },
 
   // Cluster row (a row with sub-items that is collapsed)

--- a/packages/haiku-timeline/src/components/styles/zIndex.js
+++ b/packages/haiku-timeline/src/components/styles/zIndex.js
@@ -4,17 +4,20 @@ const zIndex = {
     base: 2
   },
   scrubber: {
-    base: 1
+    base: 4
+  },
+  timekeepingWrapper: {
+    base: 6
   },
 
   // Heading row (name of the row, drag handler, etc)
   headingRow: {
-    base: 3
+    base: 10
   },
 
   // Cluster row (a row with sub-items that is collapsed)
   clusterRowHeading: {
-    base: 2
+    base: 5
   },
   clusterRow: {
     base: 1
@@ -22,7 +25,7 @@ const zIndex = {
 
   // Property row
   propertyRowHeading: {
-    base: 2
+    base: 4
   },
   propertyRow: {
     base: 1
@@ -32,10 +35,8 @@ const zIndex = {
   segmentsBox: {
     base: 1
   },
-
-  // Frames/seconds switcher block
-  timekeepingWrapper: {
-    base: 4
+  collapsedSegments: {
+    base: 1
   },
 
   // Vertial line simulating a shadow between the properties and the tweens

--- a/packages/haiku-timeline/src/electron.js
+++ b/packages/haiku-timeline/src/electron.js
@@ -46,6 +46,14 @@ function createWindow () {
 
   if (process.env.DEV === '1') {
     mainWindow.webContents.openDevTools()
+    // const { default: installExtension, REACT_DEVELOPER_TOOLS } = require('electron-devtools-installer')
+    // installExtension(REACT_DEVELOPER_TOOLS)
+    //     .then((name) => console.log(`Added Extension:  ${name}`))
+    //     .catch((err) => console.log('An error occurred: ', err))
+
+    // installExtension('jigamimbjojkdgnlldajknogfgncplbh')
+    //     .then((name) => console.log(`Added Extension:  ${name}`))
+    //     .catch((err) => console.log('An error occurred: ', err))
   }
 
   mainWindow.on('closed', () => { mainWindow = null })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5548,25 +5548,6 @@ growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
 
-haiku-testing@3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/haiku-testing/-/haiku-testing-3.4.5.tgz#4942a4d5066c3d2746104986c877323c8bb984c5"
-  dependencies:
-    "@types/node" "8.9.4"
-    "@types/tape" "^4.2.32"
-    cross-env "^5.1.6"
-    istanbul-reporter-cobertura-haiku "^1.0.1"
-    nyc "^11.8.0"
-    sinon "^5.0.10"
-    tap-spec "^4.1.2"
-    tape "^4.9.0"
-    ts-node "^6.1.0"
-    tsconfig-paths "^3.3.2"
-    tslint "^5.10.0"
-    tslint-config-haiku "^1.0.3"
-    typescript "^2.9.1"
-    xml-js "^1.6.4"
-
 handlebars@^4.0.1, handlebars@^4.0.3:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
@@ -11469,7 +11450,7 @@ tslint-config-airbnb@^5.8.0:
     tslint-eslint-rules "^5.3.1"
     tslint-microsoft-contrib "~5.0.1"
 
-tslint-config-haiku@^1.0.15, tslint-config-haiku@^1.0.3:
+tslint-config-haiku@^1.0.15:
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/tslint-config-haiku/-/tslint-config-haiku-1.0.15.tgz#a5800936e6a99f8f62d0a0a84b28d1edd6cc33a4"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5548,6 +5548,25 @@ growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
 
+haiku-testing@3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/haiku-testing/-/haiku-testing-3.4.5.tgz#4942a4d5066c3d2746104986c877323c8bb984c5"
+  dependencies:
+    "@types/node" "8.9.4"
+    "@types/tape" "^4.2.32"
+    cross-env "^5.1.6"
+    istanbul-reporter-cobertura-haiku "^1.0.1"
+    nyc "^11.8.0"
+    sinon "^5.0.10"
+    tap-spec "^4.1.2"
+    tape "^4.9.0"
+    ts-node "^6.1.0"
+    tsconfig-paths "^3.3.2"
+    tslint "^5.10.0"
+    tslint-config-haiku "^1.0.3"
+    typescript "^2.9.1"
+    xml-js "^1.6.4"
+
 handlebars@^4.0.1, handlebars@^4.0.3:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
@@ -11450,7 +11469,7 @@ tslint-config-airbnb@^5.8.0:
     tslint-eslint-rules "^5.3.1"
     tslint-microsoft-contrib "~5.0.1"
 
-tslint-config-haiku@^1.0.15:
+tslint-config-haiku@^1.0.15, tslint-config-haiku@^1.0.3:
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/tslint-config-haiku/-/tslint-config-haiku-1.0.15.tgz#a5800936e6a99f8f62d0a0a84b28d1edd6cc33a4"
   dependencies:


### PR DESCRIPTION
Not OK to merge yet.

Short review.

Summary of changes:

A lot of changes in this PR (sorry about that) but all of them very carefully hidden behind feature flags (@stristr will be happy!).

There's still some work to be done, please hold a couple of hours until it's ready to be reviewed/tested, but it is almost there.

- Timeline marquee selection
- When selecting element on stage, *nicely* scroll to the corresponding row in the timeline?
- Special-casing + disabling `bool` and `string` tweens
- Perf: Horizontal scrolling + timeline-frame-range
- Perf: Smoothness of ticker playback
- General refactors of the timeline CSS

Regressions to look for:

- Timeline in general

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
