### PR TITLE
Timeline fixes outside refactors

### DIFF
--- a/packages/haiku-timeline/src/components/PropertyInputField.js
+++ b/packages/haiku-timeline/src/components/PropertyInputField.js
@@ -127,8 +127,9 @@ class PropertyInputFieldValueDisplay extends React.Component {
 
   render () {
     const valueDescriptor = this.props.row.getPropertyValueDescriptor()
+
     return (
-      <span>{remapPrettyValue(valueDescriptor.prettyValue)}</span>
+      <span>{remapPrettyValue(valueDescriptor.prettyValue)} {valueDescriptor.valueUnit}</span>
     )
   }
 }

--- a/packages/haiku-timeline/src/components/PropertyRow.js
+++ b/packages/haiku-timeline/src/components/PropertyRow.js
@@ -197,6 +197,7 @@ export default class PropertyRow extends React.Component {
             })
           }}
           className='property-timeline-segments-box'
+          onDoubleClick={this.props.onDoubleClickToMoveGauge}
           onMouseDown={() => {
             this.props.row.activate()
           }}

--- a/packages/haiku-timeline/src/components/RowManager.js
+++ b/packages/haiku-timeline/src/components/RowManager.js
@@ -52,6 +52,7 @@ class RowManager extends React.PureComponent {
     if (row.isProperty()) {
       return (
         <PropertyRow
+          onDoubleClickToMoveGauge={this.props.onDoubleClickToMoveGauge}
           key={row.getUniqueKey()}
           rowHeight={this.props.rowHeight}
           timeline={activeComponent.getCurrentTimeline()}

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -605,6 +605,7 @@ class Timeline extends React.Component {
         const timeline = this.getActiveComponent().getCurrentTimeline()
         const frameInfo = timeline.getFrameInfo()
         const ms = Math.round(timeline.getHoveredFrame() * frameInfo.mspf)
+        Keyframe.deselectAndDeactivateAllKeyframes()
         model.createKeyframe(undefined, ms, { from: 'timeline' })
       }
     })

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -106,6 +106,7 @@ class Timeline extends React.Component {
     this.mouseMoveListener = this.mouseMoveListener.bind(this)
     this.mouseUpListener = this.mouseUpListener.bind(this)
     this.onGaugeMouseDown = this.onGaugeMouseDown.bind(this)
+    this.moveGaugeOnDoubleClick = this.moveGaugeOnDoubleClick.bind(this)
 
     this.handleCutDebounced = lodash.debounce(this.handleCut.bind(this), MENU_ACTION_DEBOUNCE_TIME, {leading: true, trailing: false})
     this.handleCopyDebounced = lodash.debounce(this.handleCopy.bind(this), MENU_ACTION_DEBOUNCE_TIME, {leading: true, trailing: false})
@@ -1354,6 +1355,12 @@ class Timeline extends React.Component {
     )
   }
 
+  moveGaugeOnDoubleClick (dblClickEvent) {
+    this._doHandleMouseMovesInGauge = true
+    this.mouseMoveListener(dblClickEvent)
+    this._doHandleMouseMovesInGauge = false
+  }
+
   renderComponentRows () {
     const groups = this.getActiveComponent().getDisplayableRowsGroupedByElementInZOrder()
 
@@ -1417,6 +1424,7 @@ class Timeline extends React.Component {
                                 showEventHandlersEditor={(...args) => {
                                   this.showEventHandlersEditor(...args)
                                 }}
+                                onDoubleClickToMoveGauge={this.moveGaugeOnDoubleClick}
                               />
                             </div>
                             {provided.placeholder}


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

A series of allegedly safe to merge fixes/feats, _totally unrelated to the timeline refactors_, this includes:

- [ux: double click empty space in timeline to move scrubber to that point in time](https://app.asana.com/0/713061630135205/699216096995318)
- [Keyframe created within constant segment results in quirky selection state thereafter](https://app.asana.com/0/713061630135205/667246707931774)
- [Add units to right side of input when applicable](https://app.asana.com/0/713061630135205/676470147357791)

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
