### PR TITLE
chore: add title attributes to elements in the UI

### DIFF
--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -353,7 +353,7 @@ class ProjectBrowser extends React.Component {
               option: 'show-changelog',
             });
           }}>
-          <span style={DASH_STYLES.popover.icon} title="Show Changelog">
+          <span style={DASH_STYLES.popover.icon} title="Show changelog">
             <PresentIconSVG />
           </span>
           <span style={[DASH_STYLES.popover.text, DASH_STYLES.upcase]}>What's New</span>

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -353,7 +353,7 @@ class ProjectBrowser extends React.Component {
               option: 'show-changelog',
             });
           }}>
-          <span style={DASH_STYLES.popover.icon}>
+          <span style={DASH_STYLES.popover.icon} title="Show Changelog">
             <PresentIconSVG />
           </span>
           <span style={[DASH_STYLES.popover.text, DASH_STYLES.upcase]}>What's New</span>

--- a/packages/haiku-creator/src/react/components/ProjectThumbnail.js
+++ b/packages/haiku-creator/src/react/components/ProjectThumbnail.js
@@ -110,6 +110,7 @@ class ProjectThumbnail extends React.Component {
             {this.props.projectName}
           </span>
           <span
+            title="Show Project options"
             style={[DASH_STYLES.titleOptions, {transform: 'translateY(1px)'}]}
             onClick={() => {
               this.setState({

--- a/packages/haiku-creator/src/react/components/ProjectThumbnail.js
+++ b/packages/haiku-creator/src/react/components/ProjectThumbnail.js
@@ -110,7 +110,7 @@ class ProjectThumbnail extends React.Component {
             {this.props.projectName}
           </span>
           <span
-            title="Show Project options"
+            title="Show project options"
             style={[DASH_STYLES.titleOptions, {transform: 'translateY(1px)'}]}
             onClick={() => {
               this.setState({

--- a/packages/haiku-creator/src/react/components/SideBar.js
+++ b/packages/haiku-creator/src/react/components/SideBar.js
@@ -129,13 +129,13 @@ class SideBar extends React.Component {
             this.props.activeNav === 'state_inspector' && STYLES.activeSecond,
             this.props.activeNav === 'component_info_inspector' && STYLES.activeThird,
           ]} />
-          <div key="library"
+          <div key="library" title="Show Library panel"
             style={[STYLES.btnNav, this.props.activeNav === 'library' && STYLES.activeBtnNav]}
             onClick={() => this.props.switchActiveNav('library')}>
             <LibraryIconSVG color={Palette.ROCK} />
           </div>
           {(activeComponent)
-            ? <div id="state-inspector" key="state_inspector"
+            ? <div id="state-inspector" key="state_inspector" title="Show State Inspector panel"
               style={[STYLES.btnNav, this.props.activeNav === 'state_inspector' && STYLES.activeBtnNav]}
               onClick={() => this.props.switchActiveNav('state_inspector')}>
               <StateInspectorIconSVG color={Palette.ROCK} />

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -662,6 +662,7 @@ class StageTitleBar extends React.Component {
           <button
             key="show-event-handlers-editor-button"
             id="show-event-handlers-editor-button"
+            title="Edit Element Actions"
             onClick={this.handleShowEventHandlersEditor}
             style={[
               BTN_STYLES.btnIcon,
@@ -722,6 +723,7 @@ class StageTitleBar extends React.Component {
         <button
           key="save"
           id="publish"
+          title="Publish project"
           onClick={this.handleSaveSnapshotClick}
           disabled={!this.props.isTimelineReady && this.state.snapshotSyndicated === false}
           style={[

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -662,7 +662,7 @@ class StageTitleBar extends React.Component {
           <button
             key="show-event-handlers-editor-button"
             id="show-event-handlers-editor-button"
-            title="Edit Element Actions"
+            title="Edit element Actions"
             onClick={this.handleShowEventHandlersEditor}
             style={[
               BTN_STYLES.btnIcon,

--- a/packages/haiku-creator/src/react/components/library/FileImporter.js
+++ b/packages/haiku-creator/src/react/components/library/FileImporter.js
@@ -132,7 +132,7 @@ class FileImporter extends React.PureComponent {
         body={this.popoverBody}
       >
         <button
-          title="Import File"
+          title="Import file"
           style={STYLES.button}
           onClick={() => {
             this.showPopover();

--- a/packages/haiku-creator/src/react/components/library/FileImporter.js
+++ b/packages/haiku-creator/src/react/components/library/FileImporter.js
@@ -132,6 +132,7 @@ class FileImporter extends React.PureComponent {
         body={this.popoverBody}
       >
         <button
+          title="Import File"
           style={STYLES.button}
           onClick={() => {
             this.showPopover();

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -272,7 +272,7 @@ export default class ComponentHeadingRow extends React.Component {
                 {SyncIconSVG({color: this.props.row.element.isLocked() ? Palette.RED_DARKER : Palette.DARK_ROCK})}
               </div>
               <div
-                title="Edit element Actions"
+                title='Edit element Actions'
                 className='event-handler-triggerer-button'
                 style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {} : {
                   width: 10,
@@ -290,7 +290,7 @@ export default class ComponentHeadingRow extends React.Component {
                   : ''}
               </div>
               <div
-                title="Add property"
+                title='Add property'
                 className='property-manager-button'
                 style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {} : {
                   width: 10,

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -272,6 +272,7 @@ export default class ComponentHeadingRow extends React.Component {
                 {SyncIconSVG({color: this.props.row.element.isLocked() ? Palette.RED_DARKER : Palette.DARK_ROCK})}
               </div>
               <div
+                title="Edit element Actions"
                 className='event-handler-triggerer-button'
                 style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {} : {
                   width: 10,
@@ -289,6 +290,7 @@ export default class ComponentHeadingRow extends React.Component {
                   : ''}
               </div>
               <div
+                title="Add property"
                 className='property-manager-button'
                 style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {} : {
                   width: 10,


### PR DESCRIPTION
OK to merge.

Very short review.

Summary of changes:

I did this during yarn installs, mostly motivated after presenting Haiku to a friend this weekend, he tried multiple times to hover over elements for the usual help tooltip, so I wondered that adding a couple of title tags here and there is good enough for now.

Please feel free to edit for grammar/wording or disregard this completely!

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
