### PR TITLE
Snapping, align & distribute

### DIFF
--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -10,7 +10,7 @@ import {BTN_STYLES} from '../styles/btnShared';
 import Toggle from './Toggle';
 import {ShareModal} from 'haiku-ui-common/lib/react/ShareModal';
 import {
-  ComponentIconSVG, ConnectionIconSVG, DangerIconSVG, EventsBoltIcon, PublishSnapshotSVG, WarningIconSVG,
+  ComponentIconSVG, ConnectionIconSVG, DangerIconSVG, EventsBoltIcon, PublishSnapshotSVG, WarningIconSVG, AlignDistributeIcons,
 } from 'haiku-ui-common/lib/react/OtherIcons';
 import {ExporterFormat} from 'haiku-sdk-creator/lib/exporter';
 import * as Element from 'haiku-serialization/src/bll/Element';
@@ -138,6 +138,21 @@ const STYLES = {
     height: 3,
     backgroundColor: Palette.LIGHTEST_PINK,
   },
+  alignDistributeBtn: {
+    width: 28,
+  },
+  alignDistributeIconWrapper: {
+    transform: 'scale(0.65)',
+    display: 'block',
+    marginTop: -7,
+  },
+  alignPanel: {
+    padding: '10px 5px 10px 13px',
+    position: 'fixed',
+    zIndex: 100000,
+    backgroundColor: Palette.COAL,
+    borderRadius: 3,
+  },
 };
 
 const SNAPSHOT_SAVE_RESOLUTION_STRATEGIES = {
@@ -160,6 +175,7 @@ class StageTitleBar extends React.Component {
     this.handleShowEventHandlersEditor = this.handleShowEventHandlersEditor.bind(this);
     this.handleConglomerateComponent = this.handleConglomerateComponent.bind(this);
     this.handleShowProjectLocationToast = this.handleShowProjectLocationToast.bind(this);
+    this.handleShowAlignPanel = this.handleShowAlignPanel.bind(this);
     this.handleGlobalMenuSave = this.handleGlobalMenuSave.bind(this);
     this.handleSaveOnRawCodeEditor = this.handleSaveOnRawCodeEditor.bind(this);
     this.handleSaveOnGlass = this.handleSaveOnGlass.bind(this);
@@ -264,6 +280,15 @@ class StageTitleBar extends React.Component {
     }
 
     this.handleSaveSnapshotClick();
+  }
+
+  handleShowAlignPanel () {
+    const toggleBbox = this.refs.alignPanelButton.getBoundingClientRect();
+    const basePoint = {x: toggleBbox.left, y: toggleBbox.bottom};
+    this.setState({
+      alignPanelShown: !this.state.alignPanelShown,
+      alignPanelBasePoint: basePoint,
+    });
   }
 
   handleShowProjectLocationToast () {
@@ -371,6 +396,18 @@ class StageTitleBar extends React.Component {
 
   clearSyndicationChecks () {
     clearInterval(this._performSyndicationCheckInterval);
+  }
+
+  performAlign (xEdge, yEdge) {
+    const toStage = this.refs.to_stage_toggle && this.refs.to_stage_toggle.checked; // TODO:  get selection value of checkbox
+    const proxy = this.fetchProxyElementForSelection();
+    proxy.align(xEdge, yEdge, toStage);
+  }
+
+  performDistribute (xEdge, yEdge) {
+    const toStage = this.refs.to_stage_toggle && this.refs.to_stage_toggle.checked;
+    const proxy = this.fetchProxyElementForSelection();
+    proxy.distribute(xEdge, yEdge, toStage);
   }
 
   performSyndicationCheck () {
@@ -577,6 +614,18 @@ class StageTitleBar extends React.Component {
     return proxy && (proxy.doesManageSingleElement() || proxy.hasNothingInSelection());
   }
 
+  isAlignPanelAvailable () {
+    // This would show the align panel only when elements are selected:
+    // const proxy = this.fetchProxyElementForSelection();
+    // return proxy && !proxy.hasNothingInSelection();
+    // But it feels better (in zb's opinion at authoring time) to keep it shown at all times glass is shown
+    return this.props.showGlass;
+  }
+
+  shouldShowAlignPanel () {
+    return this.state.alignPanelShown && !this.state.showSharePopover && !this.props.isPreviewMode && this.props.showGlass;
+  }
+
   handleShowEventHandlersEditor () {
     if (this.isEventHandlersEditorAvailable()) {
       const element = this.getProxySelectionElement();
@@ -669,6 +718,194 @@ class StageTitleBar extends React.Component {
             ]}>
             <EventsBoltIcon color={this.getEventHandlersEditorButtonColor()} />
           </button>
+        }
+
+        {this.isAlignPanelAvailable() &&
+          <button
+            key="show-align-panel-button"
+            id="show-align-panel-button"
+            onClick={this.handleShowAlignPanel}
+            ref="alignPanelButton"
+            style={[
+              BTN_STYLES.btnIcon,
+              BTN_STYLES.leftBtns,
+              STYLES.alignDistributeBtn,
+            ]}>
+            <span style={[STYLES.alignDistributeIconWrapper]}>
+              <AlignDistributeIcons.AlignVLeft color={this.getEventHandlersEditorButtonColor()} />
+            </span>
+          </button>
+        }
+
+        {this.shouldShowAlignPanel() &&
+          <div
+            style={[
+              STYLES.alignPanel,
+              {
+                top: this.state.alignPanelBasePoint.y,
+                left: this.state.alignPanelBasePoint.x,
+              },
+            ]}
+          >
+            <div style={{margin: '0 3px 2px 0'}}>Align:</div>
+            <div style={{height: 27}}>
+              <button
+                onClick={this.performAlign.bind(this, 0, undefined)}
+                key="btn-align-v-left"
+                style={[
+                  BTN_STYLES.btnIcon,
+                  BTN_STYLES.leftBtns,
+                  STYLES.alignDistributeBtn,
+                ]}>
+                <span style={[STYLES.alignDistributeIconWrapper]}>
+                  <AlignDistributeIcons.AlignVLeft color={this.getEventHandlersEditorButtonColor()} />
+                </span>
+              </button>
+              <button
+                onClick={this.performAlign.bind(this, .5, undefined)}
+                key="btn-align-v-mid"
+                style={[
+                  BTN_STYLES.btnIcon,
+                  BTN_STYLES.leftBtns,
+                  STYLES.alignDistributeBtn,
+                ]}>
+                <span style={[STYLES.alignDistributeIconWrapper]}>
+                  <AlignDistributeIcons.AlignVMid color={this.getEventHandlersEditorButtonColor()} />
+                </span>
+              </button>
+              <button
+                onClick={this.performAlign.bind(this, 1, undefined)}
+                key="btn-align-v-right"
+                style={[
+                  BTN_STYLES.btnIcon,
+                  BTN_STYLES.leftBtns,
+                  STYLES.alignDistributeBtn,
+                  {marginRight: 18},
+                ]}>
+                <span style={[STYLES.alignDistributeIconWrapper]}>
+                  <AlignDistributeIcons.AlignVRight color={this.getEventHandlersEditorButtonColor()} />
+                </span>
+              </button>
+              <button
+                onClick={this.performAlign.bind(this, undefined, 0)}
+                key="btn-align-h-top"
+                style={[
+                  BTN_STYLES.btnIcon,
+                  BTN_STYLES.leftBtns,
+                  STYLES.alignDistributeBtn,
+                ]}>
+                <span style={[STYLES.alignDistributeIconWrapper]}>
+                  <AlignDistributeIcons.AlignHTop color={this.getEventHandlersEditorButtonColor()} />
+                </span>
+              </button>
+              <button
+                onClick={this.performAlign.bind(this, undefined, .5)}
+                key="btn-align-h-mid"
+                style={[
+                  BTN_STYLES.btnIcon,
+                  BTN_STYLES.leftBtns,
+                  STYLES.alignDistributeBtn,
+                ]}>
+                <span style={[STYLES.alignDistributeIconWrapper]}>
+                  <AlignDistributeIcons.AlignHMid color={this.getEventHandlersEditorButtonColor()} />
+                </span>
+              </button>
+              <button
+                onClick={this.performAlign.bind(this, undefined, 1)}
+                key="btn-align-h-bottom"
+                style={[
+                  BTN_STYLES.btnIcon,
+                  BTN_STYLES.leftBtns,
+                  STYLES.alignDistributeBtn,
+                ]}>
+                <span style={[STYLES.alignDistributeIconWrapper]}>
+                  <AlignDistributeIcons.AlignHBottom color={this.getEventHandlersEditorButtonColor()} />
+                </span>
+              </button>
+            </div>
+            <div style={{margin: '5px 3px 2px 0'}}>Distribute:</div>
+            <div style={{height: 27}}>
+              <button
+                onClick={this.performDistribute.bind(this, undefined, 0)}
+                key="btn-dist-v-left"
+                style={[
+                  BTN_STYLES.btnIcon,
+                  BTN_STYLES.leftBtns,
+                  STYLES.alignDistributeBtn,
+                ]}>
+                <span style={[STYLES.alignDistributeIconWrapper]}>
+                  <AlignDistributeIcons.DistributeHTop color={this.getEventHandlersEditorButtonColor()} />
+                </span>
+              </button>
+              <button
+                onClick={this.performDistribute.bind(this, undefined, .5)}
+                key="btn-dist-v-mid"
+                style={[
+                  BTN_STYLES.btnIcon,
+                  BTN_STYLES.leftBtns,
+                  STYLES.alignDistributeBtn,
+                ]}>
+                <span style={[STYLES.alignDistributeIconWrapper]}>
+                  <AlignDistributeIcons.DistributeHMid color={this.getEventHandlersEditorButtonColor()} />
+                </span>
+              </button>
+              <button
+                onClick={this.performDistribute.bind(this, undefined, 1)}
+                key="btn-dist-v-right"
+                style={[
+                  BTN_STYLES.btnIcon,
+                  BTN_STYLES.leftBtns,
+                  STYLES.alignDistributeBtn,
+                  {marginRight: 18},
+                ]}>
+                <span style={[STYLES.alignDistributeIconWrapper]}>
+                  <AlignDistributeIcons.DistributeHBottom color={this.getEventHandlersEditorButtonColor()} />
+                </span>
+              </button>
+              <button
+                onClick={this.performDistribute.bind(this, 0, undefined)}
+                key="btn-dist-h-top"
+                style={[
+                  BTN_STYLES.btnIcon,
+                  BTN_STYLES.leftBtns,
+                  STYLES.alignDistributeBtn,
+                ]}>
+                <span style={[STYLES.alignDistributeIconWrapper]}>
+                  <AlignDistributeIcons.DistributeVLeft color={this.getEventHandlersEditorButtonColor()} />
+                </span>
+              </button>
+              <button
+                onClick={this.performDistribute.bind(this, .5, undefined)}
+                key="btn-dist-h-mid"
+                style={[
+                  BTN_STYLES.btnIcon,
+                  BTN_STYLES.leftBtns,
+                  STYLES.alignDistributeBtn,
+                ]}>
+                <span style={[STYLES.alignDistributeIconWrapper]}>
+                  <AlignDistributeIcons.DistributeVMid color={this.getEventHandlersEditorButtonColor()} />
+                </span>
+              </button>
+              <button
+                onClick={this.performDistribute.bind(this, 1, undefined)}
+                key="btn-dist-h-bottom"
+                style={[
+                  BTN_STYLES.btnIcon,
+                  BTN_STYLES.leftBtns,
+                  STYLES.alignDistributeBtn,
+                ]}>
+                <span style={[STYLES.alignDistributeIconWrapper]}>
+                  <AlignDistributeIcons.DistributeVRight color={this.getEventHandlersEditorButtonColor()} />
+                </span>
+              </button>
+            </div>
+            <div style={{margin: '9px 3px 2px 0'}}>
+              <label>
+                <input type="checkbox" ref="to_stage_toggle" /> To Stage
+              </label>
+            </div>
+
+          </div>
         }
         {this.props.showPopupCannotSwitchToDesign &&
           <CannotSwitchToDesignPopup

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -49,6 +49,7 @@ const Globals = require('haiku-ui-common/lib/Globals').default
 const {clipboard, shell, remote, ipcRenderer} = require('electron')
 const fse = require('haiku-fs-extra')
 const moment = require('moment')
+const SingletonSnapEmitter = require('haiku-serialization/src/bll/SingletonSnapEmitter')
 const {HOMEDIR_PATH} = require('haiku-serialization/src/utils/HaikuHomeDir')
 
 fse.mkdirpSync(HOMEDIR_PATH)
@@ -95,6 +96,8 @@ const isNumeric = (n) => {
 const niceTimestamp = () => {
   return moment().format('YYYY-MM-DD-HHmmss')
 }
+
+
 
 const writeHtmlSnapshot = (html, react) => {
   fse.mkdirpSync(path.join(HOMEDIR_PATH, 'snapshots'))
@@ -475,11 +478,16 @@ export class Glass extends React.Component {
     window.requestAnimationFrame(this.drawLoop.bind(this))
   }
 
+  handleSnapsUpdated (newSnaps){
+    this.setState({'snapLines': newSnaps})
+  }
+
   componentDidMount () {
     const resetKeyStates = () => {
       Globals.allKeysUp()
 
       this.setState({
+        snapLines: [],
         controlActivation: null,
         isAnythingScaling: false,
         isAnythingRotating: false,
@@ -490,6 +498,8 @@ export class Glass extends React.Component {
         isMouseDragging: false
       })
     }
+
+    SingletonSnapEmitter.getInstance().on('snaps-updated', this.handleSnapsUpdated.bind(this))
 
     // If the user e.g. Cmd+tabs away from the window
     this.addEmitterListener(window, 'blur', () => {
@@ -770,6 +780,69 @@ export class Glass extends React.Component {
     this.removeEmitterListeners()
     this.tourClient.off('tour:requestElementCoordinates', this.handleRequestElementCoordinates)
     this.project.getEnvoyClient().closeConnection()
+  }
+
+  modColor (i) {
+    return ((i || 0) * 8) % 360
+  }
+
+  renderSnapLines () {
+    //Don't do anything until a project is initialized
+    if(!this.getActiveComponent()){
+      return []
+    }
+
+    const MAX_SNAPS_PER_AXIS = 3
+
+    let getLineElements = () =>{
+      let horizSnaps = []
+      let vertSnaps = []
+
+      if (this.state.isMouseDown
+        && this.state.snapLines
+        && this.state.snapLines.length
+        && !Globals.isSpecialKeyDown()
+        && !this.isMarqueeActive()) {
+
+        lodash.forEach(this.state.snapLines, (snapLine, index) => {
+          if(snapLine.direction === 'HORIZONTAL') horizSnaps.push(snapLine)
+          else vertSnaps.push(snapLine)
+        })
+      }
+
+      let lines = []
+      this._renderCount = this._renderCount || 0
+      horizSnaps.forEach((snap, i) => {
+        lines.push(<line key={'h-' + i} x1='-5000' x2='5000' y1={snap.positionWorld} y2={snap.positionWorld} strokeWidth='1.25' stroke={'hsl(' + this.modColor(this._renderCount) + ', 100%, 50%)'} />)
+      })
+      vertSnaps.forEach((snap, i) => {
+        lines.push(<line key={'v-' + i}  x1={snap.positionWorld} x2={snap.positionWorld} y1='-5000' y2='5000' strokeWidth='1.25' stroke={'hsl(' + this.modColor(this._renderCount) + ', 100%, 50%)'} />)
+      })
+      this._renderCount++
+
+      return lines
+    }
+    
+    let artboard = this.getActiveComponent().getArtboard()
+
+    let SNAP_LINE_OVERLAY_STYLE = {
+      position: 'fixed',
+      width: '100%',
+      height: '100%',
+      pointerEvents: 'none',
+      bottom: 0,
+      right: 0,
+      pointerEvents: 'none',
+      zIndex: MAX_Z_INDEX - 2,
+      overflow: 'visible',
+      top: artboard.getMountY(),
+      left: artboard.getMountX()
+    }
+    return (
+      <svg id='snap-overlay' style={SNAP_LINE_OVERLAY_STYLE}>
+        {getLineElements()}
+      </svg>
+    )
   }
 
   handleUndo (payload) {
@@ -1154,6 +1227,8 @@ export class Glass extends React.Component {
 
     this.state.isMouseDown = true
     const mouseDownPosition = this.storeAndReturnMousePosition(mousedownEvent, 'lastMouseDownPosition')
+    const proxy = this.fetchProxyElementForSelection()
+    proxy.handleMouseDown(mouseDownPosition)
 
     switch (mousedownEvent.nativeEvent.target.getAttribute('class')) {
       case 'direct-selection-anchor': {
@@ -1277,7 +1352,7 @@ export class Glass extends React.Component {
         }
 
         const finish = () => {
-          this.fetchProxyElementForSelection().pushCachedTransform('CONSTRAINED_DRAG') // wishlist: enum
+          this.fetchProxyElementForSelection().cacheOrigins()
         }
 
         if (this.getActiveComponent().getArtboard().getActiveDrawingTool() !== 'pointer') {
@@ -1824,7 +1899,10 @@ export class Glass extends React.Component {
       this.getActiveComponent().getSelectionMarquee().endSelection()
     }
 
-    this.storeAndReturnMousePosition(mouseupEvent, 'lastMouseUpPosition')
+    let mousePosition = this.storeAndReturnMousePosition(mouseupEvent, 'lastMouseUpPosition')
+
+    const proxy = this.fetchProxyElementForSelection()
+    proxy.handleMouseUp(mousePosition)
     this.state.isMouseDown = false
     this.state.lastMouseUpTime = Date.now()
     this.handleDragStop()
@@ -1905,7 +1983,7 @@ export class Glass extends React.Component {
     const delta = keyEvent.shiftKey ? 5 : 1
     const proxy = this.fetchProxyElementForSelection()
     if (proxy.hasAnythingInSelection()) {
-      proxy.move(-delta, 0)
+      proxy.move(-delta, 0, Globals)
     }
   }
 
@@ -1914,7 +1992,7 @@ export class Glass extends React.Component {
     const delta = keyEvent.shiftKey ? 5 : 1
     const proxy = this.fetchProxyElementForSelection()
     if (proxy.hasAnythingInSelection()) {
-      proxy.move(0, -delta)
+      proxy.move(0, -delta, Globals)
     }
   }
 
@@ -1923,7 +2001,7 @@ export class Glass extends React.Component {
     const delta = keyEvent.shiftKey ? 5 : 1
     const proxy = this.fetchProxyElementForSelection()
     if (proxy.hasAnythingInSelection()) {
-      proxy.move(delta, 0)
+      proxy.move(delta, 0, Globals)
     }
   }
 
@@ -1932,7 +2010,7 @@ export class Glass extends React.Component {
     const delta = keyEvent.shiftKey ? 5 : 1
     const proxy = this.fetchProxyElementForSelection()
     if (proxy.hasAnythingInSelection()) {
-      proxy.move(0, delta)
+      proxy.move(0, delta, Globals)
     }
   }
 
@@ -1959,13 +2037,27 @@ export class Glass extends React.Component {
       case 46: this.handleDelete(); break
       case 8: this.handleDelete(); break
       case 13: this.handleKeyEnter(); break
+      case 91: this.handleKeyCommand(true); break //left cmd
+      case 93: this.handleKeyCommand(true); break //left cmd
     }
   }
 
-  handleKeyUp () {
+  handleKeyCommand (isDown) {
+    this.setState({isCommandKeyDown: isDown})
+  }
+
+  handleKeyUp (keyEvent) {
     if (this.state.isEventHandlerEditorOpen) {
       return
     }
+
+    switch (keyEvent.nativeEvent.which) {
+      case 91: this.handleKeyCommand(false); break
+      case 93: this.handleKeyCommand(false); break
+    }
+
+    const proxy = this.fetchProxyElementForSelection()
+    proxy.handleKeyUp()
 
     if (this.getActiveComponent()) {
       this.getActiveComponent().getSelectionMarquee().endSelection()
@@ -3188,7 +3280,7 @@ export class Glass extends React.Component {
               position: 'fixed',
               top: 5,
               right: 10,
-              zIndex: MAX_Z_INDEX - 1,
+              zIndex: MAX_Z_INDEX - 8,
               color: '#ccc',
               fontSize: 14
             }}>
@@ -3363,7 +3455,7 @@ export class Glass extends React.Component {
                   'opacity': 0.5,
                   'pointerEvents': 'none'
                 }} />
-              {/* draw the red border around the stage when selected */}
+              {/* draw the border around the stage when selected */}
               <rect
                 x={mount.x - 1}
                 y={mount.y - 1}
@@ -3372,8 +3464,8 @@ export class Glass extends React.Component {
                 style={{
                   strokeWidth: 1.5,
                   fill: 'none',
-                  stroke: Palette.LIGHTEST_PINK,
-                  opacity: this.state.isStageNameHovering && !this.state.isStageSelected ? 0.75 : 0,
+                  stroke: 'hsl(' + this.modColor(this._renderCount) + ', 100%, 50%)',
+                  opacity: this.state.isStageNameHovering && !this.state.isStageSelected ? 1 : 0,
                   overflow: 'visible'
                 }}
                 />
@@ -3426,7 +3518,7 @@ export class Glass extends React.Component {
             : ''}
 
           {this.renderHotComponentMount(mount, drawingClassName)}
-
+          {this.renderSnapLines()}
           {(!this.isPreviewMode())
             ? <div
               ref='outline'
@@ -3454,7 +3546,7 @@ export class Glass extends React.Component {
                 width: '100%',
                 height: '100%',
                 overflow: 'hidden',
-                zIndex: MAX_Z_INDEX,
+                zIndex: MAX_Z_INDEX - 4,
                 backgroundColor: 'white'
               }}>
               <Preview
@@ -3487,4 +3579,4 @@ Glass.propTypes = {
   folder: React.PropTypes.string
 }
 
-export default Radium(Glass)
+export default Glass

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -2039,7 +2039,13 @@ export class Glass extends React.Component {
       case 13: this.handleKeyEnter(); break
       case 91: this.handleKeyCommand(true); break //left cmd
       case 93: this.handleKeyCommand(true); break //left cmd
+      case 76: this.handleAlignRequest(undefined, 1, false); break // l key
     }
+  }
+
+  handleAlignRequest(xEdge, yEdge, toStage) {
+    const proxy = this.fetchProxyElementForSelection()
+    proxy.align(xEdge, yEdge, toStage)
   }
 
   handleKeyCommand (isDown) {

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -97,8 +97,6 @@ const niceTimestamp = () => {
   return moment().format('YYYY-MM-DD-HHmmss')
 }
 
-
-
 const writeHtmlSnapshot = (html, react) => {
   fse.mkdirpSync(path.join(HOMEDIR_PATH, 'snapshots'))
   const filename = (react.props.projectName || 'Unknown') + '-' + niceTimestamp() + '.html'
@@ -478,7 +476,7 @@ export class Glass extends React.Component {
     window.requestAnimationFrame(this.drawLoop.bind(this))
   }
 
-  handleSnapsUpdated (newSnaps){
+  handleSnapsUpdated (newSnaps) {
     this.setState({'snapLines': newSnaps})
   }
 
@@ -787,25 +785,24 @@ export class Glass extends React.Component {
   }
 
   renderSnapLines () {
-    //Don't do anything until a project is initialized
-    if(!this.getActiveComponent()){
+    // Don't do anything until a project is initialized
+    if (!this.getActiveComponent()) {
       return []
     }
 
     const MAX_SNAPS_PER_AXIS = 3
 
-    let getLineElements = () =>{
+    let getLineElements = () => {
       let horizSnaps = []
       let vertSnaps = []
 
-      if (this.state.isMouseDown
-        && this.state.snapLines
-        && this.state.snapLines.length
-        && !Globals.isSpecialKeyDown()
-        && !this.isMarqueeActive()) {
-
+      if (this.state.isMouseDown &&
+        this.state.snapLines &&
+        this.state.snapLines.length &&
+        !Globals.isSpecialKeyDown() &&
+        !this.isMarqueeActive()) {
         lodash.forEach(this.state.snapLines, (snapLine, index) => {
-          if(snapLine.direction === 'HORIZONTAL') horizSnaps.push(snapLine)
+          if (snapLine.direction === 'HORIZONTAL') horizSnaps.push(snapLine)
           else vertSnaps.push(snapLine)
         })
       }
@@ -816,13 +813,13 @@ export class Glass extends React.Component {
         lines.push(<line key={'h-' + i} x1='-5000' x2='5000' y1={snap.positionWorld} y2={snap.positionWorld} strokeWidth='1.25' stroke={'hsl(' + this.modColor(this._renderCount) + ', 100%, 50%)'} />)
       })
       vertSnaps.forEach((snap, i) => {
-        lines.push(<line key={'v-' + i}  x1={snap.positionWorld} x2={snap.positionWorld} y1='-5000' y2='5000' strokeWidth='1.25' stroke={'hsl(' + this.modColor(this._renderCount) + ', 100%, 50%)'} />)
+        lines.push(<line key={'v-' + i} x1={snap.positionWorld} x2={snap.positionWorld} y1='-5000' y2='5000' strokeWidth='1.25' stroke={'hsl(' + this.modColor(this._renderCount) + ', 100%, 50%)'} />)
       })
       this._renderCount++
 
       return lines
     }
-    
+
     let artboard = this.getActiveComponent().getArtboard()
 
     let SNAP_LINE_OVERLAY_STYLE = {
@@ -2037,19 +2034,19 @@ export class Glass extends React.Component {
       case 46: this.handleDelete(); break
       case 8: this.handleDelete(); break
       case 13: this.handleKeyEnter(); break
-      case 91: this.handleKeyCommand(true); break //left cmd
-      case 93: this.handleKeyCommand(true); break //left cmd
+      case 91: this.handleKeyCommand(true); break // left cmd
+      case 93: this.handleKeyCommand(true); break // left cmd
       case 76: this.handleAlignRequest(undefined, 1, false); break // l key
-      case 75: this.handleDistributeRequest(undefined, .5, true); break // k key
+      case 75: this.handleDistributeRequest(undefined, 0.5, true); break // k key
     }
   }
 
-  handleAlignRequest(xEdge, yEdge, toStage) {
+  handleAlignRequest (xEdge, yEdge, toStage) {
     const proxy = this.fetchProxyElementForSelection()
     proxy.align(xEdge, yEdge, toStage)
   }
 
-  handleDistributeRequest(xEdge, yEdge, toStage) {
+  handleDistributeRequest (xEdge, yEdge, toStage) {
     const proxy = this.fetchProxyElementForSelection()
     proxy.distribute(xEdge, yEdge, toStage)
   }

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import lodash from 'lodash'
-import Radium from 'radium'
 import path from 'path'
 import HaikuDOMRenderer from '@haiku/core/lib/renderers/dom'
 import HaikuContext from '@haiku/core/lib/HaikuContext'
@@ -790,8 +789,6 @@ export class Glass extends React.Component {
       return []
     }
 
-    const MAX_SNAPS_PER_AXIS = 3
-
     let getLineElements = () => {
       let horizSnaps = []
       let vertSnaps = []
@@ -826,7 +823,6 @@ export class Glass extends React.Component {
       position: 'fixed',
       width: '100%',
       height: '100%',
-      pointerEvents: 'none',
       bottom: 0,
       right: 0,
       pointerEvents: 'none',

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -2040,12 +2040,18 @@ export class Glass extends React.Component {
       case 91: this.handleKeyCommand(true); break //left cmd
       case 93: this.handleKeyCommand(true); break //left cmd
       case 76: this.handleAlignRequest(undefined, 1, false); break // l key
+      case 75: this.handleDistributeRequest(undefined, .5, true); break // k key
     }
   }
 
   handleAlignRequest(xEdge, yEdge, toStage) {
     const proxy = this.fetchProxyElementForSelection()
     proxy.align(xEdge, yEdge, toStage)
+  }
+
+  handleDistributeRequest(xEdge, yEdge, toStage) {
+    const proxy = this.fetchProxyElementForSelection()
+    proxy.distribute(xEdge, yEdge, toStage)
   }
 
   handleKeyCommand (isDown) {

--- a/packages/haiku-serialization/src/bll/Artboard.js
+++ b/packages/haiku-serialization/src/bll/Artboard.js
@@ -256,7 +256,6 @@ class Artboard extends BaseModel {
     return screenSpace
   }
 
-
   getZoom () {
     return this._zoomXY
   }
@@ -327,7 +326,7 @@ class Artboard extends BaseModel {
 
       let marginX = (this._containerWidth - this._mountWidth) / 2
       let marginY = (this._containerHeight - this._mountHeight) / 2
-      let bbox = elem.getBoundingClientRect(- marginX, - marginY)
+      let bbox = elem.getBoundingClientRect(-marginX, -marginY)
 
       snapLines.push({
         direction: 'HORIZONTAL',

--- a/packages/haiku-serialization/src/bll/Artboard.js
+++ b/packages/haiku-serialization/src/bll/Artboard.js
@@ -1,6 +1,6 @@
 const BaseModel = require('./BaseModel')
 const Matrix = require('gl-matrix')
-
+const _ = require('lodash')
 const HAIKU_ID_ATTRIBUTE = 'haiku-id'
 
 /**
@@ -239,18 +239,23 @@ class Artboard extends BaseModel {
     this._originalPanY = this._panY
   }
 
-  // takes a point in screen space {x,y} and transforms it to 2D world space {x,y}
   transformScreenToWorld (screenCoords) {
     let mat = Matrix.mat2d.create()
-    let scale = Matrix.vec2.create()
-    Matrix.vec2.set(scale, 1 / this._zoomXY, 1 / this._zoomXY)
-    Matrix.mat2d.scale(mat, mat, scale)
+    let mount = Matrix.vec2.create()
+
+    Matrix.vec2.set(mount, -this._mountX, -this._mountY)
+
+    let mountMat = Matrix.mat2d.create()
+    Matrix.mat2d.translate(mountMat, mountMat, mount)
+    Matrix.mat2d.multiply(mat, mat, mountMat)
+
     let screenVec = Matrix.vec2.create()
     Matrix.vec2.set(screenVec, screenCoords.x, screenCoords.y)
     Matrix.vec2.transformMat2d(screenVec, screenVec, mat)
-    let ret = {x: screenVec[0], y: screenVec[1]}
-    return ret
+    let screenSpace = {x: screenVec[0], y: screenVec[1]}
+    return screenSpace
   }
+
 
   getZoom () {
     return this._zoomXY
@@ -265,6 +270,102 @@ class Artboard extends BaseModel {
 
   getActiveDrawingTool () {
     return this._activeDrawingTool
+  }
+
+  // Snapline {
+  //  direction : "HORIZONTAL"|"VERTICAL"
+  //  positionWorld: Number
+  //  elementId: String | undefined
+  // }
+
+  getSnapLinesInScreenCoords () {
+    let snapLines = []
+    let topWorld = 0
+    let rightWorld = this._mountWidth
+    let bottomWorld = this._mountHeight
+    let leftWorld = 0
+
+    snapLines.push({
+      direction: 'HORIZONTAL',
+      positionWorld: topWorld,
+      elementId: 'STAGE_TOP'
+    })
+    snapLines.push({
+      direction: 'VERTICAL',
+      positionWorld: rightWorld,
+      elementId: 'STAGE_RIGHT'
+    })
+    snapLines.push({
+      direction: 'HORIZONTAL',
+      positionWorld: bottomWorld,
+      elementId: 'STAGE_BOTTOM'
+    })
+    snapLines.push({
+      direction: 'VERTICAL',
+      positionWorld: leftWorld,
+      elementId: 'STAGE_LEFT'
+    })
+    snapLines.push({
+      direction: 'VERTICAL',
+      positionWorld: (leftWorld + rightWorld) / 2,
+      elementId: 'STAGE_VERTICAL_MID'
+    })
+    snapLines.push({
+      direction: 'HORIZONTAL',
+      positionWorld: (topWorld + bottomWorld) / 2,
+      elementId: 'STAGE_HORIZONTAL_MID'
+    })
+
+    const rootElement = this.getElement()
+    const topLevelElements = rootElement.children
+
+    _.forEach(topLevelElements, (elem) => {
+      // deleted elements will show up as null entries in this array
+      if (!elem) {
+        return
+      }
+
+      let marginX = (this._containerWidth - this._mountWidth) / 2
+      let marginY = (this._containerHeight - this._mountHeight) / 2
+      let bbox = elem.getBoundingClientRect(- marginX, - marginY)
+
+      snapLines.push({
+        direction: 'HORIZONTAL',
+        positionWorld: this.transformScreenToWorld({x: 0, y: bbox.top}).y,
+        elementId: elem.getComponentId()
+      })
+      snapLines.push({
+        direction: 'HORIZONTAL',
+        positionWorld: this.transformScreenToWorld({x: 0, y: bbox.bottom}).y,
+        elementId: elem.getComponentId()
+      })
+      snapLines.push({
+        direction: 'HORIZONTAL',
+        positionWorld: this.transformScreenToWorld({x: 0, y: (bbox.bottom + bbox.top) / 2}).y,
+        elementId: elem.getComponentId()
+      })
+      snapLines.push({
+        direction: 'VERTICAL',
+        positionWorld: this.transformScreenToWorld({x: bbox.left, y: 0}).x,
+        elementId: elem.getComponentId()
+      })
+      snapLines.push({
+        direction: 'VERTICAL',
+        positionWorld: this.transformScreenToWorld({x: bbox.right, y: 0}).x,
+        elementId: elem.getComponentId()
+      })
+      snapLines.push({
+        direction: 'VERTICAL',
+        positionWorld: this.transformScreenToWorld({x: (bbox.right + bbox.left) / 2, y: 0}).x,
+        elementId: elem.getComponentId()
+      })
+    })
+
+    if (typeof window !== 'undefined') {
+      window.snapLines = snapLines
+    }
+
+    return snapLines
   }
 }
 

--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -457,30 +457,29 @@ class Element extends BaseModel {
     this.emit('update', 'element-send-backward')
   }
 
-  //marginX and marginY represent the distance from the container
-  //boundary to the stage boundary, i.e. the margin that centers the
-  //stage. 
-  //since this is dependent on artboard + window dimensions,
-  //this needs to be passed in from the artboard.
+  // marginX and marginY represent the distance from the container
+  // boundary to the stage boundary, i.e. the margin that centers the
+  // stage.
+  // since this is dependent on artboard + window dimensions,
+  // this needs to be passed in from the artboard.
   getBoundingClientRect (marginX, marginY) {
     const points = this.getBoxPointsTransformed()
 
-    //account for stage margin to provide a screen-space bbox
-    if(marginX !== undefined && marginY !== undefined){
+    // account for stage margin to provide a screen-space bbox
+    if (marginX !== undefined && marginY !== undefined) {
       let mat = Matrix.mat2d.create()
       let margin = Matrix.vec2.create()
 
       Matrix.vec2.set(margin, -marginX, -marginY)
       Matrix.mat2d.translate(mat, mat, margin)
 
-      for(let i = 0; i < points.length; i++){
+      for (let i = 0; i < points.length; i++) {
         let pointInput = Matrix.vec2.create()
         let pointOutput = Matrix.vec2.create()
         Matrix.vec2.set(pointInput, points[i].x, points[i].y)
         Matrix.vec2.transformMat2d(pointOutput, pointInput, mat)
         points[i] = {x: pointOutput[0], y: pointOutput[1]}
       }
-
     }
 
     const top = Math.min(points[0].y, points[2].y, points[6].y, points[8].y)
@@ -489,7 +488,7 @@ class Element extends BaseModel {
     const right = Math.max(points[0].x, points[2].x, points[6].x, points[8].x)
     const height = Math.abs(bottom - top)
     const width = Math.abs(right - left)
-    
+
     return {
       top,
       right,
@@ -498,7 +497,6 @@ class Element extends BaseModel {
       width,
       height
     }
-    
   }
 
   getAncestry () {

--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -7,6 +7,7 @@ const {LAYOUT_3D_SCHEMA} = require('@haiku/core/lib/HaikuComponent')
 const KnownDOMEvents = require('@haiku/core/lib/renderers/dom/Events').default
 const titlecase = require('titlecase')
 const decamelize = require('decamelize')
+const Matrix = require('gl-matrix')
 const polygonOverlap = require('polygon-overlap')
 const logger = require('./../utils/LoggerInstance')
 const BaseModel = require('./BaseModel')
@@ -456,13 +457,48 @@ class Element extends BaseModel {
     this.emit('update', 'element-send-backward')
   }
 
-  getBoundingClientRect () {
-    // TODO:
-    //   This doesn't quite work yet.
-    //   Stubbing out possible behavior while cleaning out DOM/render dependencies/races
-    //
+  //marginX and marginY represent the distance from the container
+  //boundary to the stage boundary, i.e. the margin that centers the
+  //stage. 
+  //since this is dependent on artboard + window dimensions,
+  //this needs to be passed in from the artboard.
+  getBoundingClientRect (marginX, marginY) {
     const points = this.getBoxPointsTransformed()
-    return HaikuElement.getRectFromPoints(points)
+
+    //account for stage margin to provide a screen-space bbox
+    if(marginX !== undefined && marginY !== undefined){
+      let mat = Matrix.mat2d.create()
+      let margin = Matrix.vec2.create()
+
+      Matrix.vec2.set(margin, -marginX, -marginY)
+      Matrix.mat2d.translate(mat, mat, margin)
+
+      for(let i = 0; i < points.length; i++){
+        let pointInput = Matrix.vec2.create()
+        let pointOutput = Matrix.vec2.create()
+        Matrix.vec2.set(pointInput, points[i].x, points[i].y)
+        Matrix.vec2.transformMat2d(pointOutput, pointInput, mat)
+        points[i] = {x: pointOutput[0], y: pointOutput[1]}
+      }
+
+    }
+
+    const top = Math.min(points[0].y, points[2].y, points[6].y, points[8].y)
+    const bottom = Math.max(points[0].y, points[2].y, points[6].y, points[8].y)
+    const left = Math.min(points[0].x, points[2].x, points[6].x, points[8].x)
+    const right = Math.max(points[0].x, points[2].x, points[6].x, points[8].x)
+    const height = Math.abs(bottom - top)
+    const width = Math.abs(right - left)
+    
+    return {
+      top,
+      right,
+      bottom,
+      left,
+      width,
+      height
+    }
+    
   }
 
   getAncestry () {

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -11,6 +11,9 @@ const {Experiment, experimentIsEnabled} = require('haiku-common/lib/experiments'
 const Figma = require('./Figma')
 const Sketch = require('./Sketch')
 const Illustrator = require('./Illustrator')
+const EventEmitter = require('event-emitter')
+const SingletonSnapEmitter = require('./SingletonSnapEmitter')
+const _ = require('lodash')
 
 const PI_OVER_12 = Math.PI / 12
 
@@ -20,6 +23,10 @@ const forceNumeric = (n) => (isNaN(n) || !isFinite(n)) ? 0 : n
 
 const HAIKU_SOURCE_ATTRIBUTE = 'haiku-source'
 const HAIKU_TITLE_ATTRIBUTE = 'haiku-title'
+const SNAP_THRESHOLD = 10 // px, world-space (i.e. will get bigger/smaller with zoom)
+const SNAP_EPSILON = .025
+
+
 
 /**
  * @class ElementSelectionProxy
@@ -38,6 +45,7 @@ class ElementSelectionProxy extends BaseModel {
 
     // When representing multiple elements, we apply changes to our proxy properties
     this.reinitializeLayout()
+
 
     // Allows transforms to be recalled on demand, e.g. during Alt+drag
     this.transformCache = new TransformCache(this)
@@ -144,6 +152,15 @@ class ElementSelectionProxy extends BaseModel {
     this.selection.forEach((element) => {
       element.transformCache.push(key)
     })
+  }
+
+  //very similar to pushCachedTransform, but does it for all selected elements,
+  //doesn't keep a stack, and only tracks origins rather than full transforms
+  cacheOrigins () {
+    this._originCache = this.selection.map((elem) => {
+      return elem.getOriginTransformed()
+    })
+    this._originCache.groupOrigin = this.getOriginTransformed()
   }
 
   canCreateComponentFromSelection () {
@@ -478,6 +495,18 @@ class ElementSelectionProxy extends BaseModel {
     return this._proxyBoxPoints.map((point) => Object.assign({}, point))
   }
 
+  //returns the box points of the base element, without transform applied
+  getBoxPointsCompletelyNotTransformed() {
+    const layout = this.getComputedLayout()
+    const w = layout.size.x
+    const h = layout.size.y
+    return [
+      {x: 0, y: 0, z: 0}, {x: w / 2, y: 0, z: 0}, {x: w, y: 0, z: 0},
+      {x: 0, y: h / 2, z: 0}, {x: w / 2, y: h / 2, z: 0}, {x: w, y: h / 2, z: 0},
+      {x: 0, y: h, z: 0}, {x: w / 2, y: h, z: 0}, {x: w, y: h, z: 0}
+    ]
+  }
+
   getLayoutSpec () {
     if (this.shouldUseChildLayout()) {
       return this.selection[0].getLayoutSpec()
@@ -583,7 +612,38 @@ class ElementSelectionProxy extends BaseModel {
 
   getBoundingClientRect () {
     const points = this.getBoxPointsTransformed()
-    return HaikuElement.getRectFromPoints(points)
+
+    let left, right, top, bottom, width, height
+    if(!points || !points.length){
+      //It seems that sometimes proxy is given an empty set of elements to drag (?)
+      //so `getBoxPointsTransformed` sensibly returns an empty array.
+      //Unfortunately, that crashes the UI.
+      //This provides a stub, non-UI-breaking bbox.
+      left = -21
+      right = -20
+      top = -21
+      bottom = -20
+      width = 1
+      height = 1
+    }else{
+      left = Math.min(points[0].x, points[2].x, points[6].x, points[8].x)
+      right = Math.max(points[0].x, points[2].x, points[6].x, points[8].x)
+      top = Math.min(points[0].y, points[2].y, points[6].y, points[8].y)
+      bottom = Math.max(points[0].y, points[2].y, points[6].y, points[8].y)
+      width = Math.abs(left - right)
+      height = Math.abs(bottom - top)
+    }
+
+    const proxyRect = {
+      left,
+      right,
+      top,
+      bottom,
+      width,
+      height
+    }
+
+    return proxyRect
   }
 
   getElementOrProxyPropertyValue (key) {
@@ -622,6 +682,89 @@ class ElementSelectionProxy extends BaseModel {
     this.applyPropertyValue('scale.y', 1)
   }
 
+  handleMouseDown (mousePosition) {
+    this._shouldCaptureMousePosition = true
+  }
+
+  handleMouseUp (mousePosition) {
+    //no-op for now; 'lifecycle' event stub
+  }
+
+  //this is used specifically for the CMD key (though it is not explicitly filtered here.)
+  //if we don't "recapture" mouse position when CMD is released, the element will unexpectedly
+  //jolt back to its original position pre-drag.
+  handleKeyUp () {
+    this._shouldCaptureMousePosition = true
+  }
+
+  //snapDefinitions are the element-side 'snap points' (lines)
+  //snapLines are the stage-side 'snap points' (lines)
+  //note that snapLines will generally include snapDefinitions, so there's a filter step at the beginning
+  findSnapsMatchesAndBreakTies(snapDefinitions, snapLines) {
+
+    let horizWinners = []
+    let vertWinners = []
+    let winningDeltaHoriz = undefined
+    let winningDeltaVert = undefined
+    snapLines.forEach((snap) => {
+
+      // don't snap to this element's own bounding snaplines
+      let ids = this.getComponentIds()
+      if(ids.indexOf(snap.elementId) !== -1){
+        return
+      }
+
+      snapDefinitions.forEach((def) => {
+        if (snap.direction === def.direction
+          && def.bboxEdgePosition > snap.positionWorld - SNAP_THRESHOLD
+          && def.bboxEdgePosition < snap.positionWorld + SNAP_THRESHOLD) {
+
+          let delta = Math.abs(def.bboxEdgePosition - snap.positionWorld)
+
+            if(snap.direction === 'HORIZONTAL' && (winningDeltaHoriz === undefined || delta < winningDeltaHoriz + SNAP_EPSILON)){
+              winningDeltaHoriz = Math.min(delta, winningDeltaHoriz) || delta
+              
+              let newWinner = {
+                direction: def.direction,
+                positionWorld: snap.positionWorld,
+                bboxEdgePosition: def.bboxEdgePosition,
+                metadata: Object.assign({}, def.metadata, snap.metadata)
+              }
+              for(var i = 0; i < horizWinners.length; i++){
+                let oldWinner = horizWinners[i]
+                let oldWinningDelta = Math.abs(oldWinner.bboxEdgePosition - oldWinner.positionWorld)
+                if(winningDeltaHoriz + SNAP_EPSILON < oldWinningDelta){
+                  horizWinners.splice(i, 1)
+                  i--
+                }
+              }
+              horizWinners.push(newWinner)
+              
+            }else if(snap.direction === 'VERTICAL' && (winningDeltaVert === undefined || delta < winningDeltaVert + SNAP_EPSILON)){
+              winningDeltaVert = Math.min(delta, winningDeltaVert) || delta
+              let newWinner = {
+                direction: def.direction,
+                positionWorld: snap.positionWorld,
+                bboxEdgePosition: def.bboxEdgePosition,
+                metadata: Object.assign({}, def.metadata, snap.metadata)
+              }
+              for(var i = 0; i < vertWinners.length; i++){
+                let oldWinner = vertWinners[i]
+                let oldWinningDelta = Math.abs(oldWinner.bboxEdgePosition - oldWinner.positionWorld)
+                if(winningDeltaVert + SNAP_EPSILON < oldWinningDelta){
+                  vertWinners.splice(i, 1)
+                  i--
+                }
+              }
+              vertWinners.push(newWinner)
+            }
+          }
+      })
+    })
+    return [].concat(horizWinners, vertWinners)
+  }
+
+
   /**
    * @method drag
    * @description Scale, rotate, or translate the elements in the selection
@@ -639,6 +782,28 @@ class ElementSelectionProxy extends BaseModel {
     viewportTransform,
     globals
   ) {
+
+
+    //'mousetrap' for snapping 
+    if(this._shouldCaptureMousePosition || this._lastMouseDownPosition === undefined){
+      this._lastMouseDownPosition = mouseCoordsCurrent
+      this._lastBbox = this.getBoundingClientRect()
+      this._lastProxyBox = this.getBoxPointsTransformed()
+      this._lastOrigin = this.getOriginTransformed()
+      this._baseBoxPointsNotTransformed = this.getBoxPointsCompletelyNotTransformed()
+      // this.transformCache.push('CONTROL_ACTIVATION')
+      this._lastOrigins = this.selection.map((elem) => {
+        return elem.getOriginTransformed()
+      })
+      this._shouldCaptureMousePosition = false
+    }
+
+    //track mouse positions, offsets, and original bounding boxes for snapping
+    let totalDragDelta = {
+      x: mouseCoordsCurrent.x - this._lastMouseDownPosition.x,
+      y: mouseCoordsCurrent.y - this._lastMouseDownPosition.y
+    }
+
     if (isOriginPanning) {
       return this.panOrigin(dx, dy)
     }
@@ -646,13 +811,15 @@ class ElementSelectionProxy extends BaseModel {
     if (this.canControlHandles()) {
       if (isAnythingScaling) {
         if (!controlActivation.cmd) {
+          //TODO: add snapping
           return this.scale(
             dx,
             dy,
             controlActivation,
             mouseCoordsCurrent,
             mouseCoordsPrevious,
-            viewportTransform
+            viewportTransform,
+            globals
           )
         }
       } else if (isAnythingRotating) {
@@ -667,7 +834,8 @@ class ElementSelectionProxy extends BaseModel {
             dy,
             mouseCoordsCurrent,
             mouseCoordsPrevious,
-            controlActivation
+            controlActivation,
+            globals
           )
         }
       }
@@ -678,21 +846,147 @@ class ElementSelectionProxy extends BaseModel {
       return
     }
 
-    if (globals.isShiftKeyDown) {
-      return this.moveWithShiftDown(
-        dx,
-        dy,
-        mouseCoordsCurrent
-      )
-    } else {
-      return this.move(
-        dx,
-        dy,
-        mouseCoordsCurrent,
-        mouseCoordsPrevious,
-        lastMouseDownCoord
-      )
+    let artboard = Artboard.all()[0]
+
+    // handle snapping
+    // don't snap if user is holding cmd key (like Sketch)
+    if (!globals.isCommandKeyDown) {
+      const targetElement = this.shouldUseChildLayout() ? this.selection[0] : this
+
+      let bbox
+      if(this._lastBbox !== undefined){
+          bbox = ((bbox, delta) => { 
+          let ret = {}
+          ret.top = bbox.top + delta.y
+          ret.right = bbox.right + delta.x
+          ret.bottom = bbox.bottom + delta.y
+          ret.left = bbox.left + delta.x
+          ret.height = ret.bottom - ret.top
+          ret.width = ret.right - ret.left
+          return ret
+        })(this._lastBbox, totalDragDelta)
+      }else{
+        bbox = this.getBoundingClientRect()
+      }
+
+      //SNAPPING:
+      //========
+
+      //TODO:  
+      //       - handle snapping for origin
+      //       - simple align + distribute passes, since much logic is related
+      //         ^ bonus points for supporting "to stage," a la Flash
+      //       - clean-up pass:
+      //           - "screen space" from v0 may not be necessary; maybe can remove many matrix ops
+      //       - perf pass?
+      //           - perf could filter only snaps within viewport     
+      //           - perf could check snap lines and bounding box edges using bounding volumes,
+      //             instead of checking every element linearly+        
+
+      // Snapline {
+      //  direction : "HORIZONTAL"|"VERTICAL"
+      //  position : Number
+      //  positionWorld : Number
+      //  elementId : (Number | String) (?)
+      // }
+      let snapLines = artboard.getSnapLinesInScreenCoords()
+
+      let _applyOffset = (v0, v1) => {
+        return {
+          x: v0.x + v1.x,
+          y: v0.y + v1.y
+        }
+      }
+
+      //index corresponds with selected elements' indicies        
+        //{ x : number
+        //  y : number }
+      let overrides = []
+
+      let origin = _applyOffset(this._lastOrigin, totalDragDelta)//this.getOriginTransformed();        
+      let origins = this._lastOrigins.map((o) => {
+        return _applyOffset(o, totalDragDelta)
+      })
+
+      origins.groupOrigin = origin
+      
+      //note that 'name' is really only used for readability & debugging
+      const SNAP_DEFINITIONS = [
+        {
+          name: 'TOP',
+          direction: 'HORIZONTAL',
+          bboxEdgePosition: bbox.top,
+        },
+        {
+          name: 'RIGHT',
+          direction: 'VERTICAL',
+          bboxEdgePosition: bbox.right,
+        },
+        {
+          name: 'BOTTOM',
+          direction: 'HORIZONTAL',
+          bboxEdgePosition: bbox.bottom,
+        },
+        {
+          name: 'LEFT',
+          direction: 'VERTICAL',
+          bboxEdgePosition: bbox.left,
+        },
+        {
+          name: 'VERTICAL_MID',
+          direction: 'VERTICAL',
+          bboxEdgePosition: (bbox.right + bbox.left) / 2
+        },
+        {
+          name: 'HORIZONTAL_MID',
+          direction: 'HORIZONTAL',
+          bboxEdgePosition: (bbox.bottom + bbox.top) / 2
+        }
+      ]
+      let foundSnaps = this.findSnapsMatchesAndBreakTies(SNAP_DEFINITIONS, snapLines)
+
+      //Shift-dragging affects which axis we want to snap on
+      //and can use the same `overrides` mechanism
+      if (globals.isShiftKeyDown) {
+        const isXAxis = Math.abs(mouseCoordsCurrent.x - this._originCache.groupOrigin.x) >
+          Math.abs(mouseCoordsCurrent.y - this._originCache.groupOrigin.y)
+
+        //only snap to the relevant axis
+        if(isXAxis){
+          foundSnaps = foundSnaps.filter((snap)=>{return snap.direction === 'VERTICAL'})
+          for(var i = 0; i < this.selection.length; i++){
+            overrides[i] = overrides[i] || {}
+            overrides[i].y = this._originCache[i].y
+            overrides.groupOrigin = overrides.groupOrigin || {}
+            overrides.groupOrigin.y = this._originCache.groupOrigin.y
+          }
+        }else{
+          foundSnaps = foundSnaps.filter((snap)=>{return snap.direction === 'HORIZONTAL'})
+          for(var i = 0; i < this.selection.length; i++){
+            overrides[i] = overrides[i] || {}
+            overrides[i].x = this._originCache[i].x
+            overrides.groupOrigin = overrides.groupOrigin || {}
+            overrides.groupOrigin.x = this._originCache.groupOrigin.x
+          }
+        }
+      }
+
+      foundSnaps.forEach((snap) => {
+        let whichAxis = (snap.direction === 'HORIZONTAL' ? 'y' : 'x')
+        let desiredPosition = snap.positionWorld
+        this.selection.forEach((elem, i) => {
+          overrides[i] = overrides[i] || {}
+          overrides[i][whichAxis] = desiredPosition - (snap.bboxEdgePosition - origins[i][whichAxis])
+        })
+        overrides.groupOrigin = overrides.groupOrigin || {} 
+        overrides.groupOrigin[whichAxis] = desiredPosition - (snap.bboxEdgePosition - origins.groupOrigin[whichAxis])
+      })
+
+      SingletonSnapEmitter.getInstance().emit('snaps-updated', foundSnaps)
+      return this.move(dx, dy, overrides)
     }
+   
+    return this.move(dx, dy)
   }
 
   panOrigin (dx, dy) {
@@ -771,7 +1065,8 @@ class ElementSelectionProxy extends BaseModel {
     }
   }
 
-  move (dx, dy) {
+  //overrides allow per-element absolute position overrides, useful for snapping
+  move (dx, dy, overrides) {
     const propertyGroupDelta = {
       'translation.x': {
         value: dx
@@ -783,8 +1078,14 @@ class ElementSelectionProxy extends BaseModel {
 
     const accumulatedUpdates = {}
 
-    this.selection.forEach((element) => {
-      const propertyGroup = element.computePropertyGroupValueFromGroupDelta(propertyGroupDelta)
+    this.selection.forEach((element, i) => {
+      let propertyGroup = element.computePropertyGroupValueFromGroupDelta(propertyGroupDelta)
+      if(overrides && overrides[i] && overrides[i].x !== undefined){
+        propertyGroup['translation.x'] = {value: overrides[i].x}
+      }
+      if(overrides && overrides[i] && overrides[i].y !== undefined){
+        propertyGroup['translation.y'] = {value: overrides[i].y}
+      }
 
       ElementSelectionProxy.accumulateKeyframeUpdates(
         accumulatedUpdates,
@@ -801,54 +1102,31 @@ class ElementSelectionProxy extends BaseModel {
       this.component.project.getMetadata(),
       () => {} // no-op
     )
-    this.applyPropertyDelta('translation.x', dx)
-    this.applyPropertyDelta('translation.y', dy)
+    if(overrides && overrides.groupOrigin && overrides.groupOrigin.x){
+      this.applyPropertyValue('translation.x', overrides.groupOrigin.x)
+    }else{
+      this.applyPropertyDelta('translation.x', dx)
+    }
+
+    if(overrides && overrides.groupOrigin && overrides.groupOrigin.y){
+      this.applyPropertyValue('translation.y', overrides.groupOrigin.y)
+    }else{
+      this.applyPropertyDelta('translation.y', dy)
+    }
   }
 
-  moveWithShiftDown (dx, dy, mouseCoordsCurrent) {
-    const accumulatedUpdates = {}
-
-    const elementTransform = this.transformCache.peek('CONSTRAINED_DRAG')
-    const initialTransform = {
-      // If the user multi-selects too quickly the transform may not be available, hence the guard
-      x: (elementTransform && elementTransform.translation.x) || 0,
-      y: (elementTransform && elementTransform.translation.y) || 0
+  getActivationPointInRadians(index){
+    switch(index){
+      case 5: return Math.PI * 2
+      case 8: return Math.PI / 4
+      case 7: return Math.PI / 2
+      case 6: return 3 * Math.PI / 4
+      case 3: return Math.PI
+      case 0: return 5 * Math.PI / 4
+      case 1: return 3 * Math.PI / 2
+      case 2: return 7 * Math.PI / 4
+      throw new Error("Cannot retrieve radian value for provided activation point: " + index)
     }
-
-    const isXAxis = Math.abs(mouseCoordsCurrent.x - initialTransform.x) >
-      Math.abs(mouseCoordsCurrent.y - initialTransform.y)
-
-    const constrainedDeltaX = isXAxis ? dx : initialTransform.x - this.computePropertyValue('translation.x')
-    const constrainedDeltaY = isXAxis ? initialTransform.y - this.computePropertyValue('translation.y') : dy
-
-    const propertyGroupDelta = {
-      'translation.x': {
-        value: constrainedDeltaX
-      },
-      'translation.y': {
-        value: constrainedDeltaY
-      }
-    }
-
-    this.selection.forEach((element) => {
-      const propertyGroup = element.computePropertyGroupValueFromGroupDelta(propertyGroupDelta)
-      ElementSelectionProxy.accumulateKeyframeUpdates(
-        accumulatedUpdates,
-        element.getComponentId(),
-        element.component.getCurrentTimelineName(),
-        element.component.getCurrentTimelineTime(),
-        propertyGroup
-      )
-    })
-
-    this.component.updateKeyframes(
-      accumulatedUpdates,
-      {},
-      this.component.project.getMetadata(),
-      () => {} // no-op
-    )
-    this.applyPropertyDelta('translation.x', constrainedDeltaX)
-    this.applyPropertyDelta('translation.y', constrainedDeltaY)
   }
 
   scale (
@@ -857,7 +1135,8 @@ class ElementSelectionProxy extends BaseModel {
     activationPoint,
     mouseCoordsCurrent,
     mouseCoordsPrevious,
-    viewportTransform
+    viewportTransform,
+    globals
   ) {
     if (this.doesSelectionContainArtboard()) {
       return this.scaleArtboard(
@@ -869,33 +1148,194 @@ class ElementSelectionProxy extends BaseModel {
     }
 
     return this.scaleElements(
-      dx,
-      dy,
-      activationPoint
+      mouseCoordsCurrent,
+      mouseCoordsPrevious,
+      activationPoint,
+      globals
     )
   }
 
-  scaleElements (dx, dy, activationPoint) {
-    const accumulatedUpdates = {}
-    const proxyBoxPoints = this.getBoxPointsTransformed()
-    const fixedPoint = activationPoint.alt
-      ? this.getOriginTransformed()
-      : ElementSelectionProxy.getFixedPointForScale(proxyBoxPoints, activationPoint)
-    const translatedPoint = ElementSelectionProxy.getTranslatedPointForScale(proxyBoxPoints, activationPoint)
+  translateBoxPointsManual(boxPoints, delta){
+    return boxPoints.map((point) =>{
+      return {
+        x: point.x + delta.x,
+        y: point.y + delta.y
+      }
+    })
+  }
 
-    const delta = {
-      x: dx,
-      y: dy,
+  scaleElements (mouseCoordsCurrent, mouseCoordsPrevious, activationPoint, globals) {
+
+    let foundSnaps = []
+    const accumulatedUpdates = {}
+
+    const baseProxyBox = Object.assign({}, this._lastProxyBox)
+
+    //note an Object.assign({}, ...) doesn't suffice here because computeScalePropertyGroup mutates properties deeply
+    let baseTransform = _.cloneDeep(this.transformCache.peek('CONTROL_ACTIVATION'))
+
+    const fixedPoint = activationPoint.alt
+      ? this._lastOrigin
+      : ElementSelectionProxy.getFixedPointForScale(baseProxyBox, activationPoint)
+
+    let translatedPoint = ElementSelectionProxy.getTranslatedPointForScale(baseProxyBox, activationPoint)
+
+    const totalMouseDelta = {
+      x: mouseCoordsCurrent.x - this._lastMouseDownPosition.x,
+      y: mouseCoordsCurrent.y - this._lastMouseDownPosition.y,
       z: 0
     }
 
-    if (this.hasMultipleInSelection()) {
-      const cachedTransform = this.transformCache.peek('CONTROL_ACTIVATION')
-      if (!cachedTransform) {
-        return
+    let scalePropertyGroup = ElementSelectionProxy.computeScalePropertyGroup(
+      baseTransform,
+      fixedPoint,
+      translatedPoint,
+      totalMouseDelta,
+      activationPoint,
+      true,
+    )
+
+    let updatedLayout = _.cloneDeep(baseTransform)
+    updatedLayout.scale.x = scalePropertyGroup['scale.x'].value
+    updatedLayout.scale.y = scalePropertyGroup['scale.y'].value
+    updatedLayout.translation.x = scalePropertyGroup['translation.x'].value
+    updatedLayout.translation.y = scalePropertyGroup['translation.y'].value
+    let transformedPoints = _.cloneDeep(this._baseBoxPointsNotTransformed)
+    ElementSelectionProxy.transformPointsByLayoutInPlace(transformedPoints, updatedLayout)
+    //find axis-aligned bounding box; add each edge
+    let axisAlignedBbox = [
+      {name: "TOP", value: Math.min.apply(this, transformedPoints.map((p) => {return p.y}))},
+      {name: "RIGHT", value: Math.max.apply(this, transformedPoints.map((p) => {return p.x}))},
+      {name: "BOTTOM", value: Math.max.apply(this, transformedPoints.map((p) => {return p.y}))},
+      {name: "LEFT", value: Math.min.apply(this, transformedPoints.map((p) => {return p.x}))},
+    ]
+
+    const transformedTranslatedPoint = transformedPoints[activationPoint.index]
+
+    let filteredEdges = []
+
+    let isWithinEpsilon = (v0, v1, override) => {
+      return (v0 < v1 + (override || SNAP_EPSILON)) && (v0 > v1 - (override || SNAP_EPSILON))
+    }
+
+    //When scaling, we want to snap to the axis-aligned bounding box of the control points, a.k.a. the "super-bounding box."
+    //To complicate things though, the user expects only some of the edges of the bounding box to snap, depending on
+    //which control point is being dragged and the rotation of the element.  The logic below simplifies this 'lookup'
+    //based on observations of how the translated point and fixed point intersect with the axis-aligned bbox.
+    let isDraggingEdge = false
+
+    if(activationPoint.alt){
+      //TODO:  when alt is held, we care about all bounding edges
+      //BUT, the 'unusual' edges need to give a proper offset
+      //for now, disable snapping when alt-scaling
+      filteredEdges = []
+    }else if(activationPoint.shift){
+      //TODO:  when shift is held, break ties between horiz & vert (could refactor findSnapsMatchesAndBreakTies to handle based on flag, or could do a post-pass manually)
+      //for now, disable snapping when shift-scaling
+      filteredEdges = []
+    }else if([1,3,5,7].indexOf(activationPoint.index) > -1){
+      //When dragging an edge, check if the translated point is touching a bbox edge.  if it is,
+      //we care ONLY about that edge.  If it's not, we care about the bbox edges that its two neighbor (corners) are touching.
+      let onlyEdge = undefined
+      axisAlignedBbox.forEach((edge) => {
+        const isHoriz = (edge.name === 'TOP' || edge.name === 'BOTTOM')
+        if(isHoriz && isWithinEpsilon(transformedTranslatedPoint.y, edge.value, 10)) {
+          onlyEdge = edge
+        }else if(!isHoriz && isWithinEpsilon(transformedTranslatedPoint.x, edge.value, 10)) {
+          onlyEdge = edge
+        }
+      })
+      if(onlyEdge !== undefined){
+        filteredEdges = [onlyEdge]
+      }else{
+        //get neighbor points and find the edges they're touching
+        isDraggingEdge = true
+        const transformedNeighborPoints = ElementSelectionProxy.getNeighborPointsForScaleSnapping(transformedPoints, activationPoint)
+        filteredEdges = axisAlignedBbox.filter((edge) => {
+          const isHoriz = (edge.name === 'TOP' || edge.name === 'BOTTOM')
+          if(isHoriz && (isWithinEpsilon(transformedNeighborPoints[0].y, edge.value) || isWithinEpsilon(transformedNeighborPoints[1].y, edge.value))) return true
+          if(!isHoriz && (isWithinEpsilon(transformedNeighborPoints[0].x, edge.value) || isWithinEpsilon(transformedNeighborPoints[1].x, edge.value))) return true
+          return false
+        })
       }
+      
+    }else{
+      //TODO: Level up; when dragging a corner, we can handle adjacent corners by the following:
+      // - We don't want to snap to any edges that the fixed point is touching
+      // - Non 'active' corners (the ones that can still snap) have to provide an offset to the final
+      //   delta-x and delta-y, as there's a trig relationship between active point's positionX and non-active-point's positionY
+
+      // let transformedFixedPoint = activationPoint.alt
+      //    ? this._lastOrigin
+      //    : ElementSelectionProxy.getFixedPointForScale(transformedPoints, activationPoint)
+      //
+      // filteredEdges = axisAlignedBbox.filter((edge) => {
+      //   const isHoriz = (edge.name === 'TOP' || edge.name === 'BOTTOM')
+      //   if(isHoriz && isWithinEpsilon(transformedFixedPoint.y, edge.value)) return false
+      //   if(!isHoriz && isWithinEpsilon(transformedFixedPoint.x, edge.value)) return false
+      //   return true
+      // })
+
+      //Instead of the above, when dragging a corner, we only want to snap to the edge(s) that the translatedPoint is touching
+      filteredEdges = axisAlignedBbox.filter((edge) => {
+        const isHoriz = (edge.name === 'TOP' || edge.name === 'BOTTOM')
+        if(isHoriz && isWithinEpsilon(transformedTranslatedPoint.y, edge.value, 1)) return true
+        if(!isHoriz && isWithinEpsilon(transformedTranslatedPoint.x, edge.value, 1)) return true
+        return false
+      })
+    }
+
+    let snapDefinitions = filteredEdges.map((edge)=>{
+      const isHoriz = (edge.name === 'TOP' || edge.name === 'BOTTOM')
+      return {
+        name: edge.name,
+        direction: isHoriz ? 'HORIZONTAL' : 'VERTICAL',
+        bboxEdgePosition: edge.value,
+        metadata: {
+          offset: edge.value - transformedTranslatedPoint[isHoriz ? 'y' : 'x'],
+          isDraggingEdge
+        }
+      }
+    })
+
+    let artboard = Artboard.all()[0]
+    foundSnaps = this.findSnapsMatchesAndBreakTies(snapDefinitions, artboard.getSnapLinesInScreenCoords())
+    foundSnaps.forEach((snap)=>{
+      if(snap.direction === 'HORIZONTAL'){        
+        totalMouseDelta.y = (snap.positionWorld - (snap.metadata.offset || 0)) - (this._lastProxyBox[activationPoint.index].y)
+        if(snap.metadata && snap.metadata.isDraggingEdge){
+          //we know one of the deltas but must solve for the other based on our knowledge of the current
+          //rotation & the transform controls' absolute rotations.
+          let offsetRotation = this.getActivationPointInRadians(activationPoint.index)
+          let transformRotation = updatedLayout.rotation.z
+          let theta = (((offsetRotation + transformRotation) * 10000) % 62832) / 10000 //'mod' by 2*pi
+          totalMouseDelta.x = (totalMouseDelta.y / Math.tan(theta)) || 0 
+        }
+      }else{
+        totalMouseDelta.x = (snap.positionWorld - (snap.metadata.offset || 0)) - (this._lastProxyBox[activationPoint.index].x)
+        if(snap.metadata && snap.metadata.isDraggingEdge){
+          let offsetRotation = this.getActivationPointInRadians(activationPoint.index)
+          let transformRotation = updatedLayout.rotation.z
+          let theta = (((offsetRotation + transformRotation) * 10000) % 62832) / 10000 //'mod' by 2*pi
+          totalMouseDelta.y = (totalMouseDelta.x * Math.tan(theta)) || 0
+        }
+      }
+    })
+    if(foundSnaps.length){
+      baseTransform = _.cloneDeep(this.transformCache.peek('CONTROL_ACTIVATION'))
+      scalePropertyGroup = ElementSelectionProxy.computeScalePropertyGroup(
+        baseTransform,
+        fixedPoint,
+        translatedPoint,
+        totalMouseDelta,
+        activationPoint,
+        true,
+      )
+    }
+
+    if (this.hasMultipleInSelection()) {
       const matrixBeforeInverted = new Float32Array(16)
-      invertMatrix(matrixBeforeInverted, cachedTransform.matrix)
+      invertMatrix(matrixBeforeInverted, baseTransform.matrix)
 
       const {
         'scale.x': {
@@ -910,14 +1350,7 @@ class ElementSelectionProxy extends BaseModel {
         'translation.y': {
           value: translationY
         }
-      } = ElementSelectionProxy.computeScalePropertyGroup(
-        this,
-        fixedPoint,
-        translatedPoint,
-        delta,
-        activationPoint,
-        true
-      )
+      } = scalePropertyGroup
 
       this.applyPropertyValue('scale.x', scaleX)
       this.applyPropertyValue('scale.y', scaleY)
@@ -965,23 +1398,13 @@ class ElementSelectionProxy extends BaseModel {
       })
     } else {
       const element = this.selection[0]
-      const propertyGroup = ElementSelectionProxy.computeScalePropertyGroup(
-        element,
-        fixedPoint,
-        translatedPoint,
-        delta,
-        activationPoint,
-        // If we manage a single element, we _should_ apply the shift/alt constraints in this pass (because we _didn't_
-        // do so above).
-        true
-      )
 
       ElementSelectionProxy.accumulateKeyframeUpdates(
         accumulatedUpdates,
         element.getComponentId(),
         element.component.getCurrentTimelineName(),
         element.component.getCurrentTimelineTime(),
-        propertyGroup
+        scalePropertyGroup
       )
     }
 
@@ -993,6 +1416,9 @@ class ElementSelectionProxy extends BaseModel {
         this.clearAllRelatedCaches()
       }
     )
+
+    SingletonSnapEmitter.getInstance().emit('snaps-updated', foundSnaps)
+
   }
 
   scaleArtboard (
@@ -1156,7 +1582,7 @@ class ElementSelectionProxy extends BaseModel {
     )
   }
 
-  rotate (dx, dy, coordsCurrent, coordsPrevious, activationPoint) {
+  rotate (dx, dy, coordsCurrent, coordsPrevious, activationPoint, globals) {
     const accumulatedUpdates = {}
 
     if (this.hasMultipleInSelection()) {
@@ -1170,7 +1596,8 @@ class ElementSelectionProxy extends BaseModel {
         this,
         coordsCurrent,
         coordsPrevious,
-        activationPoint
+        activationPoint,
+        globals
       )
 
       this.applyPropertyDelta('rotation.z', rotationZ)
@@ -1194,7 +1621,8 @@ class ElementSelectionProxy extends BaseModel {
         this,
         coordsCurrent,
         coordsPrevious,
-        activationPoint
+        activationPoint,
+        globals
       )
       ElementSelectionProxy.accumulateKeyframeUpdates(
         accumulatedUpdates,
@@ -1350,10 +1778,6 @@ ElementSelectionProxy.activeAxesFromActivationPoint = (activationPoint) => {
   return activeAxes
 }
 
-ElementSelectionProxy.sizeDeltaCoefficientFromActivationPoint = (activationPoint) => {
-  return (activationPoint.alt ? 2 : 1)
-}
-
 ElementSelectionProxy.isActivationPointLeft = (activationPoint) => activationPoint.index % 3 === 0
 
 ElementSelectionProxy.isActivationPointTop = (activationPoint) => activationPoint.index < 3
@@ -1367,6 +1791,7 @@ ElementSelectionProxy.computeScaleInfoForArtboard = (
   // Disable origin scaling, which does not really make sense in this context.
   activationPoint.alt = false
   const boxPoints = targetElement.getBoxPointsTransformed()
+  targetElement.getTransf
   return ElementSelectionProxy.computeScalePropertyGroup(
     targetElement,
     ElementSelectionProxy.getFixedPointForScale(boxPoints, activationPoint),
@@ -1395,6 +1820,23 @@ ElementSelectionProxy.getFixedPointForScale = (proxyBoxPoints, activationPoint) 
   }
 }
 
+//For a given activation point, we're also interested in the snaps of its neighbors, for e.g.  
+ElementSelectionProxy.getNeighborPointsForScaleSnapping = (proxyBoxPoints, activationPoint) => {
+  switch (activationPoint.index) {
+    case 1:
+      return [proxyBoxPoints[0], proxyBoxPoints[2]]
+    case 3:
+      return [proxyBoxPoints[0], proxyBoxPoints[6]] 
+    case 5:
+      return [proxyBoxPoints[2], proxyBoxPoints[8]] 
+    case 7:
+      return [proxyBoxPoints[6], proxyBoxPoints[8]] 
+    default: //4 or other
+      throw new Error("Snapping behavior for 'center point' scaling is undefined")
+  }
+}
+
+
 ElementSelectionProxy.getTranslatedPointForScale = (proxyBoxPoints, activationPoint) => {
   switch (activationPoint.index) {
     case 5:
@@ -1410,19 +1852,20 @@ ElementSelectionProxy.getTranslatedPointForScale = (proxyBoxPoints, activationPo
 }
 
 ElementSelectionProxy.computeScalePropertyGroup = (
-  element,
+  targetLayout,
   fixedPointIn,
   translatedPointIn,
-  delta,
+  deltaIn,
   activationPoint,
-  applyConstraints
+  applyConstraints,
+  
 ) => {
   // Make a copy of inbound points so we can transform them in place.
   const fixedPoint = Object.assign({}, fixedPointIn)
   const translatedPoint = Object.assign({}, translatedPointIn)
+  const delta = _.cloneDeep(deltaIn)
   // We compute the entire scale property group by fixing a point (the *temporary* transform origin) and translating a
   // point (the point being dragged). These are represented by `fixedPoint` and `translatedPoint` respectively.
-  const targetLayout = element.getComputedLayout()
 
   // Prevent zero scale because matrix multiplication will lock the scale to zero permanently while interacting.
   if (targetLayout.scale.x === 0) targetLayout.scale.x = 0.0001
@@ -1553,6 +1996,16 @@ ElementSelectionProxy.computeScalePropertyGroup = (
   }
 }
 
+// This is used for a side-effect-free 'dry run' calculation of points through a layout spec
+ElementSelectionProxy.transformPointsByLayoutInPlace = (points, layout) => {
+  const ignoredSize = {x: 0, y: 0, z: 0}
+  const matrix = Layout3D.computeMatrix(layout, layout.size, layout.size)
+  return points.map((point)=>{
+    HaikuElement.transformPointInPlace(point, matrix)
+    return point
+  })
+}
+
 ElementSelectionProxy.computeRotationPropertyGroup = (element, rotationZDelta, fixedPoint) => {
   // Given a known rotation delta, we can directly compute the new property group for a subelement of a selection.
   //       target origin (x1, y1)
@@ -1627,7 +2080,8 @@ ElementSelectionProxy.computeRotationPropertyGroupDelta = (
   contextElement,
   coordsCurrent,
   coordsPrevious,
-  activationPoint
+  activationPoint,
+  globals
 ) => {
   // Calculate rotation delta based on old mouse position and new
   //  *(x0, y0)
@@ -1664,7 +2118,7 @@ ElementSelectionProxy.computeRotationPropertyGroupDelta = (
   const delta = ElementSelectionProxy.normalizeRotationDelta(theta1 - theta0)
 
   // If shift is held, snap to absolute increments of π / 12.
-  if (activationPoint.shift) {
+  if (globals.isShiftKeyDown) {
     const originalRotation = targetElement.computePropertyValue('rotation.z')
     if (!contextElement.rotationSnapOffset) {
       // Look at the directionality of the original requested rotation and round up/down according to the apparent wish
@@ -1754,3 +2208,4 @@ module.exports = ElementSelectionProxy
 // Down here to avoid Node circular dependency stub objects. #FIXME
 const Element = require('./Element')
 const Template = require('./Template')
+const Artboard = require('./Artboard')

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -849,7 +849,11 @@ class ElementSelectionProxy extends BaseModel {
     yEdge,
     toStage
   ) {
-    if(!this.selection || !this.selection.length) {
+    if(!this.selection) {
+      return
+    }
+
+    if(!toStage && this.selection.length < 2){
       return
     }
 
@@ -892,11 +896,11 @@ class ElementSelectionProxy extends BaseModel {
     if(toStage){
       let artboard = Artboard.all()[0]
       if(axis === 'x'){
-        min = origins[elementsSortedByBoundingEdge[0]._distributeOriginalIndex][axis] - elementsSortedByBoundingEdge[0]._distributeBbox.left
-        max = artboard._mountWidth// + (origins[elementsSortedByBoundingEdge[count - 1]._distributeOriginalIndex][axis] - elementsSortedByBoundingEdge[count - 1]._distributeBbox.right)
+        min = (this.getBboxValueFromEdgeValue(elementsSortedByBoundingEdge[0]._distributeBbox, xEdge, undefined) - elementsSortedByBoundingEdge[0]._distributeBbox.left)//origins[elementsSortedByBoundingEdge[0]._distributeOriginalIndex][axis] - elementsSortedByBoundingEdge[0]._distributeBbox.left
+        max = artboard._mountWidth - (elementsSortedByBoundingEdge[count - 1]._distributeBbox.right - this.getBboxValueFromEdgeValue(elementsSortedByBoundingEdge[count - 1]._distributeBbox, xEdge, undefined))
       }else{
         min = (this.getBboxValueFromEdgeValue(elementsSortedByBoundingEdge[0]._distributeBbox, undefined, yEdge) - elementsSortedByBoundingEdge[0]._distributeBbox.top)
-        max = artboard._mountHeight + (elementsSortedByBoundingEdge[0]._distributeBbox.top - this.getBboxValueFromEdgeValue(elementsSortedByBoundingEdge[0]._distributeBbox, undefined, yEdge))
+        max = artboard._mountHeight - (elementsSortedByBoundingEdge[count - 1]._distributeBbox.bottom - this.getBboxValueFromEdgeValue(elementsSortedByBoundingEdge[count - 1]._distributeBbox, undefined, yEdge))
       }
     }
 
@@ -1017,19 +1021,12 @@ class ElementSelectionProxy extends BaseModel {
         bbox = this.getBoundingClientRect()
       }
 
-      //SNAPPING:
-      //========
-
       //TODO:  
-      //       - handle snapping for origin
-      //       - simple align + distribute passes, since much logic is related
-      //         ^ bonus points for supporting "to stage," a la Flash
-      //       - clean-up pass:
-      //           - "screen space" from v0 may not be necessary; maybe can remove many matrix ops
-      //       - perf pass?
-      //           - perf could filter only snaps within viewport     
-      //           - perf could check snap lines and bounding box edges using bounding volumes,
-      //             instead of checking every element linearly+        
+      //  - handle snapping for origin
+      //  - perf pass on snapping?
+      //     - perf could filter only snaps within viewport     
+      //     - perf could check snap lines and bounding box edges using bounding volumes,
+      //       instead of checking every element linearly+        
 
       // Snapline {
       //  direction : "HORIZONTAL"|"VERTICAL"

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -11,7 +11,6 @@ const {Experiment, experimentIsEnabled} = require('haiku-common/lib/experiments'
 const Figma = require('./Figma')
 const Sketch = require('./Sketch')
 const Illustrator = require('./Illustrator')
-const EventEmitter = require('event-emitter')
 const SingletonSnapEmitter = require('./SingletonSnapEmitter')
 const _ = require('lodash')
 
@@ -724,7 +723,7 @@ class ElementSelectionProxy extends BaseModel {
               bboxEdgePosition: def.bboxEdgePosition,
               metadata: Object.assign({}, def.metadata, snap.metadata)
             }
-            for (var i = 0; i < horizWinners.length; i++) {
+            for (let i = 0; i < horizWinners.length; i++) {
               let oldWinner = horizWinners[i]
               let oldWinningDelta = Math.abs(oldWinner.bboxEdgePosition - oldWinner.positionWorld)
               if (winningDeltaHoriz + SNAP_EPSILON < oldWinningDelta) {
@@ -741,12 +740,12 @@ class ElementSelectionProxy extends BaseModel {
               bboxEdgePosition: def.bboxEdgePosition,
               metadata: Object.assign({}, def.metadata, snap.metadata)
             }
-            for (var i = 0; i < vertWinners.length; i++) {
-              let oldWinner = vertWinners[i]
+            for (let j = 0; j < vertWinners.length; j++) {
+              let oldWinner = vertWinners[j]
               let oldWinningDelta = Math.abs(oldWinner.bboxEdgePosition - oldWinner.positionWorld)
               if (winningDeltaVert + SNAP_EPSILON < oldWinningDelta) {
-                vertWinners.splice(i, 1)
-                i--
+                vertWinners.splice(j, 1)
+                j--
               }
             }
             vertWinners.push(newWinner)
@@ -992,8 +991,6 @@ class ElementSelectionProxy extends BaseModel {
     // handle snapping
     // don't snap if user is holding cmd key (like Sketch)
     if (!globals.isCommandKeyDown) {
-      const targetElement = this.shouldUseChildLayout() ? this.selection[0] : this
-
       let bbox
       if (this._lastBbox !== undefined) {
         bbox = ((bbox, delta) => {
@@ -1088,7 +1085,7 @@ class ElementSelectionProxy extends BaseModel {
         // only snap to the relevant axis
         if (isXAxis) {
           foundSnaps = foundSnaps.filter((snap) => { return snap.direction === 'VERTICAL' })
-          for (var i = 0; i < this.selection.length; i++) {
+          for (let i = 0; i < this.selection.length; i++) {
             overrides[i] = overrides[i] || {}
             overrides[i].y = this._originCache[i].y
             overrides.groupOrigin = overrides.groupOrigin || {}
@@ -1096,9 +1093,9 @@ class ElementSelectionProxy extends BaseModel {
           }
         } else {
           foundSnaps = foundSnaps.filter((snap) => { return snap.direction === 'HORIZONTAL' })
-          for (var i = 0; i < this.selection.length; i++) {
-            overrides[i] = overrides[i] || {}
-            overrides[i].x = this._originCache[i].x
+          for (let j = 0; j < this.selection.length; j++) {
+            overrides[j] = overrides[j] || {}
+            overrides[j].x = this._originCache[j].x
             overrides.groupOrigin = overrides.groupOrigin || {}
             overrides.groupOrigin.x = this._originCache.groupOrigin.x
           }
@@ -1259,6 +1256,7 @@ class ElementSelectionProxy extends BaseModel {
       case 0: return 5 * Math.PI / 4
       case 1: return 3 * Math.PI / 2
       case 2: return 7 * Math.PI / 4
+      default:
         throw new Error('Cannot retrieve radian value for provided activation point: ' + index)
     }
   }
@@ -1922,7 +1920,6 @@ ElementSelectionProxy.computeScaleInfoForArtboard = (
   // Disable origin scaling, which does not really make sense in this context.
   activationPoint.alt = false
   const boxPoints = targetElement.getBoxPointsTransformed()
-  targetElement.getTransf
   return ElementSelectionProxy.computeScalePropertyGroup(
     targetElement,
     ElementSelectionProxy.getFixedPointForScale(boxPoints, activationPoint),
@@ -1988,7 +1985,6 @@ ElementSelectionProxy.computeScalePropertyGroup = (
   deltaIn,
   activationPoint,
   applyConstraints
-
 ) => {
   // Make a copy of inbound points so we can transform them in place.
   const fixedPoint = Object.assign({}, fixedPointIn)
@@ -2128,7 +2124,6 @@ ElementSelectionProxy.computeScalePropertyGroup = (
 
 // This is used for a side-effect-free 'dry run' calculation of points through a layout spec
 ElementSelectionProxy.transformPointsByLayoutInPlace = (points, layout) => {
-  const ignoredSize = {x: 0, y: 0, z: 0}
   const matrix = Layout3D.computeMatrix(layout, layout.size, layout.size)
   return points.map((point) => {
     HaikuElement.transformPointInPlace(point, matrix)

--- a/packages/haiku-serialization/src/bll/SingletonSnapEmitter.js
+++ b/packages/haiku-serialization/src/bll/SingletonSnapEmitter.js
@@ -1,0 +1,11 @@
+
+//hack for data flow, since there's no elegant way to
+//get data from ElementSelectionProxy.js to Glass.js
+const EventEmitter = require('event-emitter')
+let _instance = new EventEmitter()
+
+class SingletonSnapEmitter {
+  static getInstance () {return _instance}
+}
+
+module.exports = SingletonSnapEmitter

--- a/packages/haiku-serialization/src/bll/SingletonSnapEmitter.js
+++ b/packages/haiku-serialization/src/bll/SingletonSnapEmitter.js
@@ -1,11 +1,11 @@
 
-//hack for data flow, since there's no elegant way to
-//get data from ElementSelectionProxy.js to Glass.js
+// hack for data flow, since there's no elegant way to
+// get data from ElementSelectionProxy.js to Glass.js
 const EventEmitter = require('event-emitter')
 let _instance = new EventEmitter()
 
 class SingletonSnapEmitter {
-  static getInstance () {return _instance}
+  static getInstance () { return _instance }
 }
 
 module.exports = SingletonSnapEmitter

--- a/packages/haiku-ui-common/src/react/OtherIcons.tsx
+++ b/packages/haiku-ui-common/src/react/OtherIcons.tsx
@@ -535,3 +535,96 @@ export const SyncIconSVG = ({color = '#93999A'}) => (
     <path d="M19.854 8.646a.5.5 0 0 0-.707 0l-1.149 1.149a7.94 7.94 0 0 0-2.341-5.452A7.948 7.948 0 0 0 10 2a7.988 7.988 0 0 0-7.077 4.266.5.5 0 0 0 .884.468A6.99 6.99 0 0 1 10 3c3.789 0 6.885 3.027 6.997 6.789l-1.143-1.143a.5.5 0 0 0-.707.707l2 2a.498.498 0 0 0 .708 0l2-2a.5.5 0 0 0 0-.707zM16.869 13.058a.5.5 0 0 0-.676.208A6.99 6.99 0 0 1 10 17c-3.789 0-6.885-3.027-6.997-6.789l1.143 1.143a.498.498 0 0 0 .708 0 .5.5 0 0 0 0-.707l-2-2a.5.5 0 0 0-.707 0l-2 2a.5.5 0 0 0 .707.707l1.149-1.149a7.94 7.94 0 0 0 2.341 5.452A7.948 7.948 0 0 0 10.001 18a7.988 7.988 0 0 0 7.077-4.266.5.5 0 0 0-.208-.676z" fill={color}/>
   </svg>
 );
+
+export const AlignDistributeIcons = {
+  AlignVLeft: ({color = '#636E71'}) => (
+    React.createElement('svg', {xmlns:'http://www.w3.org/2000/svg', width: '32', height: '32', viewBox: '0 0 32 32'},
+      React.createElement('line', {x1: '4.48', y1:'3.04', x2: '4.48', y2: '28.96', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('rect', {x: '7.36', y:'5.92', width:'11.52', height: '8.64', style: {fill: color}}),
+      React.createElement('rect', {x: '7.36', y:'17.44', width:'20.15', height: '8.64', style: {fill: color}}),
+    )
+  ),
+  AlignVMid: ({color = '#636E71'}) => (
+    React.createElement('svg', {xmlns:'http://www.w3.org/2000/svg', width: '32', height: '32', viewBox: '0 0 32 32'},
+      React.createElement('line', {x1: '16', y1:'3.04', x2: '16', y2: '28.96', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('rect', {x: '10.24', y:'5.92', width:'11.52', height: '8.64', style: {fill: color}}),
+      React.createElement('rect', {x: '5.92', y:'17.44', width:'20.15', height: '8.64', style: {fill: color}}),
+    )
+  ),
+  AlignVRight: ({color = '#636E71'}) => (
+    React.createElement('svg', {xmlns:'http://www.w3.org/2000/svg', width: '32', height: '32', viewBox: '0 0 32 32'},
+      React.createElement('line', {x1: '27.16', y1:'3.04', x2: '27.16', y2: '28.96', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('rect', {x: '13.48', y:'5.92', width:'11.52', height: '8.64', style: {fill: color}}),
+      React.createElement('rect', {x: '4.84', y:'17.44', width:'20.15', height: '8.64', style: {fill: color}}),
+    )
+  ),
+  AlignHTop: ({color = '#636E71'}) => (
+    React.createElement('svg', {xmlns:'http://www.w3.org/2000/svg', width: '32', height: '32', viewBox: '0 0 32 32'},
+      React.createElement('line', {x1:'3.04', y1:'4.84', x2:'28.96', y2:'4.84', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('rect', {x:'4.48', y:'8.44', width:'11.52', height:'8.64', transform:'translate(-2.52 23) rotate(-90)', style: {fill: color}}),
+      React.createElement('rect', {x:'11.68', y:'12.76', width:'20.15', height:'8.64', transform:'translate(4.68 38.84) rotate(-90)', style: {fill: color}}),
+    )
+  ),
+  AlignHMid: ({color = '#636E71'}) => (
+    React.createElement('svg', {xmlns:'http://www.w3.org/2000/svg', width: '32', height: '32', viewBox: '0 0 32 32'},
+      React.createElement('line', {x1:'3.04', y1:'16', x2:'28.96', y2:'16', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('rect', {x:'4.48', y:'11.68', width:'11.52', height:'8.64', transform:'translate(-5.76 26.24) rotate(-90)', style: {fill: color}}),
+      React.createElement('rect', {x:'11.68', y:'11.68', width:'20.15', height:'8.64', transform:'translate(5.76 37.76) rotate(-90)', style: {fill: color}}),
+    )
+  ),
+  AlignHBottom: ({color = '#636E71'}) => (
+    React.createElement('svg', {xmlns:'http://www.w3.org/2000/svg', width: '32', height: '32', viewBox: '0 0 32 32'},
+      React.createElement('line', {x1:'3.04', y1:'27.16', x2:'28.96', y2:'27.16', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('rect', {x:'4.48', y:'14.92', width:'11.52', height:'8.64', transform:'translate(-9 29.48) rotate(-90)', style: {fill: color}}),
+      React.createElement('rect', {x:'11.68', y:'10.6', width:'20.15', height:'8.64', transform:'translate(6.84 36.68) rotate(-90)', style: {fill: color}}),
+    )
+  ),
+  DistributeHTop: ({color = '#636E71'}) => (
+    React.createElement('svg', {xmlns:'http://www.w3.org/2000/svg', width: '32', height: '32', viewBox: '0 0 32 32'},
+      React.createElement('line', {x1:'28.96', y1:'5.85', x2:'3.04', y2:'5.85', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('line', {x1:'28.96', y1:'17.85', x2:'3.04', y2:'17.85', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('rect', {x:'10.24', y:'7.85', width:'11.52', height:'6', style: {fill: color}}),
+      React.createElement('rect', {x:'6.85', y:'19.85', width:'17.99', height:'7', transform:'translate(31.69 46.7) rotate(180)', style: {fill: color}}),
+    )
+  ),
+  DistributeHMid: ({color = '#636E71'}) => (
+    React.createElement('svg', {xmlns:'http://www.w3.org/2000/svg', width: '32', height: '32', viewBox: '0 0 32 32'},
+      React.createElement('line', {x1:'28.96', y1:'9.54', x2:'3.04', y2:'9.54', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('line', {x1:'28.96', y1:'21.96', x2:'3.04', y2:'21.96', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('rect', {x:'10.24', y:'6.54', width:'11.52', height:'6', style: {fill: color}}),
+      React.createElement('rect', {x:'7', y:'18.46', width:'17.99', height:'7', transform:'translate(32 43.92) rotate(180)', style: {fill: color}}),
+    )
+  ),
+  DistributeHBottom: ({color = '#636E71'}) => (
+    React.createElement('svg', {xmlns:'http://www.w3.org/2000/svg', width: '32', height: '32', viewBox: '0 0 32 32'},
+      React.createElement('line', {x1:'28.96', y1:'13.33', x2:'3.04', y2:'13.33', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('line', {x1:'28.96', y1:'26.31', x2:'3.04', y2:'26.31', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('rect', {x:'10.24', y:'5.69', width:'11.52', height:'6', style: {fill: color}}),
+      React.createElement('rect', {x:'7', y:'17.78', width:'17.99', height:'7', transform:'translate(32 42.57) rotate(180)', style: {fill: color}}),
+    )
+  ),
+  DistributeVLeft: ({color = '#636E71'}) => (
+    React.createElement('svg', {xmlns:'http://www.w3.org/2000/svg', width: '32', height: '32', viewBox: '0 0 32 32'},
+      React.createElement('line', {x1:'5.5', y1:'3.04', x2:'5.5', y2:'28.96', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('line', {x1:'17.5', y1:'3.04', x2:'17.5', y2:'28.96', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('rect', {x:'4.74', y:'13', width:'11.52', height:'6', transform:'translate(-5.5 26.5) rotate(-90)', style: {fill: color}}),
+      React.createElement('rect', {x:'14', y:'12.65', width:'17.99', height:'7', transform:'translate(39.15 -6.85) rotate(90)', style: {fill: color}}),
+    )
+  ),
+  DistributeVMid: ({color = '#636E71'}) => (
+    React.createElement('svg', {xmlns:'http://www.w3.org/2000/svg', width: '32', height: '32', viewBox: '0 0 32 32'},
+      React.createElement('line', {x1:'9.62', y1:'3.04', x2:'9.62', y2:'28.96', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('line', {x1:'22.04', y1:'3.04', x2:'22.04', y2:'28.96', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('rect', {x:'3.87', y:'13.12', width:'11.52', height:'5.76', transform:'translate(-6.38 25.62) rotate(-90)', style: {fill: color}}),
+      React.createElement('rect', {x:'13.04', y:'12.79', width:'17.99', height:'6.43', transform:'translate(38.04 -6.04) rotate(90)', style: {fill: color}}),
+    )
+  ),
+  DistributeVRight: ({color = '#636E71'}) => (
+    React.createElement('svg', {xmlns:'http://www.w3.org/2000/svg', width: '32', height: '32', viewBox: '0 0 32 32'},
+      React.createElement('line', {x1:'13.27', y1:'3.04', x2:'13.27', y2:'28.96', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('line', {x1:'26.25', y1:'3.04', x2:'26.25', y2:'28.96', style: {fill: 'none', stroke: color, strokeMiterlimit: '10', strokeWidth: '2px'}}),
+      React.createElement('rect', {x:'2.87', y:'13.12', width:'11.52', height:'5.76', transform:'translate(-7.37 24.63) rotate(-90)', style: {fill: color}}),
+      React.createElement('rect', {x:'12.23', y:'12.79', width:'17.99', height:'6.43', transform:'translate(37.22 -5.22) rotate(90)', style: {fill: color}}),
+    )
+  ),
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9330,6 +9330,8 @@ react-html-attributes@^1.3.0:
 react-icons@^2.2.7:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-2.2.7.tgz#d7860826b258557510dac10680abea5ca23cf650"
+  dependencies:
+    react-icon-base "2.1.0"
 
 react-inspector@^2.2.2:
   version "2.2.2"


### PR DESCRIPTION
OK to merge.

Medium/long review.

Summary of changes:

- Adds snapping for translate & scale
- Adds align & distribute

Known issues:

- Align/distribute operations are very fast, but when triggered from the Creator process there's high latency.  (When triggered from Glass, latency is low — you can see this by pressing the magic keys "k" and "l", which are each hard-wired to a specific align/distribute operation.)
- When an element is ROTATED and you are SCALING from an EDGE (non-corner,) there's a case where two corners NEARLY snap to respective horizontal and vertical lines, but in fact only one is actually snapped.  In this case, both horizontal & vertical lines show, when they should not.  I judged that the ratio of impact to fix-effort was small enough to let this slide for now.
 - When DISTRIBUTING tops & bottoms TO THE STAGE, sometimes elements spill slightly outside of the stage.  I'm unsure if this is actually the correct math or not (it does work as expected when distributing centers,) so I decided this was good enough to ship.
 - The align panel UI will not update its x/y position when it's active and the component button shows up or disappears.  Since I'm not sure this is even the ideal place/design for the align panel (would be nice for @taylorpoe to take a pass at some point,) I left this for now.


