### PR TITLE
feat: Copy/Paste tweens

### DIFF
--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -26,5 +26,7 @@
   "TimelineMarqueeSelection": true,
   "LocalAssetExport": false,
   "UserConsole": true,
-  "CleanInitialLibraryState": true
+  "CleanInitialLibraryState": true,
+  "CopyPasteTweens": true,
+  "CopyPasteTweensWithAccelerators": true
 }

--- a/packages/haiku-common/src/experiments/index.ts
+++ b/packages/haiku-common/src/experiments/index.ts
@@ -35,6 +35,8 @@ export enum Experiment {
   LocalAssetExport = 'LocalAssetExport',
   UserConsole = 'UserConsole',
   CleanInitialLibraryState = 'CleanInitialLibraryState',
+  CopyPasteTweens = 'CopyPasteTweens',
+  CopyPasteTweensWithAccelerators = 'CopyPasteTweensWithAccelerators',
 }
 
 /**

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -1930,7 +1930,7 @@ class ActiveComponent extends BaseModel {
 
   getFirstSelectedCurve () {
     const keyframes = this.getSelectedKeyframes()
-    const selectedKeyframeWithCurve = keyframes.first((keyframe) => keyframe.isSelectedBody())
+    const selectedKeyframeWithCurve = keyframes.find((keyframe) => keyframe.isSelectedBody())
     return selectedKeyframeWithCurve ? selectedKeyframeWithCurve.getCurve() : null
   }
 

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -1928,6 +1928,12 @@ class ActiveComponent extends BaseModel {
     })
   }
 
+  getFirstSelectedCurve () {
+    const keyframes = this.getSelectedKeyframes()
+    const selectedKeyframeWithCurve = keyframes.first((keyframe) => keyframe.isSelectedBody())
+    return selectedKeyframeWithCurve ? selectedKeyframeWithCurve.getCurve() : null
+  }
+
   dragStartSelectedKeyframes (dragData) {
     const keyframes = this.getSelectedKeyframes()
     keyframes.forEach((keyframe) => keyframe.dragStart(dragData))

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -364,8 +364,7 @@ class Keyframe extends BaseModel {
   }
 
   isTweenable () {
-    const value = this.getValue()
-    return typeof (value) !== 'boolean' && (typeof value === 'string' || value instanceof String)
+    return  typeof (this.value) !== 'boolean' && !(typeof this.value === 'string' || this.value instanceof String)
   }
 
   next () {

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -364,7 +364,7 @@ class Keyframe extends BaseModel {
   }
 
   isTweenable () {
-    return  typeof (this.value) !== 'boolean' && !(typeof this.value === 'string' || this.value instanceof String)
+    return typeof (this.value) !== 'boolean' && !(typeof this.value === 'string' || this.value instanceof String)
   }
 
   next () {

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -601,8 +601,6 @@ class Timeline extends React.Component {
     this.setState({isPreviewModeActive: isPreviewMode(interactionMode)})
   }
 
-
-
   getPopoverMenuItems ({ event, type, model, offset, curve }) {
     const items = []
 

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -589,17 +589,21 @@ class Timeline extends React.Component {
     this.setState({isPreviewModeActive: isPreviewMode(interactionMode)})
   }
 
+
+
   getPopoverMenuItems ({ event, type, model, offset, curve }) {
     const items = []
 
     const selectedKeyframes = this.getActiveComponent().getSelectedKeyframes()
     const numSelectedKeyframes = selectedKeyframes.length
+    const isTweenableTransitionSegment = type === 'keyframe-segment' && (model && model.isTweenable())
+    const useSingular = numSelectedKeyframes < 3
 
     items.push({
       label: 'Create Keyframe',
       enabled: (
         // During multi-select it's weird to show "Create Keyframe" in the menu
-        (numSelectedKeyframes < 3) &&
+        useSingular &&
         (
           type === 'keyframe-segment' ||
           type === 'keyframe-transition' ||
@@ -640,15 +644,15 @@ class Timeline extends React.Component {
     items.push({ type: 'separator' })
 
     items.push({
-      label: (numSelectedKeyframes < 3) ? 'Make Tween' : 'Make Tweens',
-      enabled: type === 'keyframe-segment' && (model && model.isTweenable()),
-      submenu: (type === 'keyframe-segment') && this.curvesMenu(curve, (event, curveName) => {
+      label: useSingular ? 'Make Tween' : 'Make Tweens',
+      enabled: isTweenableTransitionSegment,
+      submenu: isTweenableTransitionSegment && this.curvesMenu(curve, (event, curveName) => {
         this.getActiveComponent().joinSelectedKeyframes(curveName, { from: 'timeline' })
       })
     })
 
     items.push({
-      label: (numSelectedKeyframes < 3) ? 'Change Tween' : 'Change Tweens',
+      label: useSingular ? 'Change Tween' : 'Change Tweens',
       enabled: type === 'keyframe-transition',
       submenu: (type === 'keyframe-transition') && this.curvesMenu(curve, (event, curveName) => {
         this.getActiveComponent().changeCurveOnSelectedKeyframes(curveName, { from: 'timeline' })
@@ -656,7 +660,7 @@ class Timeline extends React.Component {
     })
 
     items.push({
-      label: (numSelectedKeyframes < 3) ? 'Remove Tween' : 'Remove Tweens',
+      label: useSingular ? 'Remove Tween' : 'Remove Tweens',
       enabled: type === 'keyframe-transition',
       onClick: (event) => {
         this.getActiveComponent().splitSelectedKeyframes({ from: 'timeline' })

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -597,13 +597,13 @@ class Timeline extends React.Component {
     const selectedKeyframes = this.getActiveComponent().getSelectedKeyframes()
     const numSelectedKeyframes = selectedKeyframes.length
     const isTweenableTransitionSegment = type === 'keyframe-segment' && (model && model.isTweenable())
-    const useSingular = numSelectedKeyframes < 3
+    const isSingular = numSelectedKeyframes < 3
 
     items.push({
       label: 'Create Keyframe',
       enabled: (
         // During multi-select it's weird to show "Create Keyframe" in the menu
-        useSingular &&
+        isSingular &&
         (
           type === 'keyframe-segment' ||
           type === 'keyframe-transition' ||
@@ -644,7 +644,7 @@ class Timeline extends React.Component {
     items.push({ type: 'separator' })
 
     items.push({
-      label: useSingular ? 'Make Tween' : 'Make Tweens',
+      label: isSingular ? 'Make Tween' : 'Make Tweens',
       enabled: isTweenableTransitionSegment,
       submenu: isTweenableTransitionSegment && this.curvesMenu(curve, (event, curveName) => {
         this.getActiveComponent().joinSelectedKeyframes(curveName, { from: 'timeline' })
@@ -652,7 +652,7 @@ class Timeline extends React.Component {
     })
 
     items.push({
-      label: useSingular ? 'Change Tween' : 'Change Tweens',
+      label: isSingular ? 'Change Tween' : 'Change Tweens',
       enabled: type === 'keyframe-transition',
       submenu: (type === 'keyframe-transition') && this.curvesMenu(curve, (event, curveName) => {
         this.getActiveComponent().changeCurveOnSelectedKeyframes(curveName, { from: 'timeline' })
@@ -660,7 +660,23 @@ class Timeline extends React.Component {
     })
 
     items.push({
-      label: useSingular ? 'Remove Tween' : 'Remove Tweens',
+      label: 'Copy Tween',
+      enabled: type === 'keyframe-transition' && isSingular,
+      onClick: (event) => {
+        this._lastCopiedCurve = curve
+      }
+    })
+
+    items.push({
+      label: 'Paste Tween',
+      enabled: isTweenableTransitionSegment && this._lastCopiedCurve,
+      onClick: (event) => {
+        this.getActiveComponent().changeCurveOnSelectedKeyframes(this._lastCopiedCurve, { from: 'timeline' })
+      }
+    })
+
+    items.push({
+      label: isSingular ? 'Remove Tween' : 'Remove Tweens',
       enabled: type === 'keyframe-transition',
       onClick: (event) => {
         this.getActiveComponent().splitSelectedKeyframes({ from: 'timeline' })

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1050,11 +1050,13 @@ class Timeline extends React.Component {
   }
 
   copySelectedCurve () {
+    this.props.mixpanel.haikuTrack('creator:timeline:copy-curve')
     this._lastCopiedCurve = this.getActiveComponent().getFirstSelectedCurve()
   }
 
   pasteSelectedCurve () {
     if (this._lastCopiedCurve) {
+      this.props.mixpanel.haikuTrack('creator:timeline:paste-curve')
       this.getActiveComponent().changeCurveOnSelectedKeyframes(
         this._lastCopiedCurve,
         { from: 'timeline' }

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -110,6 +110,8 @@ class Timeline extends React.Component {
     this.mouseUpListener = this.mouseUpListener.bind(this)
     this.onGaugeMouseDown = this.onGaugeMouseDown.bind(this)
     this.moveGaugeOnDoubleClick = this.moveGaugeOnDoubleClick.bind(this)
+    this.copySelectedCurve = this.copySelectedCurve.bind(this)
+    this.pasteSelectedCurve = this.pasteSelectedCurve.bind(this)
 
     this.handleCutDebounced = lodash.debounce(this.handleCut.bind(this), MENU_ACTION_DEBOUNCE_TIME, {leading: true, trailing: false})
     this.handleCopyDebounced = lodash.debounce(this.handleCopy.bind(this), MENU_ACTION_DEBOUNCE_TIME, {leading: true, trailing: false})
@@ -678,7 +680,7 @@ class Timeline extends React.Component {
 
       items.push({
         label: 'Paste Tween',
-        enabled: isTweenableTransitionSegment && this._lastCopiedCurve,
+        enabled: isTweenableTransitionSegment && Boolean(this._lastCopiedCurve),
         onClick: this.pasteSelectedCurve
       })
     }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

This adds a single feature, sectioned between two different feature flags:

- `right-click curve` -> copy curve; `right-click constant segment(s)` -> paste curve, hidden behind `CopyPasteTweens`
- `ctrl/cmd + c` on selected curve -> `ctrl/cmd + v` on constant segment(s) to paste, hidden behind `CopyPasteTweensWithAccelerators`

There's also a fix of faulty logic (371ec61 and d9110b7) related to hiding curves that are not tweenables.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [x] Added measurement instrumentation (Mixpanel, etc.)
