### PR TITLE
feat: wire up @haiku/sdk-inkstone endpoints for billing.

### DIFF
--- a/packages/@haiku/sdk-inkstone/src/config.ts
+++ b/packages/@haiku/sdk-inkstone/src/config.ts
@@ -1,0 +1,10 @@
+export interface InkstoneConfig {
+  baseUrl?: string;
+  baseShareUrl?: string;
+  authToken?: string;
+}
+
+export const inkstoneConfig: InkstoneConfig = {
+  baseUrl: 'https://inkstone.haiku.ai/',
+  baseShareUrl: 'https://share.haiku.ai/',
+};

--- a/packages/@haiku/sdk-inkstone/src/services.ts
+++ b/packages/@haiku/sdk-inkstone/src/services.ts
@@ -1,0 +1,135 @@
+import * as request from 'request';
+// @ts-ignore
+import packageJson = require('../package.json');
+import {inkstoneConfig} from './config';
+import {requestInstance} from './transport';
+
+export const enum Endpoints {
+  BillingDescribe = '/billing',
+  BillingListProducts = '/billing/products',
+  BillingSetCustomer = '/billing/customer',
+  BillingAddCard = '/billing/card',
+  BillingSetCardAsDefaultById = '/billing/card/:card_id/is_default',
+  BillingDeleteCardById = '/billing/card/:card_id',
+  BillingSetPlan = '/billing/plan',
+  BillingCancelPlan = '/billing/plan',
+}
+
+export interface UriParams {
+  [parameterName: string]: string;
+}
+
+export interface QueryParams {
+  [parameterName: string]: string|undefined;
+}
+
+export type MaybeAuthToken = string|undefined;
+
+export class RequestBuilder {
+  private url: string;
+  private json: any;
+  private readonly queryParams: QueryParams = {};
+  private readonly headers: request.Headers = {
+    'X-Haiku-Version': packageJson.version,
+    'Content-Type': 'application/json',
+  };
+
+  private setAuthToken (authToken: string) {
+    this.headers.Authorization = `INKSTONE auth_token="${authToken}"`;
+  }
+
+  constructor (private readonly method: (options: request.OptionsWithUrl, cb: request.RequestCallback) => void) {}
+
+  withEndpoint (endpoint: Endpoints) {
+    this.url = `${inkstoneConfig.baseUrl}v0${endpoint}`;
+    return this;
+  }
+
+  withUrlParameters (params: UriParams) {
+    for (const param in params) {
+      this.url = this.url.replace(param, params[param]);
+    }
+    return this;
+  }
+
+  /**
+   * @deprecated - prefer config-based and/or cookie-based auth tokens!
+   */
+  withAuthToken (authToken: MaybeAuthToken) {
+    if (authToken) {
+      this.setAuthToken(authToken);
+    }
+    return this;
+  }
+
+  withJson (json: any) {
+    this.json = json;
+    return this;
+  }
+
+  withQueryParams (params: QueryParams) {
+    Object.assign(this.queryParams, params);
+    return this;
+  }
+
+  get fullUrl () {
+    if (Object.keys(this.queryParams).length === 0) {
+      return this.url;
+    }
+
+    const expandedParams = [];
+    for (const param in this.queryParams) {
+      expandedParams.push(`${param}=${encodeURIComponent(this.queryParams[param])}`);
+    }
+
+    return `${this.url}?${expandedParams.join('&')}`;
+  }
+
+  get fullHeaders () {
+    if (inkstoneConfig.authToken) {
+      this.setAuthToken(inkstoneConfig.authToken);
+    }
+
+    return this.headers;
+  }
+
+  call (cb: request.RequestCallback) {
+    if (!this.url) {
+      throw new Error('No URL specified!');
+    }
+
+    this.method(
+      {
+        headers: this.fullHeaders,
+        json: this.json,
+        url: this.fullUrl,
+      },
+      (err, httpResponse, body) => {
+        cb(err || new Error('Uncategorized error'), httpResponse, body);
+      },
+    );
+  }
+
+  callWithCallback<T> (
+    cb: (err: string, data: T, response: request.RequestResponse) => void,
+    successCode = 200,
+    parseJson = true,
+  ) {
+    this.call((err, httpResponse, body) => {
+      if (httpResponse && httpResponse.statusCode === successCode) {
+        cb(
+          undefined,
+          ((body && parseJson) ? JSON.parse(body) : (body || null)) as T,
+          httpResponse,
+        );
+      } else {
+        cb(err, null, httpResponse);
+      }
+    });
+  }
+}
+
+export const newGetRequest = () => new RequestBuilder(requestInstance.get);
+export const newPostRequest = () => new RequestBuilder(requestInstance.post);
+export const newPutRequest = () => new RequestBuilder(requestInstance.put);
+export const newDeleteRequest = () => new RequestBuilder(requestInstance.delete);

--- a/packages/@haiku/sdk-inkstone/src/transport.ts
+++ b/packages/@haiku/sdk-inkstone/src/transport.ts
@@ -1,0 +1,42 @@
+import * as request from 'request';
+
+export interface RequestInstance {
+  get: (options: request.OptionsWithUrl, cb: request.RequestCallback) => void;
+  post: (options: request.OptionsWithUrl, cb: request.RequestCallback) => void;
+  put: (options: request.OptionsWithUrl, cb: request.RequestCallback) => void;
+  delete: (options: request.OptionsWithUrl, cb: request.RequestCallback) => void;
+}
+
+const getInstanceWithDefaults = (defaults: request.CoreOptions): RequestInstance => {
+  if (typeof request.defaults === 'function') {
+    return request.defaults(defaults);
+  }
+
+  return {
+    get: (options: request.OptionsWithUrl, cb: request.RequestCallback) => request.get(
+      {...defaults, ...options},
+      cb,
+    ),
+    post: (options: request.OptionsWithUrl, cb: request.RequestCallback) => request.post(
+      {...defaults, ...options},
+      cb,
+    ),
+    put: (options: request.OptionsWithUrl, cb: request.RequestCallback) => request.put(
+      {...defaults, ...options},
+      cb,
+    ),
+    delete: (options: request.OptionsWithUrl, cb: request.RequestCallback) => request.del(
+      {...defaults, ...options},
+      cb,
+    ),
+  };
+};
+
+export const requestInstance = getInstanceWithDefaults({
+  // Delegate to the browser to handle "strictSSL" if we're in a browser context. We have seen some false
+  // negatives with the 'request' Node dependency in certain contextx, and every modern browser has its own,
+  // battle-hardened strict SSL behavior which will stop requests in preflight regardless of this setting.
+  // There isn't an unspoofable way to prove we're in a browser and not Node, but the check here is perfectly valid.
+  strictSSL: typeof window === 'undefined' || Object.prototype.toString.call(window) !== '[object Window]',
+  withCredentials: true,
+});

--- a/packages/@haiku/sdk-inkstone/test/index.test.ts
+++ b/packages/@haiku/sdk-inkstone/test/index.test.ts
@@ -1,8 +1,34 @@
+import {inkstoneConfig} from '@sdk-inkstone/config';
+import {inkstone} from '@sdk-inkstone/index';
 import * as tape from 'tape';
 
 tape('index', (suite: tape.Test) => {
-  suite.test('the truth is true', (test: tape.Test) => {
-    test.true(true);
+  suite.test('setConfig', (test: tape.Test) => {
+    test.is(inkstoneConfig.baseUrl, 'https://inkstone.haiku.ai/', 'default base URL');
+    test.is(inkstoneConfig.baseShareUrl, 'https://share.haiku.ai/', 'default base share URL');
+    test.is(inkstoneConfig.authToken, undefined, 'default auth token is undefined');
+    inkstone.setConfig({
+      baseUrl: 'baseUrl',
+      baseShareUrl: 'baseShareUrl',
+      authToken: 'foobar',
+    });
+    test.deepEqual(
+      inkstoneConfig,
+      {
+        baseUrl: 'baseUrl',
+        baseShareUrl: 'baseShareUrl',
+        authToken: 'foobar',
+      },
+      'inkstone.setConfig overrides defaults',
+    );
+
+    // Restore defaults for future tests.
+    inkstone.setConfig({
+      baseUrl: 'https://inkstone.haiku.ai/',
+      baseShareUrl: 'https://share.haiku.ai/',
+      authToken: undefined,
+    });
+
     test.end();
   });
 

--- a/packages/@haiku/sdk-inkstone/test/services.test.ts
+++ b/packages/@haiku/sdk-inkstone/test/services.test.ts
@@ -1,0 +1,37 @@
+import {newPutRequest} from '@sdk-inkstone/services';
+import {requestInstance} from '@sdk-inkstone/transport';
+import {stubProperties} from 'haiku-testing/lib/mock';
+import * as tape from 'tape';
+
+tape('services', (suite: tape.Test) => {
+  suite.test('RequestBuilder.e2e', (test: tape.Test) => {
+    const [mockPut, unstub] = stubProperties(requestInstance, 'put');
+    newPutRequest()
+      // @ts-ignore
+      .withEndpoint('/foo/:id')
+      .withUrlParameters({':id': 'fooId'})
+      .withAuthToken('auth-token')
+      .withJson({stuff: 'blah'})
+      .withQueryParams({hey: 'ho'})
+      .call(() => {});
+
+    test.deepEqual(
+      mockPut.getCall(0).args[0],
+      {
+        headers: {
+          'X-Haiku-Version': require('../package.json').version,
+          'Content-Type': 'application/json',
+          Authorization: 'INKSTONE auth_token="auth-token"',
+        },
+        json: {stuff: 'blah'},
+        url: 'https://inkstone.haiku.ai/v0/foo/fooId?hey=ho',
+      },
+      'called with expected parameters',
+    );
+
+    unstub();
+    test.end();
+  });
+
+  suite.end();
+});


### PR DESCRIPTION
OK to merge. More changes coming on this branch, but will merge after health checks pass.

cc: @roperzh for visibility.

Short review.

Summary of changes:

- Adds a new, tighter/DRYer factory(-ish) pattern for calling endpoints. Self-explanatory, but worth noting auth headers can now be set via config (`inkstone.setConfig({authToken: '...'});`) or via cookies (no action required; inkstone sends cookies automatically and in the browser, cookies "just work"). Cookies are preferred, and for a browser-based application (like all the new billing stuff) no auth tokens need to be dealt with—just make sure the user is signed in before calling an endpoint that requires a signed-in user! New points requiring authentication are annotated with `@authentication-required`.
- Implements endpoints and docs for billing functionality.

Regressions to look for:

- None—I left everything else alone, but designed the request factory to ensure migration will be a pleasant (future) task.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test for existing and modified functionality