### PR TITLE
Sdk billing tweaks

### DIFF
--- a/packages/@haiku/sdk-inkstone/src/index.ts
+++ b/packages/@haiku/sdk-inkstone/src/index.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-namespace */
 import * as request from 'request';
 import {InkstoneConfig, inkstoneConfig} from './config';
-import {Endpoints, MaybeAuthToken, newDeleteRequest, newGetRequest, newPutRequest} from './services';
+import {Endpoints, MaybeAuthToken, newDeleteRequest, newGetRequest, newPostRequest, newPutRequest} from './services';
 import {requestInstance} from './transport';
 
 // tslint:disable-next-line:no-var-requires
@@ -1136,7 +1136,7 @@ export namespace inkstone {
      * @see {@link https://stripe.com/docs/stripe-js/reference#stripe-create-token}
      */
     export const addCard = (card: AddCardRequestParams, cb: inkstone.Callback<void>) => {
-      newPutRequest()
+      newPostRequest()
         .withEndpoint(Endpoints.BillingAddCard)
         .withJson(card)
         .callWithCallback<void>(cb, 204);

--- a/packages/@haiku/sdk-inkstone/src/services.ts
+++ b/packages/@haiku/sdk-inkstone/src/services.ts
@@ -113,7 +113,7 @@ export class RequestBuilder {
   callWithCallback<T> (
     cb: (err: string, data: T, response: request.RequestResponse) => void,
     successCode = 200,
-    parseJson = true,
+    parseJson = false,
   ) {
     this.call((err, httpResponse, body) => {
       if (httpResponse && httpResponse.statusCode === successCode) {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- fix: change sdk-inkstone addCard to do a POST request
- fix: do not parse JSON by default in sdk-inkstone request, I couldn't figure out why at first glance, but the body of the request is already being parsed before reaching this method, causing an error when trying to parse a JS object.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
