### PR TITLE
chore: upgrade electron to 2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "dependency-graph": "^0.5.0",
     "derequire": "^2.0.6",
     "dotenv": "^5.0.1",
-    "electron": "2.0.2",
+    "electron": "2.0.4",
     "electron-builder": "20.15.1",
     "electron-rebuild": "^1.7.3",
     "fs-extra": "^4.0.2",
@@ -104,7 +104,7 @@
     "nodeGypRebuild": false,
     "productName": "Haiku",
     "forceCodeSigning": true,
-    "electronVersion": "2.0.2",
+    "electronVersion": "2.0.4",
     "mac": {
       "category": "public.app-category.developer-tools",
       "target": [

--- a/packages/haiku-common/package.json
+++ b/packages/haiku-common/package.json
@@ -21,7 +21,7 @@
   ],
   "license": "UNLICENSED",
   "devDependencies": {
-    "electron": "2.0.2",
+    "electron": "2.0.4",
     "haiku-testing": "3.5.1"
   },
   "dependencies": {

--- a/packages/haiku-creator/package.json
+++ b/packages/haiku-creator/package.json
@@ -67,7 +67,7 @@
     "@types/fs-extra": "^4.0.8",
     "@types/node-fetch": "^2.1.1",
     "@types/qs": "^6.5.1",
-    "electron": "2.0.2",
+    "electron": "2.0.4",
     "electron-devtools-installer": "^2.2.4",
     "haiku-testing": "3.5.1"
   }

--- a/packages/haiku-glass/package.json
+++ b/packages/haiku-glass/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "async": "^2.5.0",
-    "electron": "2.0.2",
+    "electron": "2.0.4",
     "haiku-testing": "3.5.1",
     "jsdom": "^11.1.0",
     "prop-types": "^15.6.0"

--- a/packages/haiku-plumbing/package.json
+++ b/packages/haiku-plumbing/package.json
@@ -66,7 +66,7 @@
     "@types/es6-promise": "^3.3.0",
     "@types/semver": "^5.4.1",
     "@types/fs-extra": "^4.0.8",
-    "electron": "2.0.2",
+    "electron": "2.0.4",
     "haiku-creator": "3.5.1",
     "haiku-testing": "3.5.1",
     "leaked-handles": "^5.2.0",

--- a/packages/haiku-timeline/package.json
+++ b/packages/haiku-timeline/package.json
@@ -42,7 +42,7 @@
     "strip-indent": "^2.0.0"
   },
   "devDependencies": {
-    "electron": "2.0.2",
+    "electron": "2.0.4",
     "haiku-testing": "3.5.1",
     "jsdom": "^11.1.0"
   }

--- a/packages/haiku-ui-common/package.json
+++ b/packages/haiku-ui-common/package.json
@@ -28,7 +28,7 @@
     "@types/dedent": "^0.7.0",
     "@types/numeral": "^0.0.22",
     "@types/react": "^15.4.2",
-    "electron": "2.0.2",
+    "electron": "2.0.4",
     "haiku-testing": "3.5.1",
     "url-loader": "^1.0.1",
     "webpack-conditional-loader": "^1.0.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4321,9 +4321,9 @@ electron-to-chromium@^1.3.30:
   dependencies:
     electron-releases "^2.1.0"
 
-electron@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.2.tgz#b77e05f83419cc5ec921a2d21f35b55e4bfc3d68"
+electron@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.4.tgz#87b86b8d9c13748032868c1be97e2b7021a51808"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
OK to merge after testing build is not a dud.

Short review.

Summary of changes:

- Upgrade electron `2.0.2` -> `2.0.4`.

Regressions to look for:

- Unknowable.