### PR TITLE
Library and Sketch fixes

### DIFF
--- a/packages/haiku-creator/src/react/components/SketchDownloader.js
+++ b/packages/haiku-creator/src/react/components/SketchDownloader.js
@@ -1,154 +1,49 @@
 import * as React from 'react';
-import {download, createSketchDialogFile} from 'haiku-serialization/src/utils/HaikuHomeDir';
+import {createSketchDialogFile} from 'haiku-serialization/src/utils/HaikuHomeDir';
 import {DOWNLOAD_STYLES as STYLES} from '../styles/downloadShared';
-import * as logger from 'haiku-serialization/src/utils/LoggerInstance';
+import {ExternalLink} from 'haiku-ui-common/lib/react/ExternalLink';
 
-const statuses = {
-  PROMPT_USER: 'PromptUser',
-  DOWNLOADING: 'Downloading',
-  DOWNLOAD_FAILED: 'DownloadFailed',
-};
+const DOWNLOAD_URL = 'https://download.sketchapp.com/sketch.zip';
 
-class SketchDownloader extends React.Component {
-  constructor (props) {
-    super(props);
-
-    this.hide = this.hide.bind(this);
-    this.download = this.download.bind(this);
-    this.updateProgress = this.updateProgress.bind(this);
-    this.onFail = this.onFail.bind(this);
-
-    this.state = {
-      status: statuses.PROMPT_USER,
-      progress: 0,
-      shouldCancel: false,
-    };
-  }
-
-  componentWillReceiveProps () {
-    this.setState({status: statuses.PROMPT_USER});
-  }
-
-  download (url) {
-    this.setState({status: statuses.DOWNLOADING});
-    this.dismiss();
-
-    download(this.updateProgress, () => this.state.shouldCancel)
-      .then(() => {
-        this.props.onDownloadComplete();
-      })
-      .catch((error) => {
-        error.message === 'Download cancelled' ? this.hide() : this.onFail(error);
-      });
-  }
-
-  updateProgress (progress) {
-    this.setState({progress});
-  }
-
-  onFail (error) {
-    this.setState({
-      status: statuses.DOWNLOAD_FAILED,
-      progress: 0,
-      shouldCancel: false,
-    });
-
-    logger.error(error);
-  }
-
-  hide () {
-    this.setState({
-      status: statuses.IDLE,
-      progress: 0,
-      shouldCancel: false,
-    });
-
-    this.dismiss();
-  }
-
-  dismiss () {
+class SketchDownloader extends React.PureComponent {
+  dismiss = () => {
     if (this.checkInput.checked) {
       createSketchDialogFile();
     }
 
     this.props.onDismiss(!this.checkInput.checked);
-  }
-
-  renderPromptUser () {
-    return (
-      <div>
-        <p>
-          Sketch is required to edit this file. <br />
-          You can install a 30-day trial for free.
-        </p>
-        <p>Would you like to download Sketch?</p>
-
-        <form action="#" style={STYLES.formInput}>
-          <input
-            type="checkbox"
-            name="not-show-again"
-            id="not-show-again"
-            style={STYLES.checkInput}
-            ref={(input) => {
-              this.checkInput = input;
-            }} />
-          <label htmlFor="not-show-again">Don't show this again.</label>
-        </form>
-
-        <button style={STYLES.btnSecondary} onClick={this.hide}>
-          Not now
-        </button>
-        <button style={STYLES.btn} onClick={this.download}>
-          Yes
-        </button>
-      </div>
-    );
-  }
-
-  renderDownloading () {
-    const progress = this.state.progress.toFixed(1);
-
-    return (
-      <div>
-        <span>Downloading and installing...</span>
-        <p style={STYLES.progressNumber}>{progress} %</p>
-        <progress value={progress} max="100" style={STYLES.progressBar}>
-          {progress} %
-        </progress>
-        <button
-          style={STYLES.btn}
-          onClick={() => this.setState({shouldCancel: true})}
-        >
-          Cancel
-        </button>
-      </div>
-    );
-  }
-
-  renderDownloadFailed () {
-    return (
-      <div>
-        <p>
-          There was an error downloading Sketch, if the problem persists, please
-          contact Haiku support.
-        </p>
-        <button style={STYLES.btn} onClick={this.hide}>
-          Ok
-        </button>
-      </div>
-    );
-  }
+  };
 
   render () {
-    const {status} = this.state;
-    if (status === statuses.IDLE) {
-      return null;
-    }
-    const content = this[`render${status}`]();
-
     return (
       <div>
-        <div style={STYLES.container}>{content}</div>
+        <div style={STYLES.container}>
+          <p>
+            Sketch is required to edit this file. <br />
+            You can install a 30-day trial for free.
+          </p>
+          <p>Would you like to download it?</p>
+
+          <form action="#" style={STYLES.formInput}>
+            <input
+              type="checkbox"
+              name="not-show-again"
+              id="not-show-again"
+              style={STYLES.checkInput}
+              ref={(input) => {
+                this.checkInput = input;
+              }} />
+            <label htmlFor="not-show-again">Don't show this again.</label>
+          </form>
+
+          <button style={STYLES.btnSecondary} onClick={this.dismiss}>
+            Not now
+          </button>
+
+          <ExternalLink href={DOWNLOAD_URL} style={STYLES.btn} onClick={this.dismiss}>
+            Get Sketch
+          </ExternalLink>
+        </div>
         <div style={STYLES.overlay} />
       </div>
     );

--- a/packages/haiku-creator/src/react/components/library/AssetItem.js
+++ b/packages/haiku-creator/src/react/components/library/AssetItem.js
@@ -532,7 +532,14 @@ class AssetItem extends React.Component {
     if (this.props.asset.isComponentsHostFolder()) {
       return `
         To create a component, select elements on stage and choose
-        "Create Component" from the element menu
+        "Create Component" from the element menu.
+      `;
+    }
+
+    if (this.props.asset.isDesignsHostFolder()) {
+      return `
+        To import a new design file, click on the + sign above and choose "Import from
+        file" from the menu options.
       `;
     }
 

--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -85,7 +85,6 @@ class Library extends React.Component {
       isLoading: false,
       figma: null,
       sketchDownloader: {
-        asset: null,
         isVisible: false,
         shouldAskForSketch: !didAskedForSketch(),
       },
@@ -95,12 +94,18 @@ class Library extends React.Component {
     this.handleAssetDeletion = this.handleAssetDeletion.bind(this);
     this.importFigmaAsset = this.importFigmaAsset.bind(this);
     this.askForFigmaAuth = this.askForFigmaAuth.bind(this);
+    this.onSketchDialogDismiss = this.onSketchDialogDismiss.bind(this);
 
     // Debounced to avoid 'flicker' when multiple updates are received quickly
     this.handleAssetsChanged = lodash.debounce(this.handleAssetsChanged.bind(this), 250);
 
     this.broadcastListener = this.broadcastListener.bind(this);
     this.onAuthCallback = this.onAuthCallback.bind(this);
+
+    // We call this here because this is an expensive operation and we want to avoid
+    // executing it when the user tries to open a Sketch file. This first call
+    // sets a cache in the module so further calls are very quick.
+    sketchUtils.checkIfInstalled();
   }
 
   broadcastListener ({name, assets, data}) {
@@ -122,10 +127,6 @@ class Library extends React.Component {
 
     this.props.websocket.on('broadcast', this.broadcastListener);
     ipcRenderer.on('open-url:oauth', this.onAuthCallback);
-
-    sketchUtils.checkIfInstalled().then((sketchInstallationPath) => {
-      this.isSketchInstalled = Boolean(sketchInstallationPath);
-    });
 
     // TODO: perform an actual check for Illustrator
     this.isIllustratorInstalled = true;
@@ -270,14 +271,16 @@ class Library extends React.Component {
   }
 
   handleSketchLaunch (asset) {
-    if (this.isSketchInstalled) {
-      mixpanel.haikuTrack('creator:sketch:open-file');
-      openWithDefaultProgram(asset);
-    // On library Sketch asset double click, ask to download Sketch only if on mac
-    } else if (isMac()) {
-      mixpanel.haikuTrack('creator:sketch:sketch-not-installed');
-      this.setState({sketchDownloader: {...this.state.sketchDownloader, isVisible: true, asset}});
-    }
+    sketchUtils.checkIfInstalled().then((isSketchInstalled) => {
+      if (isSketchInstalled) {
+        mixpanel.haikuTrack('creator:sketch:open-file');
+        openWithDefaultProgram(asset);
+        // On library Sketch asset double click, ask to download Sketch only if on mac
+      } else if (isMac()) {
+        mixpanel.haikuTrack('creator:sketch:sketch-not-installed');
+        this.setState({sketchDownloader: {...this.state.sketchDownloader, isVisible: true}});
+      }
+    });
   }
 
   handleIllustratorLaunch (asset) {
@@ -296,14 +299,9 @@ class Library extends React.Component {
     }
   }
 
-  onSketchDownloadComplete () {
-    this.isSketchInstalled = true;
-    openWithDefaultProgram(this.state.sketchDownloader.asset);
-    this.setState({sketchDownloader: {...this.state.sketchDownloader, isVisible: false, asset: null}});
-  }
-
   onSketchDialogDismiss (shouldAskForSketch) {
-    this.setState({sketchDownloader: {...this.state.sketchDownloader, isVisible: false, shouldAskForSketch}});
+    this.setState({sketchDownloader: {isVisible: false, shouldAskForSketch}});
+    sketchUtils.unsetSketchInstalledCache();
   }
 
   handleComponent (asset) {
@@ -441,8 +439,7 @@ class Library extends React.Component {
           this.state.sketchDownloader.isVisible &&
           this.state.sketchDownloader.shouldAskForSketch && (
             <SketchDownloader
-              onDownloadComplete={this.onSketchDownloadComplete.bind(this)}
-              onDismiss={this.onSketchDialogDismiss.bind(this)}
+              onDismiss={this.onSketchDialogDismiss}
             />
           )
         }

--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -372,11 +372,13 @@ class Library extends React.Component {
 
   shouldDisplayAssetCreator () {
     const designsFolder = this.state.assets.find((asset) => asset.isDesignsHostFolder());
+    const componentshostFolder = this.state.assets.find((asset) => asset.isComponentsHostFolder());
 
     return (
       experimentIsEnabled(Experiment.CleanInitialLibraryState) &&
       designsFolder &&
       designsFolder.getChildAssets().length === 0 &&
+      componentshostFolder.getChildAssets().length === 0 &&
       !this.state.isLoading
     );
   }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fix: [Sketch Downloader not working"](https://app.asana.com/0/735620450158182/740776914033573), we are also removing the logic to download Sketch from the app, by providing a link instead. (h/t: to @agustinafeijoo for the copy/CTA change, please feel free voice if you think it needs rewording).
- Implement a simple cache for `sketchUtils.checkIfInstalled`.
- Fix: ["Library doesn't show components when only components (but no design assets) exist"](https://app.asana.com/0/735620450158182/741981064606395).
- Add a help message when the assets host folder is empty.

Regressions to look for:

- Not aware of any

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [x] Added measurement instrumentation (Mixpanel, etc.)
