### PR TITLE
fix: Sketch integration

### DIFF
--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -272,7 +272,7 @@ class Library extends React.Component {
 
   handleSketchLaunch (asset) {
     sketchUtils.checkIfInstalled().then((isSketchInstalled) => {
-      if (isSketchInstalled) {
+      if (Boolean(isSketchInstalled)) {
         mixpanel.haikuTrack('creator:sketch:open-file');
         openWithDefaultProgram(asset);
         // On library Sketch asset double click, ask to download Sketch only if on mac

--- a/packages/haiku-serialization/src/utils/sketchUtils.js
+++ b/packages/haiku-serialization/src/utils/sketchUtils.js
@@ -81,9 +81,8 @@ module.exports = {
           .then(this.pathsToInstallationInfo)
           .then(this.findBestPath)
           .then((bestPath) => {
-            const isInstalled = Boolean(bestPath)
-            sketchInstalledCache = isInstalled
-            resolve(isInstalled)
+            sketchInstalledCache = Boolean(bestPath)
+            resolve(bestPath)
           })
           .catch((error) => {
             logger.info('[sketch utils] error finding Sketch: ', error)


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes the Sketch integration that I broke yesterday with #609 by sending the Sketch path instead of a boolean in `Sketchutils.checkIfInstalled`, apologies for that; I did a global search to see where the method was used but for some reason I failed to see that was used in there.

Regressions to look for:

- not aware of any

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
