### PR TITLE
tweak: forward the restful error code from inkstone if available.

### DIFF
--- a/packages/@haiku/sdk-inkstone/src/index.ts
+++ b/packages/@haiku/sdk-inkstone/src/index.ts
@@ -1067,24 +1067,15 @@ export namespace inkstone {
       IsDefault: boolean;
     }
 
-    export interface Profile {
-      Customer: Customer;
-      Cards: Card[];
-    }
-
     export interface Plan {
       ID: string;
       Currency: 'usd'; // For now!
       Interval: 'year'|'month';
       Price: number;
+      IsCurrentPlan: boolean;
     }
 
-    export interface Product {
-      Name: string;
-      Plans: Plan[];
-    }
-
-    export interface PlanOverview {
+    export interface Subscription {
       // CurrentPeriodStart and CurrentPeriodEnd are provided as UNIX timestamps.
       CurrentPeriodStart: number;
       CurrentPeriodEnd: number;
@@ -1093,9 +1084,24 @@ export namespace inkstone {
       DaysUntilDue: number;
     }
 
+    export interface Profile {
+      Customer: Customer;
+      Cards: Card[];
+      Plan: Plan;
+      Subscription: Subscription;
+    }
+
+    export interface Product {
+      Name: string;
+      Plans: Plan[];
+    }
+
     /**
+     * @authentication-optional
      * Describes the available products. This endpoint is the source of valid values of PlanID which can be used to
-     * call setPlan() below. Authentication is optional.
+     * call setPlan() below.
+     *
+     * If the call is authenticated, then the IsCurrentPlan property will be populated in the list of available plans.
      */
     export const listProducts = (cb: inkstone.Callback<Product[]>) => {
       newGetRequest()
@@ -1206,12 +1212,12 @@ export namespace inkstone {
      */
     export const setPlan = (
       plan: SetPlanRequestParams,
-      cb: inkstone.Callback<PlanOverview>,
+      cb: inkstone.Callback<Subscription>,
     ) => {
       newPutRequest()
         .withEndpoint(Endpoints.BillingSetPlan)
         .withJson(plan)
-        .callWithCallback<PlanOverview>(cb);
+        .callWithCallback<Subscription>(cb);
     };
 
     /**

--- a/packages/@haiku/sdk-inkstone/src/index.ts
+++ b/packages/@haiku/sdk-inkstone/src/index.ts
@@ -1106,6 +1106,9 @@ export namespace inkstone {
     /**
      * @authentication-required
      * Describes the customer billing profile.
+     *
+     * Error codes:
+     *   E_BILLING_CUSTOMER_NOT_FOUND - when we are unable to locate customer data.
      */
     export const describe = (cb: inkstone.Callback<Profile>) => {
       newGetRequest()
@@ -1116,6 +1119,10 @@ export namespace inkstone {
     /**
      * @authentication-required
      * Sets up the customer profile. A customer profile must be provided before calling any of the methods below.
+     *
+     * Error codes:
+     *   E_BILLING_INFO_REQUIRED - when parameters are missing.
+     *   E_BILLING_UNABLE_TO_UPDATE_CUSTOMER_RECORD - when the Stripe call fails.
      */
     export const setCustomer = (customer: Customer, cb: inkstone.Callback<void>) => {
       newPutRequest()
@@ -1134,6 +1141,11 @@ export namespace inkstone {
      * (see setCustomer() for details). The first card added will automatically be set as the default. The default can
      * be changed using setCardAsDefaultById() below.
      * @see {@link https://stripe.com/docs/stripe-js/reference#stripe-create-token}
+     *
+     * Error codes:
+     *   E_BILLING_TOKEN_REQUIRED - when a billing token is not provided in the payload.
+     *   E_BILLING_CUSTOMER_NOT_FOUND - if you have failed to call setCustomer() first.
+     *   E_BILLING_CREATE_CARD_FAILED - when the Stripe call fails.
      */
     export const addCard = (card: AddCardRequestParams, cb: inkstone.Callback<void>) => {
       newPostRequest()
@@ -1146,6 +1158,10 @@ export namespace inkstone {
      * @authentication-required
      * Sets a card as default. The card ID here is available from the Profile object, obtained by calling describe()
      * above. A customer profile is required (see setCustomer() for details).
+     *
+     * Error codes:
+     *   E_BILLING_CUSTOMER_NOT_FOUND - if you have failed to call setCustomer() first.
+     *   E_BILLING_SET_DEFAULT_CARD_FAILED - when the Stripe call fails.
      */
     export const setCardAsDefaultById = (cardId: string, cb: inkstone.Callback<void>) => {
       newPutRequest()
@@ -1159,6 +1175,10 @@ export namespace inkstone {
      * Deletes a card. This request will fail if the user attempts to delete the default card without first specifying
      * a new default card. Same as setCardAsDefaultById(), the card ID here is available from the Profile object,
      * obtained by calling describe() above. A customer profile is required (see setCustomer() for details).
+     *
+     * Error codes:
+     *   E_BILLING_CUSTOMER_NOT_FOUND - if you have failed to call setCustomer() first.
+     *   E_BILLING_DELETE_CARD_FAILED - when the Stripe call fails.
      */
     export const deleteCardById = (cardId: string, cb: inkstone.Callback<void>) => {
       newDeleteRequest()
@@ -1178,6 +1198,11 @@ export namespace inkstone {
      * a default payment source (see addCard()/setCardAsDefaultById() must be specified). As noted above, the PlanID
      * string is available via the listProducts() endpoint above…or via hardcoding, since for now we only sell one
      * plan!
+     *
+     * Error codes:
+     *   E_BILLING_UNKNOWN_PLAN_ID - when an unknown plan ID is provided to the endpoint.
+     *   E_BILLING_CUSTOMER_NOT_FOUND - if you have failed to call setCustomer() first.
+     *   E_BILLING_CHARGE_FAILED - when we are unable to charge the user's card.
      */
     export const setPlan = (
       plan: SetPlanRequestParams,
@@ -1193,6 +1218,10 @@ export namespace inkstone {
      * @authentication-required
      * Cancels the user's active plan at the end of the billing period. And active plan is required (see setPlan()
      * above).
+     *
+     * Error codes:
+     *   E_BILLING_CUSTOMER_NOT_FOUND - if you have failed to call setCustomer() first.
+     *   E_BILLING_UNABLE_TO_CANCEL_SUBSCRIPTION - when the Stripe call fails.
      */
     export const cancelPlan = (
       cb: inkstone.Callback<void>,

--- a/packages/@haiku/sdk-inkstone/src/services.ts
+++ b/packages/@haiku/sdk-inkstone/src/services.ts
@@ -120,13 +120,12 @@ export class RequestBuilder {
   callWithCallback<T> (
     cb: (err: string, data: T, response: request.RequestResponse) => void,
     successCode = 200,
-    parseJson = false,
   ) {
     this.call((err, httpResponse, body) => {
       if (httpResponse && httpResponse.statusCode === successCode) {
         cb(
           undefined,
-          ((body && parseJson) ? JSON.parse(body) : (body || null)) as T,
+          body as T,
           httpResponse,
         );
       } else {

--- a/packages/@haiku/sdk-inkstone/src/services.ts
+++ b/packages/@haiku/sdk-inkstone/src/services.ts
@@ -4,6 +4,8 @@ import packageJson = require('../package.json');
 import {inkstoneConfig} from './config';
 import {requestInstance} from './transport';
 
+const INKSTONE_ERROR_HEADER = 'x-inkstone-error-code';
+
 export const enum Endpoints {
   BillingDescribe = '/billing',
   BillingListProducts = '/billing/products',
@@ -105,7 +107,12 @@ export class RequestBuilder {
         url: this.fullUrl,
       },
       (err, httpResponse, body) => {
-        cb(err || new Error('Uncategorized error'), httpResponse, body);
+        if (err) {
+          const errorCode =
+            httpResponse && httpResponse.headers && httpResponse.headers[INKSTONE_ERROR_HEADER] as string;
+          return cb(new Error(errorCode || 'E_UNCATEGORIZED'), httpResponse, body);
+        }
+        cb(null, httpResponse, body);
       },
     );
   }

--- a/packages/@haiku/sdk-inkstone/test/services.test.ts
+++ b/packages/@haiku/sdk-inkstone/test/services.test.ts
@@ -1,4 +1,4 @@
-import {newPutRequest} from '@sdk-inkstone/services';
+import {newGetRequest, newPutRequest} from '@sdk-inkstone/services';
 import {requestInstance} from '@sdk-inkstone/transport';
 import {stubProperties} from 'haiku-testing/lib/mock';
 import * as tape from 'tape';
@@ -28,6 +28,34 @@ tape('services', (suite: tape.Test) => {
       },
       'called with expected parameters',
     );
+
+    unstub();
+    test.end();
+  });
+
+  suite.test('RequestBuilder.errorHandling.restful', (test: tape.Test) => {
+    const [mockGet, unstub] = stubProperties(requestInstance, 'get');
+    mockGet.callsArgWith(1, new Error('ignored'), {headers: {'x-inkstone-error-code': 'E_FOOBAR'}}, null);
+    newGetRequest()
+      // @ts-ignore
+      .withEndpoint('/foo/:id')
+      .call((err: Error) => {
+        test.is(err.message, 'E_FOOBAR');
+      });
+
+    unstub();
+    test.end();
+  });
+
+  suite.test('RequestBuilder.errorHandling.default', (test: tape.Test) => {
+    const [mockGet, unstub] = stubProperties(requestInstance, 'get');
+    mockGet.callsArgWith(1, new Error('ignored'));
+    newGetRequest()
+      // @ts-ignore
+      .withEndpoint('/foo/:id')
+      .call((err: Error) => {
+        test.is(err.message, 'E_UNCATEGORIZED');
+      });
 
     unstub();
     test.end();


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- For next-gen endpoints, forward the `X-Inkstone-Error-Code` header through as the error message for client-side handling.
- Documentation/interface updates for billing endpoints.

Regressions to look for:

- None.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test for existing and modified functionality
