### PR TITLE
fix: for Multiple reports of project duplication failing in latest prod.

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -140,7 +140,7 @@ export default class Creator extends React.Component {
       showChangelogModal: false,
       showProxySettings: false,
       servicesEnvoyClient: null,
-      projToDuplicateIndex: null,
+      projectToDuplicate: null,
       // showGlass:
       //  true: show glass webviewer (webviewer interactionMode are InteractionMode.EDIT or InteractionMode.LIVE)
       //  false: show creator code editor
@@ -1025,11 +1025,11 @@ export default class Creator extends React.Component {
         return;
       }
 
-      if (duplicate && this.state.projToDuplicateIndex !== null) {
+      if (duplicate && this.state.projectToDuplicate !== null) {
         this.props.websocket.request(
           {
             method: 'duplicateProject',
-            params: [newProject, this.state.projectsList[this.state.projToDuplicateIndex]],
+            params: [newProject, this.state.projectToDuplicate],
           },
           () => {
             callback(err, newProject);
@@ -1624,8 +1624,8 @@ export default class Creator extends React.Component {
     ) : null;
   }
 
-  showNewProjectModal (isDuplicateProjectModal = false, duplicateProjectName = '', projToDuplicateIndex = -1) {
-    this.setState({showNewProjectModal: true, isDuplicateProjectModal, duplicateProjectName, projToDuplicateIndex});
+  showNewProjectModal (isDuplicateProjectModal = false, duplicateProjectName = '', projectToDuplicate = null) {
+    this.setState({showNewProjectModal: true, isDuplicateProjectModal, duplicateProjectName, projectToDuplicate});
     mixpanel.haikuTrack('creator:new-project:shown');
   }
 

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -201,8 +201,8 @@ class ProjectBrowser extends React.Component {
     return `${base}${suffix}`;
   }
 
-  showDuplicateProjectModal (projToDuplicateIndex) {
-    const duplicateNameBase = this.state.projectsList[projToDuplicateIndex].projectName;
+  showDuplicateProjectModal (projectObject) {
+    const duplicateNameBase = projectObject.projectName;
     const suffixBase = 'Copy';
     let suffix = suffixBase;
     let iteration = 1;
@@ -214,7 +214,7 @@ class ProjectBrowser extends React.Component {
       iteration++;
     }
 
-    this.props.onShowNewProjectModal(true, potentialName, projToDuplicateIndex);
+    this.props.onShowNewProjectModal(true, potentialName, projectObject);
   }
 
   projectsListElement () {
@@ -238,7 +238,7 @@ class ProjectBrowser extends React.Component {
           this.tourChannel.updateLayout();
         }, 50)}
       >
-        {this.state.projectsList.map((projectObject, index) => (
+        {this.state.projectsList.map((projectObject) => (
           <ProjectThumbnail
             key={projectObject.projectName}
             organizationName={this.props.organizationName}
@@ -248,7 +248,7 @@ class ProjectBrowser extends React.Component {
             isDeleted={projectObject.isDeleted}
             launchProject={() => this.handleProjectLaunch(projectObject)}
             showDeleteModal={() => this.showDeleteModal(projectObject.projectName)}
-            showDuplicateProjectModal={() => this.showDuplicateProjectModal(index)}
+            showDuplicateProjectModal={() => this.showDuplicateProjectModal(projectObject)}
             atProjectMax={this.state.atProjectMax}
           />
         ))}


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Instead of passing around an unstable project index to duplicate, pass around the whole object. Repro of project duplication failure in prod is: delete a project, then try to duplicate your first project in the same ProjectBrowser session.

Regressions to look for:

- None.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
