### PR TITLE
fix: for Uncaught exceptions crash Creator when rendering dashboard thumbnails

### DIFF
--- a/packages/@haiku/core/test/render/dom/exceptionHandling.test.ts
+++ b/packages/@haiku/core/test/render/dom/exceptionHandling.test.ts
@@ -1,0 +1,44 @@
+import {stubProperties} from 'haiku-testing/lib/mock';
+import * as tape from 'tape';
+import {createRenderTest} from '../../TestHelpers';
+
+tape(
+  'render.dom.exceptionHandling',
+  (test: tape.Test) => {
+    const template = {
+      elementName: 'div',
+      attributes: {'haiku-id': 'abcde'},
+      children: [],
+    };
+
+    const timelines = {
+      Default: {
+        'haiku:abcde': {
+          'sizeAbsolute.x': {0: {value: 1600}},
+          'sizeAbsolute.y': {0: {value: 1200}},
+        },
+      },
+    };
+
+    createRenderTest(
+      template,
+      timelines,
+      {},
+      (err, mount, renderer, context, component, teardown) => {
+        if (err) {
+          throw err;
+        }
+        const [mockWarn, unstub] = stubProperties(console, 'warn');
+        test.false(component.isDeactivated, 'component is initially activated');
+        // This will make things crash!
+        mount.firstChild.haiku.virtual.layout.scale = null;
+        context.tick();
+        test.true(mockWarn.calledWith('[haiku core] caught error during tick'), 'console warned an error during tick');
+        test.true(component.isDeactivated, 'component was deactivated due to error');
+        teardown();
+        unstub();
+        test.end();
+      },
+    );
+  },
+);


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Wrap `HaikuContext#tick` in a try/catch so forward-/backward-incompatible changes don't crash web apps…including ours.
- Deactivate a component and warn instead of throwing an exception.

Regressions to look for:

- None expected.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test for existing and modified functionality