### PR TITLE
feat: add support for placeholders in Angular adapter.

### DIFF
--- a/packages/@haiku/core/package.json
+++ b/packages/@haiku/core/package.json
@@ -41,7 +41,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@angular/core": "^6.0.0",
+    "@angular/core": "^6.0.9",
     "async": "^2.5.0",
     "chokidar": "^1.7.0",
     "depcheck": "^0.6.7",
@@ -68,7 +68,7 @@
     "webpack-cli": "^3.0.8"
   },
   "peerDependencies": {
-    "@angular/core": "^5.2.5",
+    "@angular/core": "^6.0.9",
     "react": "^16.0.0 || ^15.4.2",
     "react-dom": "^16.0.0 || ^15.4.2"
   }

--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -346,7 +346,7 @@ export default class HaikuComponent extends HaikuElement {
   }
 
   // If the component needs to remount itself for some reason, make sure we fire the right events
-  callRemount (incomingConfig, skipMarkForFullFlush) {
+  callRemount (incomingConfig, skipMarkForFullFlush = false) {
     this.routeEventToHandlerAndEmit(GLOBAL_LISTENER_KEY, 'component:will-mount', [this]);
 
     // Note!: Only update config if we actually got incoming options!

--- a/packages/@haiku/core/src/api/index.ts
+++ b/packages/@haiku/core/src/api/index.ts
@@ -36,6 +36,8 @@ export interface BytecodeNodeAttributes {
   identifier?: string;
 }
 
+export type PlaceholderSurrogate = any;
+
 /**
  * Haiku bytecode element tree. eg. <div><svg>...</svg></div>.
  * `source` and `identifier` are rarely used.
@@ -44,11 +46,13 @@ export interface BytecodeNode {
   elementName: string|HaikuBytecode;
   attributes: BytecodeNodeAttributes;
   layout?: LayoutSpec;
+  children: (BytecodeNode|string)[];
+  __placeholder?: {surrogate: PlaceholderSurrogate};
+
   /**
    * @deprecated
    */
   rect?: DomRect;
-  children: (BytecodeNode|string)[];
 }
 
 export type MaybeBytecodeNode = BytecodeNode|null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,9 +10,9 @@
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/7zip/-/7zip-0.0.6.tgz#9cafb171af82329490353b4816f03347aa150a30"
 
-"@angular/core@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-6.0.0.tgz#785cc8a37b7fb784a6b7dcbd0984abb4f10e5dfe"
+"@angular/core@^6.0.9":
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-6.0.9.tgz#a68cc0f5ddffa535df65f3e798ba2fcd6f6eec1b"
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Adds support for placeholders in the Haiku Angular adapter. Like React, placeholders can be regular DOM or other Angular-adapted components. Unlike React, I skipped building support for generic CSS selectors because this really wouldn't make sense to do in core.
 - As noted inline, Angular Is Special™, so we have to specify placeholders like this:

```
<my-component>
  <my-placeholder-component #placeholder></my-placeholder-component>
  <strong #placeholder>Blah</strong>
</my-component>
```

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
