### PR TITLE
New users changelog

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -615,7 +615,17 @@ export default class Creator extends React.Component {
       }
     });
 
-    this.user.getConfig(UserSettings.lastViewedChangelog).then((lastViewedChangelog = process.env.HAIKU_RELEASE_VERSION) => {
+    this.user.getConfig(UserSettings.lastViewedChangelog).then((changelogVersion) => {
+      let lastViewedChangelog = changelogVersion;
+
+      // If the user doesn't have a lastViewedChangelog config set, set it to the
+      // current version (ie don't show the changelog). This is usually the case
+      // for brand new users.
+      if (!lastViewedChangelog) {
+        lastViewedChangelog = process.env.HAIKU_RELEASE_VERSION;
+        this.user.setConfig(UserSettings.lastViewedChangelog, lastViewedChangelog);
+      }
+
       this.setState({lastViewedChangelog});
     });
   }

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -615,7 +615,7 @@ export default class Creator extends React.Component {
       }
     });
 
-    this.user.getConfig(UserSettings.lastViewedChangelog).then((lastViewedChangelog) => {
+    this.user.getConfig(UserSettings.lastViewedChangelog).then((lastViewedChangelog = process.env.HAIKU_RELEASE_VERSION) => {
       this.setState({lastViewedChangelog});
     });
   }

--- a/packages/haiku-serialization/src/bll/Changelog.js
+++ b/packages/haiku-serialization/src/bll/Changelog.js
@@ -7,7 +7,7 @@ const DEFAULT_CHANGELOG_PATH = path.join(__dirname, '..', '..', '..', '..', 'cha
 
 class Changelog {
   constructor (
-    lastViewedChangelog = '0.0.0',
+    lastViewedChangelog = process.env.HAIKU_RELEASE_VERSION,
     changelogPath = DEFAULT_CHANGELOG_PATH
   ) {
     this.cachedChangelog = null

--- a/packages/haiku-serialization/test/bll/09_Changelog.test.js
+++ b/packages/haiku-serialization/test/bll/09_Changelog.test.js
@@ -42,8 +42,8 @@ tape('Changelog.readChangelogs returns changelogs ordered by version', async (t)
   }
 })
 
-tape('Changelog.readChangelogs returns an aggregated changelog of all changelogs if no prior version is provided', async (t) => {
-  t.plan(4)
+tape('Changelog.readChangelogs uses the current version by default if no version is provided', async (t) => {
+  t.plan(3)
 
   try {
     const changelogManager = new Changelog(null, 'test/fixtures/changelog/')
@@ -52,7 +52,6 @@ tape('Changelog.readChangelogs returns an aggregated changelog of all changelogs
     t.equal(changelog.version, '4.3.2')
     t.ok(changelog.sections["Fixes"])
     t.ok(changelog.sections["What's new"])
-    t.ok(changelog.sections["1.2.3 Heading"])
   } catch (e) {
     t.error(e)
   }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

If `UserSettings.lastViewedChangelog` is not present in the user config (`~/.haiku/registry.json`) set it to the current version.

_Please note that as a consequence of this, new users won't see the box with the pink dot the first time they initialize the app. They will, however, see the changelog box after subsequent updates._

Regressions to look for:

- Not aware of any

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test for existing and modified functionality
- [ ] ~Added measurement instrumentation (Mixpanel, etc.)~ (already done)
