### PR TITLE
tweak: on expressions editor navigate before committing value

### DIFF
--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -352,10 +352,12 @@ export default class ExpressionInput extends React.Component {
         });
       }
 
-      this.props.onCommitValue(committable);
+      // Store the current selected row and ms before navigating
+      const row = this.props.component.getFocusedRow();
+      const ms = this.props.component.getCurrentTimeline().getCurrentMs();
 
-      // Once finished with a successful commit, navigate to 'select' the next cell
       this.requestNavigate(maybeNavigationDirection, doFocusSubsequentCell);
+      this.props.onCommitValue(committable, row, ms);
     }
   }
 

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1277,7 +1277,8 @@ class Timeline extends React.Component {
             <GaugeTimeReadout reactParent={this} timeline={timeline} />
           </div>
         ),
-        (<SimplifiedFrameGrid
+        (
+          <SimplifiedFrameGrid
             key="frame-grid"
             timeline={timeline}
             timelineOffsetPadding={TIMELINE_OFFSET_PADDING}
@@ -1389,6 +1390,12 @@ class Timeline extends React.Component {
     this.disableTimelinePointerEvents();
     this.mouseMoveListener(event);
   }
+
+  onCommitValue = (committedValue, row, ms) => {
+    logger.info('commit', JSON.stringify(committedValue), 'at', ms, 'on', row.dump());
+    this.props.mixpanel.haikuTrack('creator:timeline:create-keyframe');
+    row.createKeyframe(committedValue, ms, {from: 'timeline'});
+  };
 
   mouseMoveListener (evt) {
     if (!this._doHandleMouseMovesInGauge) {
@@ -1665,11 +1672,7 @@ class Timeline extends React.Component {
           reactParent={this}
           component={this.getActiveComponent()}
           timeline={this.getActiveComponent().getCurrentTimeline()}
-          onCommitValue={(committedValue, row, ms) => {
-            logger.info('commit', JSON.stringify(committedValue), 'at', ms, 'on', row.dump());
-            this.props.mixpanel.haikuTrack('creator:timeline:create-keyframe');
-            row.createKeyframe(committedValue, ms, {from: 'timeline'});
-          }}
+          onCommitValue={this.onCommitValue}
           onFocusRequested={() => {
             const selected = this.getActiveComponent().getSelectedRows()[0];
             if (selected.isProperty()) {

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1665,9 +1665,7 @@ class Timeline extends React.Component {
           reactParent={this}
           component={this.getActiveComponent()}
           timeline={this.getActiveComponent().getCurrentTimeline()}
-          onCommitValue={(committedValue) => {
-            const row = this.getActiveComponent().getFocusedRow();
-            const ms = this.getActiveComponent().getCurrentTimeline().getCurrentMs();
+          onCommitValue={(committedValue, row, ms) => {
             logger.info('commit', JSON.stringify(committedValue), 'at', ms, 'on', row.dump());
             this.props.mixpanel.haikuTrack('creator:timeline:create-keyframe');
             row.createKeyframe(committedValue, ms, {from: 'timeline'});


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- On expressions editor navigate before committing value

Regressions to look for:

- Not aware of any, we are caching the row and the ms value before navigating so everything should work exactly as before.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] ~Added measurement instrumentation (Mixpanel, etc.)~ (already done)
