### PR TITLE
Figma: handling invalid SVG file names

### DIFF
--- a/packages/haiku-creator/src/react/components/library/AssetList.js
+++ b/packages/haiku-creator/src/react/components/library/AssetList.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as Radium from 'radium';
 import AssetItem from './AssetItem';
 
-class AssetList extends React.PureComponent {
+class AssetList extends React.Component {
   render () {
     return (
       <div

--- a/packages/haiku-serialization/src/bll/Figma.js
+++ b/packages/haiku-serialization/src/bll/Figma.js
@@ -7,6 +7,7 @@ const {inkstone} = require('@haiku/sdk-inkstone')
 const logger = require('../utils/LoggerInstance')
 const randomAlphabetical = require('../utils/randomAlphabetical')
 const mixpanel = require('haiku-serialization/src/utils/Mixpanel')
+const {sanitize} = require('../utils/fileManipulation')
 
 const API_BASE = 'https://api.figma.com/v1/'
 const FIGMA_URL = 'https://www.figma.com/'
@@ -125,7 +126,7 @@ class Figma {
           // Mimic the behaior of our Sketch importer: move to the slices folder
           // everything that is marked for export
           const folder = FOLDERS[element.type] || FOLDERS.SLICE
-          const svgPath = path.join(assetBaseFolder, folder, `${element.name}.svg`)
+          const svgPath = path.join(assetBaseFolder, folder, `${sanitize(element.name)}.svg`)
           return fse.writeFile(svgPath, element.svg || '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"></svg>')
         }
       })

--- a/packages/haiku-serialization/src/utils/fileManipulation.js
+++ b/packages/haiku-serialization/src/utils/fileManipulation.js
@@ -2,6 +2,8 @@ const https = require('https')
 const fs = require('fs')
 const {exec} = require('child_process')
 
+const RESERVED_CHAR_REPLACEMENT = '-'
+
 module.exports = {
   // eslint-disable-next-line
   filenameReservedRegex: /[<>:"\/\\|?*\x00-\x1F]/g,
@@ -58,6 +60,8 @@ module.exports = {
       return ''
     }
 
-    return name.replace(this.filenameReservedRegex, '!').replace(this.windowsNamesReservedRegex, '!')
+    return name
+      .replace(this.filenameReservedRegex, RESERVED_CHAR_REPLACEMENT)
+      .replace(this.windowsNamesReservedRegex, RESERVED_CHAR_REPLACEMENT)
   }
 }

--- a/packages/haiku-serialization/src/utils/fileManipulation.js
+++ b/packages/haiku-serialization/src/utils/fileManipulation.js
@@ -3,6 +3,11 @@ const fs = require('fs')
 const {exec} = require('child_process')
 
 module.exports = {
+  // eslint-disable-next-line
+  filenameReservedRegex: /[<>:"\/\\|?*\x00-\x1F]/g,
+
+  windowsNamesReservedRegex: /^(con|prn|aux|nul|com[0-9]|lpt[0-9])$/i,
+
   download (url, downloadPath, onProgress, shouldCancel) {
     const file = fs.createWriteStream(downloadPath)
 
@@ -46,5 +51,13 @@ module.exports = {
         err ? reject(err) : resolve(true)
       })
     })
+  },
+
+  sanitize (name) {
+    if (typeof name !== 'string') {
+      return ''
+    }
+
+    return name.replace(this.filenameReservedRegex, '!').replace(this.windowsNamesReservedRegex, '!')
   }
 }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

There are reports of crashes on Figma SVGs with slashes on their name
in current prod (yeah...), due to the work done in 44d41821cff02fb296599bf05e5edbff637cec91 the app no
longer crashes, but it doesn't show the asset in the library neither.

This is a step forward, now we are replacing all invalid characters
with the ~`!` character~ `-` character.

What about Illustrator and Sketch?

- Illustrator: sometimes Adobe is not that bad, they are sanitizing
arboard names for us
- Sketch: elements with slashes will not appear in the library, I
haven't tested other invalid combinations, for now this is difficult to
solve because sketchtool doesn't provide an option to sanitize file
names before exporting. We *could* change the import logic to:
  - First do a dump of the sketch file contents to JSON.
  - Then parse the JSON file, sanitize file names and export items
  providing the desired file name.

Regressions to look for:

- Figma imports

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [x] Added measurement instrumentation (Mixpanel, etc.)
