### PR TITLE
Ergonomics

### DIFF
--- a/packages/haiku-serialization/src/ast/expressionToOASTComponent.js
+++ b/packages/haiku-serialization/src/ast/expressionToOASTComponent.js
@@ -1,4 +1,4 @@
-function expressionToOASTComponent (exp, key) {
+function expressionToOASTComponent (exp, key, keyChain) {
   if (exp === undefined || exp === null) {
     return {
       type: 'NullLiteral'
@@ -40,7 +40,7 @@ function expressionToOASTComponent (exp, key) {
   if (exp.__function) {
     return RFOToFunctionAST(exp.__function, key)
   }
-  if (exp.__value) return expressionToOASTComponent(exp.__value, key)
+  if (exp.__value) return expressionToOASTComponent(exp.__value, key, keyChain)
   if (exp.__reference) {
     return {
       type: 'Identifier',
@@ -49,7 +49,7 @@ function expressionToOASTComponent (exp, key) {
   }
 
   if (typeof exp === 'object') {
-    return objectToOAST(exp)
+    return objectToOAST(exp, keyChain)
   }
 
   if (typeof exp === 'function') {

--- a/packages/haiku-serialization/src/ast/objectToOAST.js
+++ b/packages/haiku-serialization/src/ast/objectToOAST.js
@@ -1,4 +1,52 @@
-function objectToOAST (obj) {
+const {LAYOUT_3D_SCHEMA} = require('@haiku/core/lib/HaikuComponent')
+
+/**
+ * We can emit a "shorthand" for bytecode timeline properties at serialization time like so:
+ *   {"sizeAbsolute.x": {"0": {"value": 550}}} ->
+ *   {"sizeAbsolute.x": 550}
+ *
+ * The inputs are carefully checked to evaluate if we're in a safe context to perform this shortening, essentially
+ * confirming that we are looking at an object exactly like this (and in the expected place).
+ */
+const canUseShorthand = (obj, keyChain) => {
+  // keyChain provides the list of keys we have traversed in our recursive serialization.
+  // In bytecode, we encounter timeline value clusters at depth 4, as in:
+  // {
+  //   "timelines": {
+  //     "Default": {
+  //       "haiku:<selector>": {
+  //         "<property>": {...}
+  //       }
+  //     }
+  //   }
+  // }
+  // On the off chance that we encounter some other thing somewhere else which:
+  //  - is an object
+  //  - has exactly one key which is "0"
+  //  - has that key point to an object which a scalar "value" property
+  // …inspecting the key chain assures us we are actually in the correct spot.
+  if (keyChain.length !== 4 || keyChain[0] !== 'timelines') {
+    return false
+  }
+
+  const keys = Object.keys(obj)
+  return (
+    // Check we have exactly one key, and it is "0":
+    keys.length === 1 && keys[0] === '0' &&
+    // Check that we have a {value: <scalar>} sort of key value:
+    //   * IMPORTANT: we should never shorthand object-type properties. because HaikuComponent shorthand expansion
+    //     uses object-ness to exclude from shorthand expansion!
+    typeof obj[0] === 'object' && typeof obj[0].value !== 'object' &&
+    // Check that we are either looking at a layout property (Haiku only updates these at the root level) or a non-edited property:
+    (LAYOUT_3D_SCHEMA[keyChain[3]] || !obj[0].edited)
+  )
+}
+
+const objectToOAST = (obj, keyChain = []) => {
+  if (canUseShorthand(obj, keyChain)) {
+    return expressionToOASTComponent(obj['0'].value)
+  }
+
   const oast = {
     type: 'ObjectExpression',
     properties: []
@@ -7,7 +55,9 @@ function objectToOAST (obj) {
   for (const key in obj) {
     if (key === undefined) continue
     const keyexp = expressionToOASTComponent(key)
-    const valueexp = expressionToOASTComponent(obj[key], key)
+    keyChain.push(key)
+    const valueexp = expressionToOASTComponent(obj[key], key, keyChain)
+    keyChain.pop()
     oast.properties.push({
       type: 'ObjectProperty',
       key: keyexp,

--- a/packages/haiku-serialization/src/bll/Bytecode.js
+++ b/packages/haiku-serialization/src/bll/Bytecode.js
@@ -527,6 +527,23 @@ Bytecode.reinitialize = (folder, relpath, bytecode = {}, config = {}) => {
     bytecode.timelines[DEFAULT_TIMELINE_NAME] = {}
   }
 
+  // Expand shorthand. This happens during component mounting, but we may need it sooner for our static bytecode
+  // manipulation.
+  for (const timelineName in bytecode.timelines) {
+    for (const selector in bytecode.timelines[timelineName]) {
+      // Expand all bytecode properties represented as shorthand.
+      for (const property in bytecode.timelines[timelineName][selector]) {
+        if (typeof bytecode.timelines[timelineName][selector][property] !== 'object') {
+          bytecode.timelines[timelineName][selector][property] = {
+            [DEFAULT_TIMELINE_TIME]: {
+              value: bytecode.timelines[timelineName][selector][property]
+            }
+          }
+        }
+      }
+    }
+  }
+
   convertManaLayout(bytecode.template)
 
   // Make sure there is at least a baseline metadata objet
@@ -615,11 +632,6 @@ Bytecode.upsertDefaultProperties = (bytecode, componentId, propertiesToMerge, st
 
   for (let propName in propertiesToMerge) {
     if (!defaultTimeline.hasOwnProperty(propName)) defaultTimeline[propName] = {}
-
-    if (typeof defaultTimeline[propName] !== 'object') {
-      // Handle shorthand before the component has been bootstrapped
-      defaultTimeline[propName] = {[DEFAULT_TIMELINE_TIME]: {value: defaultTimeline[propName]}}
-    }
 
     if (!defaultTimeline[propName][DEFAULT_TIMELINE_TIME]) {
       defaultTimeline[propName][DEFAULT_TIMELINE_TIME] = {}

--- a/packages/haiku-serialization/src/bll/Bytecode.js
+++ b/packages/haiku-serialization/src/bll/Bytecode.js
@@ -614,7 +614,12 @@ Bytecode.upsertDefaultProperties = (bytecode, componentId, propertiesToMerge, st
   let defaultTimeline = bytecode.timelines.Default[haikuSelector]
 
   for (let propName in propertiesToMerge) {
-    if (!defaultTimeline[propName]) defaultTimeline[propName] = {}
+    if (!defaultTimeline.hasOwnProperty(propName)) defaultTimeline[propName] = {}
+
+    if (typeof defaultTimeline[propName] !== 'object') {
+      // Handle shorthand before the component has been bootstrapped
+      defaultTimeline[propName] = {[DEFAULT_TIMELINE_TIME]: {value: defaultTimeline[propName]}}
+    }
 
     if (!defaultTimeline[propName][DEFAULT_TIMELINE_TIME]) {
       defaultTimeline[propName][DEFAULT_TIMELINE_TIME] = {}

--- a/packages/haiku-serialization/test/ast/ast.test.js
+++ b/packages/haiku-serialization/test/ast/ast.test.js
@@ -1,0 +1,61 @@
+const tape = require('tape');
+const objectToOAST = require('../../src/ast/objectToOAST');
+const generateCode = require('../../src/ast/generateCode');
+
+tape.test('ast', (suite) => {
+  suite.test('objectToOAST', (test) => {
+    const bytecode = {
+      timelines: {
+        Default: {
+          foobar: {
+            // Only has one keyframe, but that keyframe is not 0, so should be left alone.
+            leaveAlone1: {1: 'blah'},
+            // Has more than one keyframe, so should be left alone.
+            leaveAlone2: {0: 'blah', 1: 'blah'},
+            // Object-values will confuse the serializer, so should be left alone.
+            leaveAlone3: {0: {value: {}}},
+            // Edited, so should be left alone.
+            leaveAlone4: {0: {value: 'blah', edited: true}},
+            // Edited, but can be shortened because it's a layout property.
+            'sizeAbsolute.x': {0: {value: 5, edited: true}},
+            // Should be shortened.
+            cheez: {0: {value: 'swiss'}},
+          },
+        },
+      },
+      blah: {
+        Default: {
+          foobar: {
+            // Has the right structure, but is not part of timelines, so should be left alone.
+            leaveAlone5: {0: {value: 'blah'}},
+          },
+        },
+      },
+    };
+
+    const ast = objectToOAST(bytecode);
+    const serialized = generateCode(ast);
+    test.deepEqual(
+      JSON.parse(serialized),
+      {
+        timelines: {
+          Default: {
+            foobar: {
+              leaveAlone1: {1: 'blah'},
+              leaveAlone2: {0: 'blah', 1: 'blah'},
+              leaveAlone3: {0: {value: {}}},
+              leaveAlone4: {0: {value: 'blah', edited: true}},
+              'sizeAbsolute.x': 5, // SHORTENED!
+              cheez: 'swiss' // SHORTENED!
+            },
+          },
+        },
+        blah: {Default: {foobar: {leaveAlone5: {0: {value: 'blah'}}}}},
+      },
+      'shorthand was correctly applied during ASTification',
+    );
+    test.end();
+  });
+
+  suite.end();
+});


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Serialize timeline shorthand during ASTification of bytecode.
- Expand timeline shorthand during pre-migration (actually implemented in [earlier PR](https://github.com/HaikuTeam/mono/pull/637/commits/4afcc22f3de0aa71b9a4a5aa723df83b85e2a7a4#diff-d32838e6880700273b8fb0c4a084addeR124)).

Regressions to look for:

- Many seem possible, but this seems to work great. I was concerned about Lottie export, but it actually runs off ActiveComponent as source of truth, which synchronously mounts/migrates bytecode before it's exposed via `getReifiedDecycledBytecode()` and friends. Still should rewrite Lottie export to accept bytecode in this format, but seems fine to skip for now.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test for existing and modified functionality
