### PR TITLE
Roberto ui fixes 27 07

### DIFF
--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
@@ -75,6 +75,7 @@ class EventHandlerEditor extends React.PureComponent {
     super(props);
 
     this.handlerManager = null;
+    this.completionDisposer = null;
 
     this.setupMonaco();
 
@@ -124,7 +125,7 @@ class EventHandlerEditor extends React.PureComponent {
     });
 
     // Define our own autocompletion items
-    monaco.languages.registerCompletionItemProvider('javascript', {
+    this.completionDisposer = monaco.languages.registerCompletionItemProvider('javascript', {
       provideCompletionItems (model, position) {
         return AUTOCOMPLETION_ITEMS.map((option) =>
           Object.assign(option, {
@@ -171,6 +172,12 @@ class EventHandlerEditor extends React.PureComponent {
     if (isNumeric(nextProps.options.frame)) {
       const event = HandlerManager.frameToEvent(nextProps.options.frame);
       this.setState({currentEvent: event});
+    }
+  }
+
+  componentWillUnmount () {
+    if (this.completionDisposer) {
+      this.completionDisposer.dispose();
     }
   }
 

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -517,7 +517,7 @@ export class Glass extends React.Component {
         return;
       }
 
-      if (experimentIsEnabled(Experiment.PinchToZoomInGlass) && evt.ctrlKey) {
+      if (experimentIsEnabled(Experiment.PinchToZoomInGlass) && (evt.ctrlKey || evt.metaKey)) {
         return this.handlePinchToZoom(evt);
       }
 

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -868,6 +868,10 @@ class ElementSelectionProxy extends BaseModel {
       return
     }
 
+    if (toStage && !this.selection.length) {
+      return
+    }
+
     let axis = (xEdge !== undefined) ? 'x' : 'y'
 
     // First, we'll sort the elements by the appropriate bounding edge, tracking

--- a/packages/haiku-timeline/public/styles/Timeline.css
+++ b/packages/haiku-timeline/public/styles/Timeline.css
@@ -261,7 +261,7 @@ input[type=number]::-webkit-outer-spin-button {
 }
 
 .component-heading-row .opacity-on-hover {
-  --wait-and-ease: 220ms ease 150ms;
+  --wait-and-ease: 220ms ease 190ms;
   opacity: 0;
   transform: scale(0.3);
   transition: transform var(--wait-and-ease), opacity var(--wait-and-ease);

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -195,6 +195,7 @@ export default class ComponentHeadingRow extends React.Component {
                 height: this.props.rowHeight,
                 display: 'flex',
                 alignItems: this.props.isExpanded ? 'baseline' : 'center',
+                width: '100%',
               } : {
                 height: this.props.rowHeight,
                 marginTop: -6,

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -251,6 +251,7 @@ export default class ComponentHeadingRow extends React.Component {
                   }
               </span>
               <ComponentHeadingRowHeading
+                setEditingRowTitleStatus={this.props.setEditingRowTitleStatus}
                 row={this.props.row}
                 isExpanded={this.props.isExpanded}
                 isSelected={this.props.isSelected}

--- a/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
@@ -67,6 +67,7 @@ export default class ComponentHeadingRowHeading extends React.Component {
       if (err) {
         // ...
       }
+      this.props.setEditingRowTitleStatus(false);
       this.setState({
         rowTitle,
         isEditingRowTitle: false,
@@ -205,6 +206,7 @@ export default class ComponentHeadingRowHeading extends React.Component {
                 clearTimeout(this.onExpandTimeout);
                 this.onExpandTimeout = null;
                 if (!this.state.isEditingRowTitle) {
+                  this.props.setEditingRowTitleStatus(true);
                   this.setState({isEditingRowTitle: true}, () => {
                     if (this.refs.rowTitleInput) {
                       this.refs.rowTitleInput.select();

--- a/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
@@ -150,6 +150,7 @@ export default class ComponentHeadingRowHeading extends React.Component {
               alignItems: 'center',
               height: 25,
               marginLeft: 5,
+              width: '88%',
             } : {
               color,
               position: 'relative',
@@ -182,7 +183,9 @@ export default class ComponentHeadingRowHeading extends React.Component {
                     ? 5
                     : 0,
                 overflowX: 'hidden',
-                width: 160,
+                width: '100%',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
               } : {
                 position: 'absolute',
                 display: 'inline-block',
@@ -231,7 +234,7 @@ export default class ComponentHeadingRowHeading extends React.Component {
                   this.persistRowTitle();
                 }}
               />
-              : trunc(this.state.rowTitle, 8)
+              : this.state.rowTitle
             }
           </span>
         </span>

--- a/packages/haiku-timeline/src/components/FrameAction.js
+++ b/packages/haiku-timeline/src/components/FrameAction.js
@@ -36,7 +36,7 @@ const STYLE = {
   },
 };
 
-const HOVER_INTENT_TIME = 150;
+const HOVER_INTENT_TIME = 190;
 
 class FrameAction extends React.Component {
   constructor () {

--- a/packages/haiku-timeline/src/components/PropertyInputField.js
+++ b/packages/haiku-timeline/src/components/PropertyInputField.js
@@ -139,7 +139,10 @@ class PropertyInputFieldValueDisplay extends React.Component {
     const valueDescriptor = this.props.row.getPropertyValueDescriptor();
 
     return (
-      <span>{remapPrettyValue(valueDescriptor.prettyValue)} {valueDescriptor.valueUnit}</span>
+      <span>
+        {remapPrettyValue(valueDescriptor.prettyValue)}{' '}
+        <span style={{opacity: 0.5}}>{valueDescriptor.valueUnit}</span>
+      </span>
     );
   }
 }

--- a/packages/haiku-timeline/src/components/RowManager.js
+++ b/packages/haiku-timeline/src/components/RowManager.js
@@ -78,6 +78,7 @@ class RowManager extends React.PureComponent {
           isSelected={row.isSelected()}
           hasAttachedActions={row.element.getVisibleEvents().length > 0}
           dragHandleProps={this.props.dragHandleProps}
+          setEditingRowTitleStatus={this.props.setEditingRowTitleStatus}
         />
       );
     }

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -85,6 +85,7 @@ class Timeline extends React.Component {
     EmitterManager.extend(this);
 
     this.state = lodash.assign({}, DEFAULTS);
+    this.isEditingRowTitle = false;
 
     if (experimentIsEnabled(Experiment.NativeTimelineScroll)) {
       this.isShiftKeyDown = false;
@@ -934,7 +935,7 @@ class Timeline extends React.Component {
     // Give the currently active expression input a chance to capture this event and short circuit us if so
     const willExprInputHandle = this.refs.expressionInput.willHandleExternalKeydownEvent(nativeEvent);
 
-    if (willExprInputHandle || this.state.isPreviewModeActive) {
+    if (willExprInputHandle || this.state.isPreviewModeActive || this.isEditingRowTitle) {
       return void (0);
     }
 
@@ -1486,6 +1487,10 @@ class Timeline extends React.Component {
     }
   }
 
+  setEditingRowTitleStatus = (status) => {
+    this.isEditingRowTitle = status;
+  };
+
   renderBottomControls () {
     return (
       <div
@@ -1583,6 +1588,7 @@ class Timeline extends React.Component {
                                   this.showEventHandlersEditor(...args);
                                 }}
                                 onDoubleClickToMoveGauge={this.moveGaugeOnDoubleClick}
+                                setEditingRowTitleStatus={this.setEditingRowTitleStatus}
                               />
                             </div>
                             {providedDraggable.placeholder}

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -517,7 +517,7 @@ class Timeline extends React.Component {
       // If you are looking for the scroll listener event, it's attached to
       // this.container on `attachContainerElement`
       this.addEmitterListener(window, 'wheel', (wheelEvent) => {
-        if (wheelEvent.ctrlKey) {
+        if (wheelEvent.ctrlKey || wheelEvent.metaKey) {
           wheelEvent.preventDefault();
           this.handleZoomThrottled(wheelEvent);
         }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

A handful of UI fixes:

- [Long component names don't truncate appropriately](https://app.asana.com/0/743996399535511/758871125443424)
- [Show units on right of input box and make .5 opacity](https://app.asana.com/0/743996399535511/758871125443425)
- [In Monaco autocomplete, setState appears many times](https://app.asana.com/0/743996399535511/759100037963905)
- [Make it harder to accidentally click the frame event button](https://app.asana.com/0/743996399535511/759100037963923)
- [Trying to use arrow keys while renaming a layer—scrolls timeline](https://app.asana.com/0/743996399535511/759100037963952)
- [Cmd+scroll to zoom on stage not working](https://app.asana.com/0/743996399535511/759100037963907)

Regressions to look for:

- Not aware of any dangerous code paths

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
