### PR TITLE
Nirvana

### DIFF
--- a/packages/@haiku/core/src/HaikuBase.ts
+++ b/packages/@haiku/core/src/HaikuBase.ts
@@ -40,28 +40,13 @@ const removeInstanceFromGlobalModelRegistry = (instance: HaikuBase): number => {
   }
 };
 
-const addValueToGlobalCache = (key: string, value: any) => {
-  HaikuGlobal.cache[key] = value;
-};
-
-const retrieveValueFromGlobalCache = (key: string) => {
-  return HaikuGlobal.cache[key];
-};
-
-const clearMatchingPropertiesInGlobalCache = (matcher: string) => {
-  for (const key in HaikuGlobal.cache) {
-    if (key.indexOf(matcher) !== -1) {
-      delete HaikuGlobal.cache[key];
-    }
-  }
-};
-
 export default class HaikuBase {
   private listeners;
 
   $id: number;
   config; // Implemented by subclass
   parent; // Implemented by subclass
+  protected cache: {[key in string]: any} = {};
 
   constructor () {
     this.$id = addInstanceToGlobalModelRegistry(this);
@@ -80,16 +65,12 @@ export default class HaikuBase {
     return (this.constructor as any).__name__;
   }
 
-  buildQualifiedCacheKey (key: string) {
-    return `${this.getPrimaryKey()}:${key}`;
-  }
-
   cacheSet (key: string, value: any) {
-    addValueToGlobalCache(this.buildQualifiedCacheKey(key), value);
+    this.cache[key] = value;
   }
 
   cacheGet (key: string) {
-    return retrieveValueFromGlobalCache(this.buildQualifiedCacheKey(key));
+    return this.cache[key];
   }
 
   cacheFetch<T> (key: string, provider: () => T): T {
@@ -106,11 +87,11 @@ export default class HaikuBase {
   }
 
   cacheUnset (key: string) {
-    addValueToGlobalCache(this.buildQualifiedCacheKey(key), undefined);
+    this.cache[key] = undefined;
   }
 
   cacheClear () {
-    clearMatchingPropertiesInGlobalCache(this.getPrimaryKey());
+    this.cache = {};
   }
 
   subcacheGet (key: string) {

--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -3162,7 +3162,7 @@ export const VANITIES = {
             timeline,
           );
 
-          sender.needsExpand = true;
+          sender.markForFullFlush();
         }
 
         return;
@@ -3209,7 +3209,7 @@ export const VANITIES = {
         element.__memory.repeater.repeatees[index] = repeatee;
       });
 
-      sender.needsExpand = true;
+      sender.markForFullFlush();
     },
 
     'controlFlow.if': (
@@ -3245,7 +3245,7 @@ export const VANITIES = {
         element.__memory.repeater.changed = true;
       }
 
-      sender.needsExpand = true;
+      sender.markForFullFlush();
     },
   },
 };

--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -3151,7 +3151,7 @@ export const VANITIES = {
             timeline,
           );
 
-          sender.markForFullFlush();
+          sender.needsExpand = true;
         }
 
         return;
@@ -3198,7 +3198,7 @@ export const VANITIES = {
         element.__memory.repeater.repeatees[index] = repeatee;
       });
 
-      sender.markForFullFlush();
+      sender.needsExpand = true;
     },
 
     'controlFlow.if': (
@@ -3234,7 +3234,7 @@ export const VANITIES = {
         element.__memory.repeater.changed = true;
       }
 
-      sender.markForFullFlush();
+      sender.needsExpand = true;
     },
   },
 };

--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -1232,25 +1232,6 @@ export default class HaikuComponent extends HaikuElement implements IHaikuCompon
   }
 
   applyGlobalBehaviors (options: any = {}) {
-    if (this.doPreserve3d) {
-      const node = this.node;
-      if (node) {
-        const didNodePreserve3dChange = ensure3dPreserved(this, node);
-        if (didNodePreserve3dChange) {
-          node.__memory.patched = true;
-        }
-      }
-
-      // The wrapper also needs preserve-3d set for 3d-preservation to work
-      const parent = this.parentNode; // This should be the "wrapper div" node
-      if (parent) {
-        const didParentPreserve3dChange = ensure3dPreserved(this, parent);
-        if (didParentPreserve3dChange) {
-          parent.__memory.patched = true;
-        }
-      }
-    }
-
     if (!this.host && options.sizing) {
       const didSizingChange = computeAndApplyPresetSizing(
         this.bytecode.template,
@@ -2495,27 +2476,6 @@ const hydrateNode = (
 
   // In case we got a __reference node or other unknown
   console.warn('[haiku core] cannot hydrate node');
-};
-
-const ensure3dPreserved = (component, node) => {
-  if (!node || !node.attributes || !node.attributes.style) {
-    return;
-  }
-
-  let changed = false;
-
-  // Only preserve 3D behavior if the node hasn't been *explicitly* defined yet
-  if (!node.attributes.style.transformStyle) {
-    node.attributes.style.transformStyle = 'preserve-3d';
-
-    changed = true;
-
-    if (!node.attributes.style.perspective) {
-      node.attributes.style.perspective = 'inherit';
-    }
-  }
-
-  return changed;
 };
 
 const computeAndApplyPresetSizing = (element, container, mode): boolean => {

--- a/packages/@haiku/core/src/HaikuGlobal.ts
+++ b/packages/@haiku/core/src/HaikuGlobal.ts
@@ -10,7 +10,6 @@ const VERSION = require('./../package.json').version;
 export interface HaikuRoot {
   haiku?: {
     [version: string]: {
-      cache?: {[key in string]: any};
       models?: {[key in string]: any[]};
       report?: () => void;
       enhance?: typeof enhance;
@@ -48,10 +47,6 @@ function buildRoot () {
   // Avoid loading entities for incompatible versions.
   if (!ROOT.haiku[VERSION]) {
     ROOT.haiku[VERSION] = {};
-  }
-
-  if (!ROOT.haiku[VERSION].cache) {
-    ROOT.haiku[VERSION].cache = {};
   }
 
   if (!ROOT.haiku[VERSION].models) {

--- a/packages/@haiku/core/src/HaikuNode.ts
+++ b/packages/@haiku/core/src/HaikuNode.ts
@@ -365,9 +365,9 @@ export const visitManaTree = (
 };
 
 export const visit = (
-  mana,
-  visitor,
-  parent?,
+  mana: BytecodeNode,
+  visitor: (node: BytecodeNode, parent?: BytecodeNode) => void,
+  parent?: BytecodeNode,
 ): void => {
   if (!mana || typeof mana !== 'object') {
     return;
@@ -375,7 +375,7 @@ export const visit = (
 
   visitor(mana, parent);
 
-  const children = (mana.__memory && mana.__memory.children) || mana.children;
+  const children = ((mana.__memory && mana.__memory.children) || mana.children) as BytecodeNode[];
   if (children) {
     for (let i = 0; i < children.length; i++) {
       const child = children[i];

--- a/packages/@haiku/core/src/Migration.ts
+++ b/packages/@haiku/core/src/Migration.ts
@@ -339,7 +339,7 @@ export const runMigrationsPostPhase = (component: IHaikuComponent, options: Migr
     if (node) {
       const didNodePreserve3dChange = ensure3dPreserved(node);
       if (didNodePreserve3dChange) {
-        node.__memory.patched = true;
+        component.patches.push(node);
       }
     }
 
@@ -348,7 +348,7 @@ export const runMigrationsPostPhase = (component: IHaikuComponent, options: Migr
     if (parent) {
       const didParentPreserve3dChange = ensure3dPreserved(parent);
       if (didParentPreserve3dChange) {
-        parent.__memory.patched = true;
+        component.patches.push(parent);
       }
     }
   }

--- a/packages/@haiku/core/src/Migration.ts
+++ b/packages/@haiku/core/src/Migration.ts
@@ -46,6 +46,27 @@ export interface MigrationOptions {
   referenceUniqueness?: string;
 }
 
+const ensure3dPreserved = (node: BytecodeNode) => {
+  if (!node || !node.attributes || !node.attributes.style) {
+    return;
+  }
+
+  let changed = false;
+
+  // Only preserve 3D behavior if the node hasn't been *explicitly* defined yet
+  if (!node.attributes.style.transformStyle) {
+    node.attributes.style.transformStyle = 'preserve-3d';
+
+    changed = true;
+
+    if (!node.attributes.style.perspective) {
+      node.attributes.style.perspective = 'inherit';
+    }
+  }
+
+  return changed;
+};
+
 /**
  * Migrations are a mechanism to modify our bytecode from legacy format to the current format.
  * This always runs against production components' bytecode to ensure their data is a format
@@ -312,6 +333,25 @@ export const runMigrationsPostPhase = (component: IHaikuComponent, options: Migr
   const coreVersion = bytecode.metadata.core || bytecode.metadata.player;
 
   let needsRerender = false;
+
+  if (component.doPreserve3d) {
+    const node = component.node;
+    if (node) {
+      const didNodePreserve3dChange = ensure3dPreserved(node);
+      if (didNodePreserve3dChange) {
+        node.__memory.patched = true;
+      }
+    }
+
+    // The wrapper also needs preserve-3d set for 3d-preservation to work
+    const parent = component.parentNode; // This should be the "wrapper div" node
+    if (parent) {
+      const didParentPreserve3dChange = ensure3dPreserved(parent);
+      if (didParentPreserve3dChange) {
+        parent.__memory.patched = true;
+      }
+    }
+  }
 
   const needsCamelAutoSizingOffsetOmnibus = requiresUpgrade(
     coreVersion, UpgradeVersionRequirement.CamelAutoSizingOffset3DOmnibus);

--- a/packages/@haiku/core/src/api/index.ts
+++ b/packages/@haiku/core/src/api/index.ts
@@ -21,6 +21,7 @@ export interface IHaikuElement extends HaikuBase {
 export interface IHaikuComponent extends IHaikuElement {
   bytecode: HaikuBytecode;
   config: BytecodeOptions;
+  patches: BytecodeNode[];
   context: IHaikuContext;
   doPreserve3d: boolean;
   state: {[key in string]: any};
@@ -132,7 +133,6 @@ export interface BytecodeNodeMemoryObject {
   instance?: IHaikuComponent;
   listener?: Function; // Bound event listener function
   parent?: BytecodeNode;
-  patched?: boolean;
   placeholder?: PlaceholderSpec;
   repeatee?: RepeateeSpec;
   repeater?: RepeaterSpec;
@@ -386,7 +386,7 @@ export interface BytecodeOptions {
  * Bytecode definition. Properties are *rarely* used.
  */
 export interface HaikuBytecode {
-  template: BytecodeNode|string;
+  template: BytecodeNode;
   states?: BytecodeStates;
   eventHandlers?: BytecodeEventHandlers;
   timelines: BytecodeTimelines;

--- a/packages/@haiku/core/src/api/index.ts
+++ b/packages/@haiku/core/src/api/index.ts
@@ -620,3 +620,14 @@ export interface ParsedValueCluster {
   };
   keys: number[];
 }
+
+/**
+ * Similar to BytecodeTimelines, but storing parsed value clusters instead of literal timelines.
+ */
+export interface ParsedValueClusterCollection {
+  [timelineName: string]: {
+    [selector: string]: {
+      [propertyName: string]: ParsedValueCluster;
+    };
+  };
+}

--- a/packages/@haiku/core/src/api/index.ts
+++ b/packages/@haiku/core/src/api/index.ts
@@ -5,6 +5,7 @@ import {RFO} from '../reflection/functionToRFO';
 export interface IHaikuElement extends HaikuBase {
   tagName: string|HaikuBytecode;
   node: BytecodeNode;
+  parentNode?: BytecodeNode;
   target?: Element;
   originX: number;
   originY: number;

--- a/packages/haiku-formats/src/exporters/bodymovin/bodymovinExporter.ts
+++ b/packages/haiku-formats/src/exporters/bodymovin/bodymovinExporter.ts
@@ -1155,7 +1155,7 @@ export class BodymovinExporter extends BaseExporter implements ExporterInterface
    * TODO: Support animations on the wrapper color and opacity.
    */
   private handleWrapper () {
-    const wrapperTimeline = this.timelineForNode(this.bytecode.template as BytecodeNode);
+    const wrapperTimeline = this.timelineForNode(this.bytecode.template);
     if (timelineHasProperties(wrapperTimeline, 'sizeAbsolute.x', 'sizeAbsolute.y')) {
       const [width, height] = [
         initialValue(wrapperTimeline, 'sizeAbsolute.x'),
@@ -1250,7 +1250,7 @@ export class BodymovinExporter extends BaseExporter implements ExporterInterface
    * where jumps occur and shimming in keyframes forcing a linear transition within a single frame.
    */
   private normalizeCurves () {
-    (this.bytecode.template as BytecodeNode).children.forEach((node: BytecodeNode) => {
+    this.bytecode.template.children.forEach((node: BytecodeNode) => {
       const timeline = this.timelineForNode(node);
       for (const property in timeline) {
         const timelineProperty = timeline[property];
@@ -1413,8 +1413,8 @@ export class BodymovinExporter extends BaseExporter implements ExporterInterface
    * Parses class-local bytecode using internal methods.
    */
   private parseBytecode () {
-    if ((this.bytecode.template as BytecodeNode).elementName !== 'div') {
-      throw new Error(`Unexpected wrapper element: ${(this.bytecode.template as BytecodeNode).elementName}`);
+    if (this.bytecode.template.elementName !== 'div') {
+      throw new Error(`Unexpected wrapper element: ${this.bytecode.template.elementName}`);
     }
 
     // Rewrite timelines to use keyframes instead of millitimes, which is the Bodymovin way. It makes sense to do
@@ -1437,13 +1437,13 @@ export class BodymovinExporter extends BaseExporter implements ExporterInterface
     // Preprocess tweened curves so that they are normalized and ready for tweening
     this.preprocessTweenedCurves();
 
-    this.structuralNode = this.bytecode.template as BytecodeNode;
+    this.structuralNode = this.bytecode.template;
     this.layerStack.set(this.structuralNode, this.rootLayers);
 
     // Handle the wrapper as a special case.
     this.handleWrapper();
 
-    (this.bytecode.template as BytecodeNode).children.forEach((template: BytecodeNode) => {
+    this.bytecode.template.children.forEach((template: BytecodeNode) => {
       Template.visitTemplate(template, this.bytecode.template, (node: BytecodeNode, parentNode: BytecodeNode) => {
         this.handleElement(node, parentNode);
       });

--- a/packages/haiku-formats/test/exporters/bodymovin.test.ts
+++ b/packages/haiku-formats/test/exporters/bodymovin.test.ts
@@ -16,7 +16,7 @@ const overrideShapeAttributes = (bytecode: HaikuBytecode, attributes: BytecodeTi
 
 const overrideShapeElement = (bytecode: HaikuBytecode, elementName: string) => {
   // tslint:disable-next-line:max-line-length
-  (((bytecode.template as BytecodeNode).children[0] as BytecodeNode).children[0] as BytecodeNode).elementName = elementName;
+  ((bytecode.template.children[0] as BytecodeNode).children[0] as BytecodeNode).elementName = elementName;
 };
 
 const baseBytecodeCopy = () => JSON.parse(JSON.stringify(baseBytecode));


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- move preserve3d work to post-migration
- use bespoke patches instead of traversing entire tree
- remove needless mark for full flush when control flow changes tree
- cache the flat mana tree (greatly speeds up initial render)
- keep a local (special) cache per HaikuBase instead of (potentially) overburdening a global cache

Regressions to look for:

- None are expected.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
