### PR TITLE
fix: wire ESC key to close the actions editor

### DIFF
--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
@@ -197,7 +197,7 @@ class EventHandlerEditor extends React.PureComponent {
   }
 
   doSave () {
-    if (!this.state.editorWithErrors) {
+    if (!this.state.editorWithErrors && this.state.currentEvent) {
       this.handlerManager.replaceEvent(
         this.editor.serialize(),
         this.state.currentEvent,
@@ -224,6 +224,13 @@ class EventHandlerEditor extends React.PureComponent {
       this.setState({currentEvent: null}, callback);
     }
   }
+
+  doCloseFromEsc = () => {
+    if (!this.state.editorWithErrors) {
+      this.doSave();
+      this.doClose();
+    }
+  };
 
   onEditorContentChange ({evaluator}) {
     this.setState({
@@ -260,7 +267,7 @@ class EventHandlerEditor extends React.PureComponent {
     const applicableEventHandlers = this.handlerManager.getApplicableEventHandlers();
 
     return (
-      <ModalWrapper style={{...visibilityStyles, ...STYLES.container}}>
+      <ModalWrapper style={{...visibilityStyles, ...STYLES.container}} onClose={this.doCloseFromEsc}>
         <div
           onMouseDown={(mouseEvent) => {
             // Prevent outer view from closing us

--- a/packages/haiku-ui-common/src/react/Modal/ModalWrapper.tsx
+++ b/packages/haiku-ui-common/src/react/Modal/ModalWrapper.tsx
@@ -16,7 +16,7 @@ const STYLES = {
 
 export interface ModalWrapperProps {
   style: React.CSSProperties;
-  onClose: () => any;
+  onClose?: () => null;
 }
 
 const stopPropagation: React.MouseEventHandler<HTMLDivElement> = (event) => event.stopPropagation();

--- a/packages/haiku-ui-common/src/react/Modal/ModalWrapper.tsx
+++ b/packages/haiku-ui-common/src/react/Modal/ModalWrapper.tsx
@@ -16,11 +16,30 @@ const STYLES = {
 
 export interface ModalWrapperProps {
   style: React.CSSProperties;
+  onClose: () => any;
 }
 
 const stopPropagation: React.MouseEventHandler<HTMLDivElement> = (event) => event.stopPropagation();
 
 export class ModalWrapper extends React.PureComponent<ModalWrapperProps> {
+  constructor () {
+    super();
+
+    // FIXME: I don't belong here, move me to the global scope once we centralize
+    // the key handlers
+    document.addEventListener('keydown', this.handleKeyEvents);
+  }
+
+  componentWillUnmount () {
+    document.removeEventListener('keydown', this.handleKeyEvents);
+  }
+
+  handleKeyEvents = (keyEvent: KeyboardEvent) => {
+    if (keyEvent.keyCode === 27 && typeof this.props.onClose === 'function') {
+      this.props.onClose();
+    }
+  };
+
   render () {
     return (
       <div


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Wire ESC key to close the actions editor

Also, since the logic is implemented at `<ModalWrapper />` level,
this same functionality should be really easy to port into other
modals using it (offline, code save, etc)

Regressions to look for:

- Not aware of any

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
