### PR TITLE
Fix this.getDefaultTimeline autocomplete (700874348545630)

### DIFF
--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/constants.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/constants.js
@@ -64,5 +64,8 @@ export const AUTOCOMPLETION_ITEMS = [
     label: 'isFinished',
     insertText: 'this.getDefaultTimeline().isFinished()',
   },
-
+  {
+    detail: 'Returns default timeline.',
+    label: 'this.getDefaultTimeline()',
+  },
 ];


### PR DESCRIPTION
OK to merge.

Unfortunately to set autocomplete type(e.g. `monaco.languages.CompletionItemKind.Text`) , monaco global var should be called inside a function after monaco is loaded (cannot be inside a const, or monaco won't be defined)   

Btw, there is a nice "documentation" property that can be explored in action editor autocomplete, eg: https://microsoft.github.io/monaco-editor/playground.html#extending-language-services-completion-provider-example. We can link ours docs individually by autocomplete (it accepts markdown according to monaco.d.ts).


Another useful feature (for code editor, not action editor) is https://microsoft.github.io/monaco-editor/playground.html#extending-language-services-folding-provider-example, so we can fold sections in a nice way



Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
