### PR TITLE
fix: avoid glitches on timeline scroll when dealing with multiple elements

### DIFF
--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -2861,6 +2861,10 @@ class ActiveComponent extends BaseModel {
     return Row.where({ component: this, _isSelected: true })
   }
 
+  getSelectedElements () {
+    return Element.where({ component: this, _isSelected: true })
+  }
+
   getCurrentRows (criteria) {
     if (!criteria) criteria = {}
     criteria.component = this

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -577,15 +577,7 @@ class Timeline extends React.Component {
         }
 
         if (what === 'row-selected' && metadata.from !== 'timeline') {
-          const rowElement = document.getElementById(`component-heading-row-${row.element.getComponentId()}-${row.getAddress()}`);
-
-          if (rowElement) {
-            this.container.scroll({
-              top: rowElement.offsetTop,
-              left: this.container.scrollLeft,
-              behavior: 'smooth',
-            });
-          }
+          this.scrollToRow(row);
         }
       }
     });
@@ -649,6 +641,19 @@ class Timeline extends React.Component {
 
     this.setState({isPreviewModeActive: isPreviewMode(interactionMode)});
   }
+
+  scrollToRow  = lodash.throttle((row) => {
+    const rowElement = document.getElementById(`component-heading-row-${row.element.getComponentId()}-${row.getAddress()}`);
+    const selectedElements = this.getActiveComponent().getSelectedElements();
+
+    if (rowElement && selectedElements.length === 1) {
+      this.container.scroll({
+        top: rowElement.offsetTop,
+        left: this.container.scrollLeft,
+        behavior: 'smooth',
+      });
+    }
+  }, 200);
 
   getPopoverMenuItems ({event, type, model, offset, curve}) {
     const items = [];


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes [Visual glitch appears in timeline after grouping, then deleting an element](https://app.asana.com/0/752360003454336/767130344203335) and related issues found when dealing with multiple elements

- Throttle the time between calls to the scrolling function
- Don't scroll if there is more than one element selected at the time

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)