### PR TITLE
fix: special case dragging for single selected tweens

### DIFF
--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -1925,9 +1925,14 @@ class ActiveComponent extends BaseModel {
     return selectedKeyframeWithCurve ? selectedKeyframeWithCurve.getCurve() : null
   }
 
-  dragStartSelectedKeyframes (dragData) {
+  dragStartSelectedKeyframes (dragData, isFromSingleKeyframe) {
     const keyframes = this.getSelectedKeyframes()
-    keyframes.forEach((keyframe) => keyframe.dragStart(dragData))
+
+    if (isFromSingleKeyframe && Keyframe.groupIsSingleTween(keyframes)) {
+      keyframes[1].dragStart(dragData)
+    } else {
+      keyframes.forEach((keyframe) => keyframe.dragStart(dragData))
+    }
   }
 
   dragStopSelectedKeyframes (dragData) {
@@ -1940,9 +1945,14 @@ class ActiveComponent extends BaseModel {
     this.commitAccumulatedKeyframeMovesDebounced()
   }
 
-  dragSelectedKeyframes (pxpf, mspf, dragData, metadata) {
+  dragSelectedKeyframes (pxpf, mspf, dragData, metadata, isFromSingleKeyframe) {
     const keyframes = this.getSelectedKeyframes()
-    keyframes.forEach((keyframe) => keyframe.drag(pxpf, mspf, dragData, metadata))
+
+    if (isFromSingleKeyframe && Keyframe.groupIsSingleTween(keyframes)) {
+      keyframes[1].drag(pxpf, mspf, dragData, metadata)
+    } else {
+      keyframes.forEach((keyframe) => keyframe.drag(pxpf, mspf, dragData, metadata))
+    }
   }
 
   // Returns true iff the element has any transitions or expressions.

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -961,6 +961,10 @@ Keyframe.epandRowsOfSelectedKeyframes = ({component, from}) => {
   })
 }
 
+Keyframe.groupIsSingleTween = (keyframes) => {
+  return keyframes.length === 2 && keyframes[0].next() === keyframes[1] && keyframes[0].hasCurveBody()
+}
+
 module.exports = Keyframe
 
 // Down here to avoid Node circular dependency stub objects. #FIXME

--- a/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
+++ b/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
@@ -77,7 +77,7 @@ export default class InvisibleKeyframeDragger extends React.Component {
           if (this.props.preventDragging) {
             return;
           }
-          this.props.component.dragStartSelectedKeyframes(dragData);
+          this.props.component.dragStartSelectedKeyframes(dragData, true);
         }}
         onStop={(dragEvent, dragData, wasDrag, lastMouseButtonPressed) => {
           if (this.props.preventDragging) {
@@ -89,7 +89,7 @@ export default class InvisibleKeyframeDragger extends React.Component {
           if (this.props.preventDragging) {
             return;
           }
-          this.props.component.dragSelectedKeyframes(frameInfo.pxpf, frameInfo.mspf, dragData, {alias: 'timeline'});
+          this.props.component.dragSelectedKeyframes(frameInfo.pxpf, frameInfo.mspf, dragData, {alias: 'timeline'}, true);
         }, THROTTLE_TIME)}>
         <span
           id={`keyframe-dragger-${this.props.keyframe.getUniqueKey()}`}


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

[For single timeline segments, clicking & dragging from edge should change duration rather than position](https://app.asana.com/0/752360003454336/767130344203364)

Regressions to look for:

- Timeline dragging

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
