### PR TITLE
fix: update special casing of single segments dragging for left keyframes

### DIFF
--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -1925,11 +1925,11 @@ class ActiveComponent extends BaseModel {
     return selectedKeyframeWithCurve ? selectedKeyframeWithCurve.getCurve() : null
   }
 
-  dragStartSelectedKeyframes (dragData, isFromSingleKeyframe) {
+  dragStartSelectedKeyframes (dragData, referenceKeyframe) {
     const keyframes = this.getSelectedKeyframes()
 
-    if (isFromSingleKeyframe && Keyframe.groupIsSingleTween(keyframes)) {
-      keyframes[1].dragStart(dragData)
+    if (referenceKeyframe && Keyframe.groupIsSingleTween(keyframes)) {
+      referenceKeyframe.dragStart(dragData)
     } else {
       keyframes.forEach((keyframe) => keyframe.dragStart(dragData))
     }
@@ -1945,11 +1945,11 @@ class ActiveComponent extends BaseModel {
     this.commitAccumulatedKeyframeMovesDebounced()
   }
 
-  dragSelectedKeyframes (pxpf, mspf, dragData, metadata, isFromSingleKeyframe) {
+  dragSelectedKeyframes (pxpf, mspf, dragData, metadata, referenceKeyframe) {
     const keyframes = this.getSelectedKeyframes()
 
-    if (isFromSingleKeyframe && Keyframe.groupIsSingleTween(keyframes)) {
-      keyframes[1].drag(pxpf, mspf, dragData, metadata)
+    if (referenceKeyframe && Keyframe.groupIsSingleTween(keyframes)) {
+      referenceKeyframe.drag(pxpf, mspf, dragData, metadata)
     } else {
       keyframes.forEach((keyframe) => keyframe.drag(pxpf, mspf, dragData, metadata))
     }

--- a/packages/haiku-serialization/test/bll/05_Keyframe.test.js
+++ b/packages/haiku-serialization/test/bll/05_Keyframe.test.js
@@ -218,7 +218,6 @@ tape('Keyframe.05', (t) => {
 })
 
 tape('Keyframe.06', (t) => {
-  t.plan(6)
   return setupTest('keyframe-06', (err, ac, rows, done) => {
     if (err) throw err
     const kfs = rows[0].getKeyframes()
@@ -233,6 +232,7 @@ tape('Keyframe.06', (t) => {
 
     t.ok(Keyframe.groupIsSingleTween(selection), 'returns true if there is a tween between the two provided keyframes')
     done()
+    t.end()
   })
 })
 

--- a/packages/haiku-serialization/test/bll/05_Keyframe.test.js
+++ b/packages/haiku-serialization/test/bll/05_Keyframe.test.js
@@ -217,6 +217,25 @@ tape('Keyframe.05', (t) => {
   })
 })
 
+tape('Keyframe.06', (t) => {
+  t.plan(6)
+  return setupTest('keyframe-06', (err, ac, rows, done) => {
+    if (err) throw err
+    const kfs = rows[0].getKeyframes()
+    const selection = [kfs[0], kfs[1]]
+
+    t.notOk(Keyframe.groupIsSingleTween([kfs[0]]), 'returns false if only one keyframe is selected')
+    t.notOk(Keyframe.groupIsSingleTween([kfs[0], kfs[1], kfs[2]]), 'returns false if more than two keyframes are selected')
+    t.notOk(Keyframe.groupIsSingleTween([kfs[0], kfs[3]]), 'returns false if the keyframes are not next to each other')
+    t.notOk(Keyframe.groupIsSingleTween(selection), 'returns false if there is not a tween between the keyframes')
+
+    selection[0].curve = 'linear'
+
+    t.ok(Keyframe.groupIsSingleTween(selection), 'returns true if there is a tween between the two provided keyframes')
+    done()
+  })
+})
+
 // Please implement the rest of these as unit tests:
 // I am able to create a tween between two keyframes
 // I am able to select a single tween by clicking on it

--- a/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
+++ b/packages/haiku-timeline/src/components/InvisibleKeyframeDragger.js
@@ -77,7 +77,7 @@ export default class InvisibleKeyframeDragger extends React.Component {
           if (this.props.preventDragging) {
             return;
           }
-          this.props.component.dragStartSelectedKeyframes(dragData, true);
+          this.props.component.dragStartSelectedKeyframes(dragData, this.props.keyframe);
         }}
         onStop={(dragEvent, dragData, wasDrag, lastMouseButtonPressed) => {
           if (this.props.preventDragging) {
@@ -89,7 +89,7 @@ export default class InvisibleKeyframeDragger extends React.Component {
           if (this.props.preventDragging) {
             return;
           }
-          this.props.component.dragSelectedKeyframes(frameInfo.pxpf, frameInfo.mspf, dragData, {alias: 'timeline'}, true);
+          this.props.component.dragSelectedKeyframes(frameInfo.pxpf, frameInfo.mspf, dragData, {alias: 'timeline'}, this.props.keyframe);
         }, THROTTLE_TIME)}>
         <span
           id={`keyframe-dragger-${this.props.keyframe.getUniqueKey()}`}


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

A fix for an 'edge' case that I didn't contemplate in #663 : with this we allow the curve to be resized from both frames.

I also included a test for `Keyframe.groupIsSingleTween`

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
