### PR TITLE
fix: allow elements to be rotated on stage outside [0, 2pi)

### DIFF
--- a/packages/@haiku/core/src/helpers/composedTransformsToTimelineProperties.ts
+++ b/packages/@haiku/core/src/helpers/composedTransformsToTimelineProperties.ts
@@ -1,12 +1,30 @@
 /**
  * Copyright (c) Haiku 2016-2018. All rights reserved.
+ *
+ * Note: this and all related work should be moved out of @haiku/core in conjunction with xmlToMana and friends.
  */
 
+import {LayoutSpec} from '../api';
 import Layout3D from '../Layout3D';
 import mat4Decompose, {DecomposedMat4, roundVector, ThreeTuple} from '../vendor/mat4-decompose';
 import {doublesEqual, getEulerAngles} from '../vendor/math3d';
 
-const cleanInvalidOrOverexplicitProps = (out, explicit = false) => {
+export interface ComposedTransformSpec {
+  'translation.x'?: number;
+  'translation.y'?: number;
+  'translation.z'?: number;
+  'rotation.x'?: number;
+  'rotation.y'?: number;
+  'rotation.z'?: number;
+  'scale.x'?: number;
+  'scale.y'?: number;
+  'scale.z'?: number;
+  'shear.xy'?: number;
+  'shear.xz'?: number;
+  'shear.yz'?: number;
+}
+
+const cleanInvalidOrOverexplicitProps = (out: ComposedTransformSpec, explicit = false) => {
   // The reason for the conditional test is we don't want to bother assigning the attribute if it's the default/fallback
   // (keeps the bytecode less noisy if we only include what is really an override)
   Object.keys(out).forEach((layoutPropertyName) => {
@@ -38,7 +56,7 @@ const cleanInvalidOrOverexplicitProps = (out, explicit = false) => {
   });
 };
 
-export const simplify3dTransformations = (out, epislon = 1e-3) => {
+export const simplify3dTransformations = (out: ComposedTransformSpec, epislon = 1e-3) => {
   // When our six degrees of freedom might allow us to remove 3D rotation entirely, opt to do so. This might prevent
   // downstream rendering issues with layout engines that don't support 3D rotation mechanics (e.g. Lottie).
   if (doublesEqual(Math.abs(out['rotation.x']), Math.PI, epislon)) {
@@ -52,7 +70,45 @@ export const simplify3dTransformations = (out, epislon = 1e-3) => {
   }
 };
 
-export default (out, matrices, explicit = false, epsilon = 1e-3) => {
+/**
+ * Normalize rotations as close as possible to the quadrant of origin. Carefully.
+ */
+const normalizeRotationsInQuadrants = (out: ComposedTransformSpec, normalizer: LayoutSpec) => {
+  if (normalizer === null) {
+    return;
+  }
+
+  ['x', 'y', 'z'].forEach((axis) => {
+    // We have to do this because the ComposedTransformSpec uses keys like "rotation.x" and the layout spec addresses
+    // layout property groups in the expected way.
+    const rotationProperty = `rotation.${axis}`;
+    // out[rotationProperty] is falsey if the property is not set OR if it's 0 (which we might care about).
+    if (!out.hasOwnProperty(rotationProperty)) {
+      return;
+    }
+
+    const originalQuadrant = Math.floor(2 * normalizer.rotation[axis] / Math.PI);
+    const quadrantOut = Math.floor(2 * out[rotationProperty] / Math.PI);
+    if (Math.abs(originalQuadrant - quadrantOut) < 3) {
+      // We're within a half "tick" of the original normalizer, so there isn't an obvious way to normalize, so let's
+      // just accept what we have.
+      return;
+    }
+
+    // Offset by the necessary rotations to land in a "less unexpected" quadrant…
+    out[rotationProperty] += Math.PI * 2 * Math.round((originalQuadrant - quadrantOut) / 4);
+    // …and round to avoid additional weirdness.
+    out[rotationProperty] = Math.round(out[rotationProperty] * 1e3) / 1e3;
+  });
+};
+
+export default (
+  out: ComposedTransformSpec,
+  matrices,
+  explicit = false,
+  epsilon = 1e-3,
+  normalizer: LayoutSpec = null,
+) => {
   // Note the array reversal - to combine matrices we go in the opposite of the transform sequence
   // I.e. if we transform A->B->C, the multiplication order should be CxBxA
   const decomposed = mat4Decompose(Layout3D.multiplyArrayOfMatrices(matrices.reverse()));
@@ -82,6 +138,7 @@ export default (out, matrices, explicit = false, epsilon = 1e-3) => {
   out['shear.yz'] = shear[2];
   simplify3dTransformations(out, epsilon);
   cleanInvalidOrOverexplicitProps(out, explicit);
+  normalizeRotationsInQuadrants(out, normalizer);
 
   return out;
 };

--- a/packages/@haiku/core/test/unit/composedTransformsToTimelineProperties.test.ts
+++ b/packages/@haiku/core/test/unit/composedTransformsToTimelineProperties.test.ts
@@ -1,0 +1,52 @@
+import * as tape from 'tape';
+
+import composedTransformsToTimelineProperties from '@core/helpers/composedTransformsToTimelineProperties';
+import Layout3D from '@core/Layout3D';
+
+tape(
+  'composedTransformsToTimelineProperties',
+  (suite) => {
+    suite.test('normalizeRotationsInQuadrants', (test) => {
+      const out = {};
+      const layoutSpec = Layout3D.createLayoutSpec();
+      const identityTransforms = [
+        [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+      ];
+
+      composedTransformsToTimelineProperties(out, identityTransforms, true, 1e-3, layoutSpec);
+      test.is(layoutSpec.rotation.z, 0);
+      test.deepEqual(out['rotation.z'], 0, 'without unrotated normalizer z rotation is 0');
+
+      layoutSpec.rotation.z = 2 * Math.PI;
+      composedTransformsToTimelineProperties(out, identityTransforms, true, 1e-3, layoutSpec);
+      test.deepEqual(out['rotation.z'], 6.283, 'with normalizer rotation is normalized');
+
+      layoutSpec.rotation.z = 2 * Math.PI - 0.1;
+      composedTransformsToTimelineProperties(out, identityTransforms, true, 1e-3, layoutSpec);
+      test.deepEqual(out['rotation.z'], 6.283, 'normalizer can round up to positive on boundary');
+
+      layoutSpec.rotation.z = -0.1;
+      composedTransformsToTimelineProperties(out, identityTransforms, true, 1e-3, layoutSpec);
+      test.deepEqual(out['rotation.z'], 0, 'normalizer can round up to 0 on boundary');
+
+      layoutSpec.rotation.z = -2 * Math.PI - 0.1;
+      composedTransformsToTimelineProperties(out, identityTransforms, true, 1e-3, layoutSpec);
+      test.deepEqual(out['rotation.z'], -6.283, 'normalizer can round up to negative on boundary');
+
+      layoutSpec.rotation.z = 2 * Math.PI + 0.1;
+      composedTransformsToTimelineProperties(out, identityTransforms, true, 1e-3, layoutSpec);
+      test.deepEqual(out['rotation.z'], 6.283, 'normalizer can round down to positive on boundary');
+
+      layoutSpec.rotation.z = 0.1;
+      composedTransformsToTimelineProperties(out, identityTransforms, true, 1e-3, layoutSpec);
+      test.deepEqual(out['rotation.z'], 0, 'normalizer can round down to 0 on boundary');
+
+      layoutSpec.rotation.z = -2 * Math.PI + 0.1;
+      composedTransformsToTimelineProperties(out, identityTransforms, true, 1e-3, layoutSpec);
+      test.deepEqual(out['rotation.z'], -6.283, 'normalizer can round down to negative on boundary');
+
+      test.end();
+    });
+    suite.end();
+  },
+);

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -1541,7 +1541,7 @@ class ElementSelectionProxy extends BaseModel {
       // This is necessary when we pass explicit = false to composedTransformsToTimelineProperties like above.
       propertyGroup['translation.x'] = propertyGroup['translation.x'] || 0
       propertyGroup['translation.y'] = propertyGroup['translation.y'] || 0
-      propertyGroup['translation.z'] = propertyGroup['translation.Z'] || 0
+      propertyGroup['translation.z'] = propertyGroup['translation.z'] || 0
 
       propertyGroup['translation.x'] +=
         finalMatrix[0] * originX + finalMatrix[4] * originY + finalMatrix[8] * originZ - offsetX

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -1528,7 +1528,7 @@ class ElementSelectionProxy extends BaseModel {
       // This converts a composition of matrices like [[1,0,0,...],...] into our own
       // transform properties like scale.x, rotation.z, and merges them into the
       // given property group object.
-      composedTransformsToTimelineProperties(propertyGroup, [finalMatrix], true)
+      composedTransformsToTimelineProperties(propertyGroup, [finalMatrix], false, 1e-3, element.getLayoutSpec())
 
       const offsetX = layoutSpec.offset.x
       const offsetY = layoutSpec.offset.y
@@ -1536,6 +1536,12 @@ class ElementSelectionProxy extends BaseModel {
       const originX = layoutSpec.origin.x * layoutSpec.size.x
       const originY = layoutSpec.origin.y * layoutSpec.size.y
       const originZ = layoutSpec.origin.z * layoutSpec.size.z
+
+      // Ensure translation properties are defined so we can do #math with them below.
+      // This is necessary when we pass explicit = false to composedTransformsToTimelineProperties like above.
+      propertyGroup['translation.x'] = propertyGroup['translation.x'] || 0
+      propertyGroup['translation.y'] = propertyGroup['translation.y'] || 0
+      propertyGroup['translation.z'] = propertyGroup['translation.Z'] || 0
 
       propertyGroup['translation.x'] +=
         finalMatrix[0] * originX + finalMatrix[4] * originY + finalMatrix[8] * originZ - offsetX
@@ -1561,7 +1567,7 @@ class ElementSelectionProxy extends BaseModel {
             propertyGroupNorm.width = {value: Math.abs(layoutSpec.size.x * scaleX / baseProxyTransform.scale.x)}
             // Note: here and below, scale.x and scale.y are guaranteed to exist as properties of propertyGroup[Norm]
             // because composedTransformsToTimelineProperties was called with explicit = true.
-            propertyGroupNorm['scale.x'] = {value: Math.sign(propertyGroup['scale.x'])}
+            propertyGroupNorm['scale.x'] = {value: Math.sign(propertyGroup['scale.x'] || 1)}
             shouldTick = true
           }
 
@@ -1570,7 +1576,7 @@ class ElementSelectionProxy extends BaseModel {
             addressables.height.typedef === 'number'
           ) {
             propertyGroupNorm.height = {value: Math.abs(layoutSpec.size.y * scaleY / baseProxyTransform.scale.y)}
-            propertyGroupNorm['scale.y'] = {value: Math.sign(propertyGroup['scale.y'])}
+            propertyGroupNorm['scale.y'] = {value: Math.sign(propertyGroup['scale.y'] || 1)}
             shouldTick = true
           }
         }
@@ -1775,7 +1781,6 @@ class ElementSelectionProxy extends BaseModel {
       this,
       coordsCurrent,
       coordsPrevious,
-      activationPoint,
       globals
     )
 
@@ -1786,10 +1791,16 @@ class ElementSelectionProxy extends BaseModel {
         element.getComponentId(),
         element.component.getCurrentTimelineName(),
         element.component.getCurrentTimelineTime(),
-        ElementSelectionProxy.computeRotationPropertyGroup(
-          element,
-          rotationZ,
-          fixedPoint
+        Object.assign(
+          {
+            // Ensure we always get a default out in case rotation is snapping to 0.
+            'rotation.z': {value: 0}
+          },
+          ElementSelectionProxy.computeRotationPropertyGroup(
+            element,
+            rotationZ,
+            fixedPoint
+          )
         )
       )
     })
@@ -2200,7 +2211,7 @@ ElementSelectionProxy.computeRotationPropertyGroup = (element, rotationZDelta, f
     ray.y += layoutSpec.offset.y
   }
   const attributes = {}
-  composedTransformsToTimelineProperties(attributes, [matrix, originalRotationMatrix])
+  composedTransformsToTimelineProperties(attributes, [matrix, originalRotationMatrix], false, 1e-3, layoutSpec)
 
   // Return directly after offsetting translation by the `fixedPoint`'s coordinates. Note that we are choosing _not_ to
   // change the z-translation, effectively projecting the origin of rotation from the context element onto the z = C
@@ -2239,7 +2250,6 @@ ElementSelectionProxy.computeRotationPropertyGroupDelta = (
   contextElement,
   coordsCurrent,
   coordsPrevious,
-  activationPoint,
   globals
 ) => {
   // Calculate rotation delta based on old mouse position and new


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- [Asana task.](https://app.asana.com/0/752360003454336/757269591518886/f)
- Fixes issue(s) in which original rotation quadrant is unexpectedly normalized in `[0, 2pi)` during on-stage rotation of elements. This was always an issue with multirotate and multiscale, and, with the recent refactor to do single rotate and single scale with the same algorithm, became an issue for everything.

Regressions to look for:

- None are expected.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test for existing and modified functionality
