### PR TITLE
feat: expand timeline properties when the row is changed on stage

### DIFF
--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -32,5 +32,6 @@
   "CopyPasteTweensWithAccelerators": false,
   "UserFacingDevTools": false,
   "ControlFlowIf": false,
-  "ControlFlowRepeat": false
+  "ControlFlowRepeat": false,
+  "ExpandTimelinePropertiesFromStageChanges": true
 }

--- a/packages/haiku-common/src/experiments/index.ts
+++ b/packages/haiku-common/src/experiments/index.ts
@@ -41,6 +41,7 @@ export enum Experiment {
   SendLogMessagesToPlumbing = 'SendLogMessagesToPlumbing',
   ControlFlowIf = 'ControlFlowIf',
   ControlFlowRepeat = 'ControlFlowRepeat',
+  ExpandTimelinePropertiesFromStageChanges = 'ExpandTimelinePropertiesFromStageChanges',
 }
 
 /**

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -3544,7 +3544,7 @@ class ActiveComponent extends BaseModel {
   }
 
   /**
-   * @method moveKeyframes
+   * @method updateKeyframes
    */
   updateKeyframes (keyframeUpdatesSerial, options, metadata, cb) {
     const keyframeUpdates = Bytecode.unserializeValue(keyframeUpdatesSerial, (ref) => {
@@ -3593,6 +3593,12 @@ class ActiveComponent extends BaseModel {
                 // Not all views necessarily have the same collection of elements
                 if (element) {
                   Row.where({ component: this, element }).forEach((row) => {
+                    if (experimentIsEnabled(Experiment.ExpandTimelinePropertiesFromStageChanges)) {
+                      if (row.property && keyframeUpdates[timelineName][componentId][row.property.name]) {
+                        row.expand(metadata)
+                      }
+                    }
+
                     row.rehydrate()
                   })
                 }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

As the title says, this fixes [UX tweak: when adjusting element on stage via controls affected properties should expand.](https://app.asana.com/0/752360003454336/695267281537668)

Regressions to look for:

- Not aware of any, but I included this feature behind a flag, just because stage -> timeline mutations always brings unexpected headaches.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
