### PR TITLE
fix: temporally hide the new component button next to component tabs in "Code" mode

### DIFF
--- a/packages/haiku-creator/src/react/components/ComponentMenu/ComponentMenu.js
+++ b/packages/haiku-creator/src/react/components/ComponentMenu/ComponentMenu.js
@@ -91,9 +91,11 @@ class ComponentMenu extends React.Component {
               tryToChangeCurrentActiveComponent={this.props.tryToChangeCurrentActiveComponent} />
           );
         }))}
-        <button style={STYLES.newComponentButton} onClick={this.showNewComponentDialog}>
-          +
-        </button>
+        {this.props.showGlass &&
+          <button style={STYLES.newComponentButton} onClick={this.showNewComponentDialog}>
+            +
+          </button>
+        }
       </div>
     );
   }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Since the "new component" modal is in Glass, and the Code Editor in
Creator, we currently can't display the modal.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
