### PR TITLE
perf: fix sender.markForFullFlush() in vanities with surgery.

### DIFF
--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -541,7 +541,6 @@ export default class HaikuComponent extends HaikuElement implements IHaikuCompon
     this.stateTransitionManager.setState(states, transitionParameter);
 
     return this;
-
   }
 
   getStates () {
@@ -3012,7 +3011,7 @@ export const VANITIES = {
       // don't have the effect of flushing the content, and the rendered text doesn't change.
       // DEMO: bind-numeric-state-to-text
       // TODO: What is the best way to make this less expensive (while still functional)?
-      sender.markForFullFlush();
+      sender.patches.push(element);
     },
 
     // Playback-related vanities that involve controlling timeline or clock time
@@ -3179,7 +3178,8 @@ export const VANITIES = {
             timeline,
           );
 
-          sender.markForFullFlush();
+          sender.patches.push(element);
+          expandNode(element, element.__memory.parent);
         }
 
         return;
@@ -3226,7 +3226,8 @@ export const VANITIES = {
         element.__memory.repeater.repeatees[index] = repeatee;
       });
 
-      sender.markForFullFlush();
+      sender.patches.push(element);
+      expandNode(element, element.__memory.parent);
     },
 
     'controlFlow.if': (

--- a/packages/@haiku/core/src/renderers/dom/HaikuDOMRenderer.ts
+++ b/packages/@haiku/core/src/renderers/dom/HaikuDOMRenderer.ts
@@ -685,7 +685,7 @@ export default class HaikuDOMRenderer extends HaikuBase implements IRenderer {
       // TODO: Fix this hack and make smarter
       const doSkipChildren = (
         isPatchOperation &&
-        (typeof children[0] !== 'string')
+        children[0] instanceof Object
       );
 
       HaikuDOMRenderer.renderTree(


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes perf regression in core with text vanities (and `controlFlow.repeat`).

Regressions to look for:

- Demos checked, none likely.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
