### PR TITLE
fix: allow very long timeline rows to be dragged and dropped

### DIFF
--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -64,6 +64,14 @@ export default class ComponentHeadingRow extends React.Component {
     );
   }
 
+  hoverRow = () => {
+    this.handleRowHoverUnhover(true);
+  };
+
+  unhoverRow = () => {
+    this.handleRowHoverUnhover(false);
+  };
+
   handleRowHoverUnhover (shouldHover) {
     if (shouldHover) {
       this.props.row.hoverAndUnhoverOthers({from: 'timeline'});
@@ -96,12 +104,8 @@ export default class ComponentHeadingRow extends React.Component {
         id={`component-heading-row-${componentId}-${this.props.row.getAddress()}`}
         key={`component-heading-row-${componentId}-${this.props.row.getAddress()}`}
         className="component-heading-row no-select unselectable-during-marquee"
-        onMouseOver={() => {
-          this.throttledHandleRowHoverUnhover(true);
-        }}
-        onMouseOut={() => {
-          this.throttledHandleRowHoverUnhover(false);
-        }}
+        onMouseOver={this.hoverRow}
+        onMouseOut={this.unhoverRow}
         style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
           display: 'flex',
           alignItems: 'top',

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1604,7 +1604,7 @@ class Timeline extends React.Component {
             },
           );
         }}>
-        <Droppable droppableId="componentRowsDroppable">
+        <Droppable droppableId="componentRowsDroppable" ignoreContainerClipping={true}>
           {(provided, snapshot) => {
             return (
               <div


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Very simple fix for an issue ([Not able to re-organize elements in attributes panel](https://app.asana.com/0/752360003454336/749856229251433)) that took me hours to figure out... I added steps to repro in the task, but in short this was happening when a row has keyframes in a time that is distant enough from t=0 to cause overflow issues.

I also included a ninja refactor of some inline functions.

Regressions to look for:

- None

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
