### PR TITLE
UI Tweaks

### DIFF
--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/EventSelector.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/EventSelector.js
@@ -29,7 +29,7 @@ class EventSelector extends React.Component {
           {`
           .react-selectize.root-node,
           .dropdown-menu.tethered {
-            width: 457px;
+            width: 568px;
           }
 
           .react-selectize.default {

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/constants.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/constants.js
@@ -6,7 +6,7 @@ export const EVALUATOR_STATES = {
   ERROR: 5,
 };
 
-export const EDITOR_WIDTH = 500;
+export const EDITOR_WIDTH = 610;
 
 export const AUTOCOMPLETION_ITEMS = [
   {

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -346,17 +346,10 @@ class StageTitleBar extends React.Component {
   handleSaveOnGlass () {
     const noticeNotice = this.props.createNotice({
       type: 'info',
-      title: 'Snapshot saved',
+      title: 'No need to save!',
       message: (
         <p>
-          <span
-            style={STYLES.link2}
-            onClick={() => {
-              shell.showItemInFolder(this.props.folder);
-            }}
-          >
-            View in Finder
-          </span>
+          Haiku saves your work automatically
         </p>
       ),
     });

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -1031,6 +1031,7 @@ class StageTitleBar extends React.Component {
               this._shareModal = el;
             }}
             projectName={this.props.project.projectName}
+            folder={this.props.folder}
             mixpanel={mixpanel}
             urls={this.state.shareUrls}
             privateProjectCount={this.state.privateProjectCount}

--- a/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
@@ -1,4 +1,5 @@
 import * as Color from 'color';
+import {shell} from 'electron';
 import * as React from 'react';
 import Palette from '../../Palette';
 import {TooltipBasic} from '../TooltipBasic';
@@ -24,6 +25,7 @@ const STYLES = {
     margin: '0',
     fontStyle: 'italic',
     lineHeight: '1.2em',
+    paddingRight: 20,
   },
   infoHeading: {
     float: 'left',
@@ -49,6 +51,7 @@ const STYLES = {
   label: {
     textTransform: 'uppercase',
     color: Palette.DARK_ROCK,
+    wordWrap: 'break-word',
   },
   toggle: {
     display: 'inline-block',
@@ -110,6 +113,7 @@ const STYLES = {
 export interface ProjectShareDetailsProps {
   semverVersion: string;
   projectName: string;
+  folder: string;
   linkAddress: string;
   isSnapshotSaveInProgress: boolean;
   snapshotSyndicated: boolean;
@@ -133,6 +137,10 @@ export class ProjectShareDetails extends React.PureComponent<ProjectShareDetails
 
   private togglePublic = () => {
     this.props.togglePublic();
+  };
+
+  private openInFinder = () => {
+    shell.openItem(this.props.folder);
   };
 
   private showTooltip = () => {
@@ -160,6 +168,7 @@ export class ProjectShareDetails extends React.PureComponent<ProjectShareDetails
   render () {
     const {
       projectName,
+      folder,
       semverVersion,
       linkAddress,
       isSnapshotSaveInProgress,
@@ -183,6 +192,13 @@ export class ProjectShareDetails extends React.PureComponent<ProjectShareDetails
             ) : (
               <p style={{height: 16, ...STYLES.info}} />
             )}
+            <p style={STYLES.info}>
+              <span
+                style={STYLES.label}
+                onClick={this.openInFinder}>
+                {folder}
+              </span>
+            </p>
 
             {<span style={{visibility: (this.props.isPublic === undefined && false) ? 'hidden' : 'visible'}}>
               <span

--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -29,6 +29,7 @@ export interface ShareModalProps {
   userName: string;
   organizationName: string;
   projectName: string;
+  folder: string;
   mixpanel: any;
   urls: HaikuShareUrls;
   explorePro: () => void;
@@ -140,6 +141,7 @@ export class ShareModal extends React.Component<ShareModalProps, ShareModalState
       userName,
       organizationName,
       mixpanel,
+      folder,
     } = this.props;
 
     return (
@@ -149,6 +151,7 @@ export class ShareModal extends React.Component<ShareModalProps, ShareModalState
           <ProjectShareDetails
             semverVersion={semverVersion}
             projectName={project.projectName}
+            folder={folder}
             linkAddress={linkAddress}
             isSnapshotSaveInProgress={isSnapshotSaveInProgress}
             snapshotSyndicated={snapshotSyndicated}

--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -8,7 +8,7 @@ import {ProjectShareDetails} from './ProjectShareDetails';
 
 const STYLES: React.CSSProperties = {
   wrapper: {
-    width: 500,
+    width: 610,
     overflow: 'hidden',
     left: 'calc(50% + 150px)',
     transform: 'translateX(-50%)',


### PR DESCRIPTION
OK to merge.

This looks pretty clunkbanger to me. I'm not sure we really score more points listing out the path over putting a [REVEAL IN FINDER] button instead. Let's consider switching. I'm okay with this for now mostly because I feel like this whole UI is due for a revamp.

Summary of changes:
![image](https://user-images.githubusercontent.com/1357566/43925902-8165ab1e-9bdd-11e8-9f81-a2352ab4f978.png)

[Add proj path to publish modal](https://app.asana.com/0/752360003454336/771482871628185)

[Make Actions modal wider](https://app.asana.com/0/752360003454336/759100037963940)

[Clarify auto-save copywriting](https://app.asana.com/0/752360003454336/759100037963911)

- [x] Did manual testing of interrelated functionality