### PR TITLE
fix: serialize event handler data when copying/pasting elements

### DIFF
--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -3,6 +3,7 @@ const HaikuElement = require('@haiku/core/lib/HaikuElement').default
 const Layout3D = require('@haiku/core/lib/Layout3D').default
 const {cssQueryTree} = require('@haiku/core/lib/HaikuNode')
 const composedTransformsToTimelineProperties = require('@haiku/core/lib/helpers/composedTransformsToTimelineProperties').default
+const functionToRFO = require('@haiku/core/lib/reflection/functionToRFO').default
 const {LAYOUT_3D_SCHEMA} = require('@haiku/core/lib/HaikuComponent')
 const KnownDOMEvents = require('@haiku/core/lib/renderers/dom/Events').default
 const titlecase = require('titlecase')
@@ -405,11 +406,19 @@ class Element extends BaseModel {
       this.component.fetchActiveBytecodeFile().getReifiedDecycledBytecode()
     )
 
+    const eventHandlers = Bytecode.getAppliedEventHandlersForNode({}, clonedBytecode, clonedNode)
+
+    Object.keys(eventHandlers).forEach((element) => {
+      Object.keys(eventHandlers[element]).forEach((event) => {
+        eventHandlers[element][event].handler = functionToRFO(eventHandlers[element][event].handler)
+      })
+    })
+
     return {
       kind: 'bytecode',
       data: {
+        eventHandlers,
         timelines: Bytecode.getAppliedTimelinesForNode({}, clonedBytecode, clonedNode),
-        eventHandlers: Bytecode.getAppliedEventHandlersForNode({}, clonedBytecode, clonedNode),
         template: clonedNode
       }
     }

--- a/packages/haiku-serialization/test/bll/04_Element.test.js
+++ b/packages/haiku-serialization/test/bll/04_Element.test.js
@@ -6,7 +6,44 @@ const Project = require('./../../src/bll/Project')
 const Row = require('./../../src/bll/Row')
 
 tape('Element', (t) => {
-  t.plan(11)
+  setupTest((ac, bytecode, done) => {
+    t.plan(11)
+    const el0 = ac.findElementByComponentId(bytecode.template.attributes['haiku-id'])
+    const a1 = el0.getCompleteAddressableProperties()
+    t.ok(a1, 'addressables are present')
+    t.ok(a1['translation.x'],'standard prop present')
+    t.equal(a1['translation.x'].type, 'native')
+    t.equal(a1['translation.x'].name, 'translation.x')
+    t.equal(a1['translation.x'].prefix, 'translation')
+    t.equal(a1['translation.x'].suffix, 'x')
+    t.equal(a1['translation.x'].fallback, 0)
+    t.equal(a1['translation.x'].typedef, 'number')
+    t.equal(a1['translation.x'].mock, undefined)
+    t.equal(a1['translation.x'].value, undefined)
+    t.deepEqual(a1['translation.x'].cluster, { prefix: 'translation', name: 'Position' })
+    done()
+  })
+})
+
+tape('Element.buildClipboardPayload', (t) => {
+  setupTest((ac, bytecode, done) => {
+    const id = bytecode.template.attributes['haiku-id']
+    const element = ac.findElementByComponentId(id)
+    element.upsertEventHandler('click', SERIALIZED_EVENT.click)
+    const payload = element.buildClipboardPayload()
+
+    t.equal(payload.kind, 'bytecode', 'the payload returned must have a kind property with the correct value')
+    t.ok(payload.data.eventHandlers, 'they payload must contain the event handlers of the element')
+    t.ok(payload.data.eventHandlers[`haiku:${id}`].click)
+    t.ok(payload.data.eventHandlers[`haiku:${id}`].click.handler.__function, 'the payload contains the event handlers of the element serialized')
+    t.ok(payload.data.timelines, 'the payload must contain the timelines of the element')
+    t.ok(payload.data.template, 'the payload must contain the template of the element')
+    t.end()
+    done()
+  })
+})
+
+const setupTest = (doTest) => {
   const folder = path.join(__dirname, '..', 'fixtures', 'projects', 'element-getaddressables-01')
   fse.removeSync(folder)
   const bytecode = require(path.join(__dirname, '..', '..', '..', 'haiku-timeline', 'test', 'projects', 'complex', 'code', 'main', 'code.js'))
@@ -23,40 +60,25 @@ tape('Element', (t) => {
         return ac0.hardReload({}, {}, () => {
           return async.series([], (err) => {
             if (err) throw err
-             const el0 = ac0.findElementByComponentId(bytecode.template.attributes['haiku-id'])
-             const a1 = el0.getCompleteAddressableProperties()
-             t.ok(a1, 'addressables are present')
-             t.ok(a1['translation.x'],'standard prop present')
-             t.equal(a1['translation.x'].type, 'native')
-             t.equal(a1['translation.x'].name, 'translation.x')
-             t.equal(a1['translation.x'].prefix, 'translation')
-             t.equal(a1['translation.x'].suffix, 'x')
-             t.equal(a1['translation.x'].fallback, 0)
-             t.equal(a1['translation.x'].typedef, 'number')
-             t.equal(a1['translation.x'].mock, undefined)
-             t.equal(a1['translation.x'].value, undefined)
-             t.deepEqual(a1['translation.x'].cluster, { prefix: 'translation', name: 'Position' })
-             fse.removeSync(folder)
+            doTest(ac0, bytecode, () => {
+              fse.removeSync(folder)
+            })
           })
         })
       })
     })
   })
-})
+}
 
-const PATH_SVG_1 = `
-  <?xml version="1.0" encoding="UTF-8"?>
-  <svg width="99px" height="69px" viewBox="0 0 99 69" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-      <!-- Generator: sketchtool 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
-      <title>PathPen</title>
-      <desc>Created with sketchtool.</desc>
-      <defs>
-        <foobar id="abc123"></foobar>
-      </defs>
-      <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-          <g foobar="url(#abc123)" id="Artboard" transform="translate(-283.000000, -254.000000)" stroke="#979797">
-              <path d="M294.851562,260.753906 C282.404105,283.559532 310.725273,290.63691 326.835937,295.734375 C331.617305,297.247215 342.059558,301.595875 338.316406,309.21875 C337.259516,311.371092 335.344104,313.379399 333.070312,314.140625 C316.687518,319.6253 318.607648,314.107756 316.175781,298.535156 C314.073483,285.072967 341.353724,262.381072 307.847656,273.160156 C302.953426,274.734657 299.363413,279.037222 295.621094,282.5625 C294.703984,283.426421 289.762583,289.749326 292.835937,292.191406 C310.800174,306.465746 310.629063,293.466831 327.605469,293.117188 C340.400227,292.853669 361.733615,282.532042 364.140625,298.585938 C364.591437,301.592694 366.227007,305.49551 364.140625,307.707031 C356.643614,315.653704 320.800977,318.428842 316.511719,304 C313.310899,293.23261 309.646651,279.191944 316.511719,270.300781 L317.605469,266.996094 C318.70025,265.578208 319.962133,263.856288 321.726562,263.546875 C348.187608,258.906626 333.406544,260.284286 342.546875,271.855469 C345.091836,275.077257 351.639186,275.674796 351.988281,279.765625 L354.464844,283.632812 C357.416932,318.226499 296.30014,340.100228 293.25,300.105469 C292.638094,292.081893 291.431499,283.803546 293.25,275.964844 C294.715721,269.646813 297.246721,262.379048 302.785156,259.003906 C320.414927,248.260262 322.400502,263.451084 330.808594,271.378906 C333.565871,273.978688 339.302903,273.7221 340.503906,277.316406 C343.115394,285.131945 334.783267,296.681412 341.050781,302.03125 C348.504241,308.39339 366.513246,311.846671 370.4375,302.867188 L372.515625,301.476562 C387.936662,266.190128 352.052706,234.955091 328.25,269.800781 C322.336272,278.458113 340.249653,294.392337 330.753906,301.621094 C326.91332,304.544788 294.058884,308.199097 286.269531,307.359375 C284.995803,307.222062 284.102217,305.584758 283.921875,304.316406 C282.389249,293.537418 285.731973,295.96395 292.257812,288.046875 C311.385715,264.841117 307.46635,267.289874 346.21875,270.695312 C348.526208,270.898085 351.084913,271.703414 352.59375,273.460938 C354.971579,276.230679 354.398541,281.016656 357.144531,283.421875 C361.463282,287.20468 369.172641,295.592094 372.613281,290.996094 C396.717804,258.797319 361.228307,257.906354 349.429687,268.339844 C338.784302,277.753531 347.977468,308.238322 342.097656,310.683594 C334.379679,313.893313 325.61253,313.607482 317.28125,314.285156 C310.815625,314.811077 304.233838,315.258597 297.820312,314.285156 C296.449037,314.077025 295.446155,312.335074 295.328125,310.953125 C294.594926,302.368493 293.381654,293.498605 295.328125,285.105469 C302.241349,255.29581 326.590452,265.047417 334.488281,291.011719 C336.03704,296.103302 335.56021,306.996168 340.308594,312.417969 C354.750775,328.908343 356.425475,297.576804 356.195312,291.328125" id="Path-4"></path>
-          </g>
-      </g>
-  </svg>
-`
+const SERIALIZED_EVENT = {
+  "click": {
+    "handler": {
+      "__function": {
+        "params": ["event"],
+        "body": "/** action logic goes here */\nconsole.log(12);",
+        "type":"FunctionExpression",
+        "name":null
+      }
+    }
+  }
+}


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes the cause of ['CRASH: Null event handler written out to bytecode'](https://app.asana.com/0/752360003454336/755630850619782), the task also requests to prevent the app from crashing, but seems like this has already been done as part of something else because the app doesn't crashes anymore.

*edit*: I forgot to mention the cause, this was happening when copying/pasting elements with actions, since the handlers are functions, they need to be serialized on the copy action.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
