### PR TITLE
fix: prevent wrong height calculations of the timeline/stage height

### DIFF
--- a/packages/haiku-creator/src/dom.js
+++ b/packages/haiku-creator/src/dom.js
@@ -17,22 +17,10 @@ export default function dom (modus, haiku) {
 
   const props = {
     medium: window,
-    width: window.innerWidth,
-    height: window.innerHeight,
     listen: (key, fn) => {
       listeners[key] = fn;
     },
   };
-
-  function resizeHandler (resizeEvent) {
-    props.width = window.innerWidth;
-    props.height = window.innerHeight;
-    if (listeners.resize) {
-      listeners.resize(props.width, props.height);
-    }
-  }
-
-  window.addEventListener('resize', lodash.debounce(resizeHandler, 64));
 
   const websocket = haiku.plumbing && !haiku.proxy.active
     ? new Websocket(

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -2073,7 +2073,7 @@ export default class Creator extends React.Component {
                 {lodash.map(this.state.notices, this.renderNotice)}
               </div>
             </CSSTransition>
-            <SplitPanel split="horizontal" minSize={300} defaultSize={this.props.height * 0.62}>
+            <SplitPanel split="horizontal" minSize={300} defaultSize={'62vh'}>
               <SplitPanel split="vertical" minSize={300} defaultSize={300}>
                 <SideBar
                   doShowBackToDashboardButton={this.state.doShowBackToDashboardButton}


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Use CSS `vh` units instead of setting the width/height as a Creator
prop.

Also remove a `resize` event listener on Creator used for the sole
purpouse of setting `width` and `height` props, that are unused.

*edit*: fixes [Opening project on 15" laptop screen, timeline is quite tall, glass is very small](https://app.asana.com/0/768374296244701/776619682628077)

Regressions to look for:

- Not aware of any, I did a deep investigation to check if the `width/height` props passed to creator are being used in a child component, but I haven't found anything. Side note on this, we should ban the usage of `{...this.props}`, makes this kind of tasks a lot harder!

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
