### PR TITLE
Fix auto-3D bugs with one crazy trick

### DIFF
--- a/packages/@haiku/core/src/Migration.ts
+++ b/packages/@haiku/core/src/Migration.ts
@@ -172,7 +172,9 @@ export const runMigrationsPrePhase = (component: IHaikuComponent, options: Migra
   const referencesToUpdate = {};
 
   if (bytecode.template) {
-    const autoPreserve3d = component.config.preserve3d === 'auto';
+    // y-overflow + preserve-3d leads to various rendering bugs, so for now, disable when overflow is available.
+    // #FIXME
+    const autoPreserve3d = component.config.preserve3d === 'auto' && component.config.overflowY !== 'visible';
 
     visitManaTree(
       '0',


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes [Weird z-index issues when editing](https://app.asana.com/0/768374296244701/776617977997479/f)
- Fixes [When scrubbing, animated things disappear and reappear](https://app.asana.com/0/768374296244701/776617977997480/f)


Regressions to look for:

- None—although by design, this PR breaks auto-3d when overflow-y is enabled.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
