### PR TITLE
Ui fixes aug 13

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -2185,6 +2185,7 @@ export default class Creator extends React.Component {
                     setGlassInteractionToEditMode={this.setGlassInteractionToEditMode}
                     setGlassInteractionToCodeEditorMode={this.setGlassInteractionToCodeEditorMode}
                     tryToChangeCurrentActiveComponent={this.tryToChangeCurrentActiveComponent}
+                    showEventHandlerEditor={this.state.showEventHandlerEditor}
                   />
                   {(this.state.assetDragging)
                     ? <div style={{width: '100%', height: '100%', backgroundColor: 'white', opacity: 0.01, position: 'absolute', top: 0, left: 0}} />

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/Editor.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/Editor.js
@@ -79,6 +79,9 @@ class Editor extends React.Component {
     monaco.editor.setTheme('haiku-actions');
     // this.editor.onMouseMove listener declared in Snippets.js
 
+    // Avoid listening for  cmd|ctrl+ctrl on action editor, because it is used as shortcut
+    this.editor.addCommand([monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter], () => {});
+
     this.forceUpdate();
   }
 

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/HandlerManager.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/HandlerManager.js
@@ -173,8 +173,7 @@ class HandlerManager {
 
       // #FIXME: our pipeline to save and retrieve bytecode modifies the code
       // wrote by the user causing two issues:
-      // 1. If the code only contains comments, the comments are deleted
-      // 2. The format is not respected.
+      // 1. The format is not respected.
       let prettierHandlerBody = null;
       if (handler.body) {
         try {
@@ -184,7 +183,8 @@ class HandlerManager {
           //     <original content indented two spaces>
           //   };
           // To restore the formatted function body, we have to strip off the terminal lines and outdent the remainder.
-          const prettierHandlerBodyLines = prettier.format(`()=>{${handler.body}}`).trim().split('\n');
+          // The added newline after body is to avoid last line having comments to delete to also comment closing }
+          const prettierHandlerBodyLines = prettier.format(`()=>{${handler.body}\n}`).trim().split('\n');
           // Strip terminal lines. Bail if we somehow encounter an unexpected format.
           if (prettierHandlerBodyLines.shift() === '() => {' && prettierHandlerBodyLines.pop() === '};') {
             // Outdent by two spaces.

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/HandlerManager.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/HandlerManager.js
@@ -183,7 +183,8 @@ class HandlerManager {
           //     <original content indented two spaces>
           //   };
           // To restore the formatted function body, we have to strip off the terminal lines and outdent the remainder.
-          // The added newline after body is to avoid last line having comments to delete to also comment closing }
+          //
+          // The added newline after body is to avoid last line being commented and also commenting closing }
           const prettierHandlerBodyLines = prettier.format(`()=>{${handler.body}\n}`).trim().split('\n');
           // Strip terminal lines. Bail if we somehow encounter an unexpected format.
           if (prettierHandlerBodyLines.shift() === '() => {' && prettierHandlerBodyLines.pop() === '};') {

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
@@ -232,6 +232,12 @@ class EventHandlerEditor extends React.PureComponent {
     }
   };
 
+  doSaveFromCmdS = () => {
+    if (!this.state.editorWithErrors) {
+      this.doSave();
+    }
+  };
+
   onEditorContentChange ({evaluator}) {
     this.setState({
       editorWithErrors: evaluator && evaluator.state === EVALUATOR_STATES.ERROR,
@@ -270,7 +276,7 @@ class EventHandlerEditor extends React.PureComponent {
       <ModalWrapper style={{...visibilityStyles, ...STYLES.container}}
             onEsc={this.doCloseFromEsc}
             onCmdEnter={this.doCloseFromEsc}
-            onCmdS={this.doCloseFromEsc}>
+            onCmdS={this.doSaveFromCmdS}>
         <div
           onMouseDown={(mouseEvent) => {
             // Prevent outer view from closing us

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
@@ -267,7 +267,10 @@ class EventHandlerEditor extends React.PureComponent {
     const applicableEventHandlers = this.handlerManager.getApplicableEventHandlers();
 
     return (
-      <ModalWrapper style={{...visibilityStyles, ...STYLES.container}} onClose={this.doCloseFromEsc}>
+      <ModalWrapper style={{...visibilityStyles, ...STYLES.container}}
+            onEsc={this.doCloseFromEsc}
+            onCmdEnter={this.doCloseFromEsc}
+            onCmdS={this.doCloseFromEsc}>
         <div
           onMouseDown={(mouseEvent) => {
             // Prevent outer view from closing us
@@ -386,9 +389,8 @@ class EventHandlerEditor extends React.PureComponent {
               />
             </ModalFooter>
           )}
-        </div>
-      </ModalWrapper>
-    );
+        </div>;
+      </ModalWrapper >);
   }
 }
 

--- a/packages/haiku-creator/src/react/components/OfflineExportUpgradeModal.tsx
+++ b/packages/haiku-creator/src/react/components/OfflineExportUpgradeModal.tsx
@@ -47,7 +47,7 @@ export interface OfflineExportUpgradeModalProps {
 export class OfflineExportUpgradeModal extends React.PureComponent<OfflineExportUpgradeModalProps> {
   render () {
     return (
-      <ModalWrapper style={STYLES.wrapper} onClose={this.props.onClose}>
+      <ModalWrapper style={STYLES.wrapper} onEsc={this.props.onClose}>
         <ModalHeader><h2>Subscription required</h2></ModalHeader>
         <div style={STYLES.inner}>
           <div style={STYLES.upgradeWrap}>

--- a/packages/haiku-creator/src/react/components/PublicPrivateOptInModal.tsx
+++ b/packages/haiku-creator/src/react/components/PublicPrivateOptInModal.tsx
@@ -99,7 +99,7 @@ export class PublicPrivateOptInModal extends React.PureComponent<PublicPrivateOp
 
   render () {
     return (
-      <ModalWrapper style={STYLES.wrapper} onClose={this.props.onClose}>
+      <ModalWrapper style={STYLES.wrapper} onEsc={this.props.onClose}>
         <ModalHeader><h2>Confirm privacy settings</h2></ModalHeader>
         <form style={STYLES.inner}>
           <div>Please confirm your privacy settings before continuing.</div>

--- a/packages/haiku-creator/src/react/components/Stage.js
+++ b/packages/haiku-creator/src/react/components/Stage.js
@@ -305,6 +305,7 @@ class Stage extends React.Component {
             interactionMode={this.props.interactionMode}
             saveCodeFromEditorToDisk={this.saveCodeFromEditorToDisk}
             onShowEventHandlerEditor={this.props.onShowEventHandlerEditor}
+            showEventHandlerEditor={this.props.showEventHandlerEditor}
           />
           <ComponentMenu
             ref="component-menu"

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -352,11 +352,7 @@ class StageTitleBar extends React.Component {
     const noticeNotice = this.props.createNotice({
       type: 'info',
       title: 'No need to save!',
-      message: (
-        <p>
-          Haiku saves your work automatically
-        </p>
-      ),
+      message: 'Haiku saves your work automatically',
     });
 
     window.setTimeout(() => {

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -206,7 +206,8 @@ class StageTitleBar extends React.Component {
     };
 
     ipcRenderer.on('global-menu:save', () => {
-      if (!this._isMounted) {
+      // Skip if event handler editor is open
+      if (!this._isMounted || this.props.showEventHandlerEditor) {
         return;
       }
 

--- a/packages/haiku-serialization/src/ast/functionBodyStringToFunctionBodyAST.js
+++ b/packages/haiku-serialization/src/ast/functionBodyStringToFunctionBodyAST.js
@@ -20,7 +20,7 @@ function functionBodyStringToFunctionBodyAST (body) {
   }
   // If have inner comments, set them
   if (innerComments) {
-    block.innerComments = innerComments;
+    block.innerComments = innerComments
   }
   return block
 }

--- a/packages/haiku-serialization/src/ast/functionBodyStringToFunctionBodyAST.js
+++ b/packages/haiku-serialization/src/ast/functionBodyStringToFunctionBodyAST.js
@@ -2,16 +2,25 @@ var babylon = require('babylon')
 
 function functionBodyStringToFunctionBodyAST (body) {
   var nodes = []
+  let innerComments = null
   if (body) {
     var ast = babylon.parse(body, {
       allowReturnOutsideFunction: true
     })
     var parse = ast.program.body
+    // Inner comments happens when only comments are existant
+    if (ast.program.innerComments) {
+      innerComments = ast.program.innerComments
+    }
     nodes = parse
   }
   var block = {
     type: 'BlockStatement',
     body: nodes
+  }
+  // If have inner comments, set them
+  if (innerComments) {
+    block.innerComments = innerComments;
   }
   return block
 }

--- a/packages/haiku-serialization/src/ast/normalizeBytecodeAST.js
+++ b/packages/haiku-serialization/src/ast/normalizeBytecodeAST.js
@@ -17,8 +17,12 @@ module.exports = function normalizeBytecodeAST (ast) {
 
   // Remove all comments at the top level since they cause more problems than they solve
   ast.program.body.forEach((node) => {
-    if (node.leadingComments) node.leadingComments.splice(0)
-    if (node.trailingComments) node.trailingComments.splice(0)
+    if (node.leadingComments){
+      node.leadingComments.splice(0)
+    } 
+    if (node.trailingComments) {
+      node.trailingComments.splice(0)
+    } 
   })
 
   // Convert any object-destructuring functions to Haiku.inject expressions

--- a/packages/haiku-serialization/src/ast/normalizeBytecodeAST.js
+++ b/packages/haiku-serialization/src/ast/normalizeBytecodeAST.js
@@ -17,12 +17,12 @@ module.exports = function normalizeBytecodeAST (ast) {
 
   // Remove all comments at the top level since they cause more problems than they solve
   ast.program.body.forEach((node) => {
-    if (node.leadingComments){
+    if (node.leadingComments) {
       node.leadingComments.splice(0)
-    } 
+    }
     if (node.trailingComments) {
       node.trailingComments.splice(0)
-    } 
+    }
   })
 
   // Convert any object-destructuring functions to Haiku.inject expressions

--- a/packages/haiku-ui-common/src/react/Modal/ModalWrapper.tsx
+++ b/packages/haiku-ui-common/src/react/Modal/ModalWrapper.tsx
@@ -1,3 +1,4 @@
+import {isMac} from 'haiku-common/lib/environments/os';
 import * as React from 'react';
 import Palette from './../../Palette';
 
@@ -16,7 +17,9 @@ const STYLES = {
 
 export interface ModalWrapperProps {
   style: React.CSSProperties;
-  onClose?: () => void;
+  onEsc?: () => void;
+  onCmdEnter?: () => void;
+  onCmdS?: () => void;
 }
 
 const stopPropagation: React.MouseEventHandler<HTMLDivElement> = (event) => event.stopPropagation();
@@ -35,9 +38,27 @@ export class ModalWrapper extends React.PureComponent<ModalWrapperProps> {
   }
 
   handleKeyEvents = (keyEvent: KeyboardEvent) => {
-    if (keyEvent.keyCode === 27 && typeof this.props.onClose === 'function') {
-      this.props.onClose();
+    // Esc on any platform
+    if (keyEvent.keyCode === 27 && this.props.onEsc instanceof Function) {
+      this.props.onEsc();
     }
+
+    // Command+Enter on MAC
+    // Ctrl+Enter on Windows/Linux
+    if (((isMac() && keyEvent.metaKey && keyEvent.keyCode === 13) ||
+         (!isMac() && keyEvent.ctrlKey && keyEvent.keyCode === 13)) &&
+         this.props.onCmdEnter instanceof Function) {
+      this.props.onCmdEnter();
+    }
+
+    // Command+s on MAC
+    // Ctrl+s on Windows/Linux
+    if (((isMac() && keyEvent.metaKey && keyEvent.keyCode === 83) ||
+         (!isMac() && keyEvent.ctrlKey && keyEvent.keyCode === 83)) &&
+         this.props.onCmdS instanceof Function) {
+      this.props.onCmdS();
+    }
+
   };
 
   render () {

--- a/packages/haiku-ui-common/src/react/Modal/ModalWrapper.tsx
+++ b/packages/haiku-ui-common/src/react/Modal/ModalWrapper.tsx
@@ -1,5 +1,5 @@
-import {isMac} from 'haiku-common/lib/environments/os';
 import * as React from 'react';
+import Globals from './../../Globals';
 import Palette from './../../Palette';
 
 const STYLES = {
@@ -45,17 +45,17 @@ export class ModalWrapper extends React.PureComponent<ModalWrapperProps> {
 
     // Command+Enter on MAC
     // Ctrl+Enter on Windows/Linux
-    if (((isMac() && keyEvent.metaKey && keyEvent.keyCode === 13) ||
-         (!isMac() && keyEvent.ctrlKey && keyEvent.keyCode === 13)) &&
-         this.props.onCmdEnter instanceof Function) {
+    if (Globals.isSpecialKeyDown() &&
+        keyEvent.keyCode === 13 &&
+        this.props.onCmdEnter instanceof Function) {
       this.props.onCmdEnter();
     }
 
     // Command+s on MAC
     // Ctrl+s on Windows/Linux
-    if (((isMac() && keyEvent.metaKey && keyEvent.keyCode === 83) ||
-         (!isMac() && keyEvent.ctrlKey && keyEvent.keyCode === 83)) &&
-         this.props.onCmdS instanceof Function) {
+    if (Globals.isSpecialKeyDown() &&
+        keyEvent.keyCode === 83 &&
+        this.props.onCmdS instanceof Function) {
       this.props.onCmdS();
     }
 

--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -152,7 +152,7 @@ export class ShareModal extends React.Component<ShareModalProps, ShareModalState
     const hasError = !!this.error;
 
     return (
-      <ModalWrapper style={STYLES.wrapper} onClose={this.props.onClose}>
+      <ModalWrapper style={STYLES.wrapper} onEsc={this.props.onClose}>
         {hasError && <ModalNotice message={'Publish was unsuccessful. Are you online?'} />}
         <ModalHeader>
           <ProjectShareDetails


### PR DESCRIPTION
OK to merge.

 - Added Cmd+Enter and Cmd+S shortcuts to action editor (700874348545634) 
 - Do not remove comments from event handlers (700874348545632) 
 - Shows do not need to save dialog and update it (775033840753851) 
 - Do not change to state inspector or library when exiting preview (776617977997478)


After merging, I'll update QA: 
```
When exiting preview mode:
- Pressing toggle preview button: restore creator widgets (open design + restore left panel) or (open code editor + state inspector)
- Pressing design button: go to desing and restore left panel
- Pressing code button: go to code editor and open state inspector on left panel
```

- [x] Did manual testing of interrelated functionality