### PR TITLE
fix: increase the value of the expressions z-index

### DIFF
--- a/packages/haiku-timeline/src/components/styles/zIndex.js
+++ b/packages/haiku-timeline/src/components/styles/zIndex.js
@@ -75,7 +75,7 @@ const zIndex = {
 
   // Box with the expression input
   expressionInput: {
-    base: 8,
+    base: 20,
   },
 
   // Box with the marquee


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Very very small fix (I was about to push directly to master to avoid wasting everybody's time), this just increases the z-index of the expressions editor which was hidden by collapsed rows in certain scenarios.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
