### PR TITLE
Various offline fixes

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -144,7 +144,7 @@ export default class Creator extends React.Component {
       },
       doShowBackToDashboardButton: false,
       doShowProjectLoader: false,
-      launchingProject: false,
+      projectLaunching: false,
       interactionMode: InteractionMode.GLASS_EDIT,
       artboardDimensions: null,
       showChangelogModal: false,
@@ -1581,8 +1581,14 @@ export default class Creator extends React.Component {
   }
 
   onNavigateToDashboard () {
-    this.teardownMaster({shouldFinishTour: true});
-    ipcRenderer.send('topmenu:update', {subComponents: [], isProjectOpen: false});
+    this.user.load().then(({user, organization}) => {
+      this.setState({
+        readyForAuth: true,
+        isUserAuthenticated: user && organization,
+      });
+      this.teardownMaster({shouldFinishTour: true});
+      ipcRenderer.send('topmenu:update', {subComponents: [], isProjectOpen: false});
+    });
   }
 
   awaitAuthAndFire (cb) {

--- a/packages/haiku-sdk-creator/src/bll/User.ts
+++ b/packages/haiku-sdk-creator/src/bll/User.ts
@@ -156,6 +156,7 @@ export class UserHandler extends EnvoyHandler {
     return new Promise<HaikuIdentity>((resolve) => {
       const authToken = sdkClient.config.getAuthToken();
       if (!authToken) {
+        this.logOut();
         return resolve(this.identity);
       }
 


### PR DESCRIPTION
OK to merge, but marking as wip to send more fixes up here.

Short review.

Summary of changes:

- Reload user when navigating back to dashboard and fully log out if we have no auth token. Together, this ensures if we are logged out (e.g. with `haiku logout`) while we have a project open, backing out to dashboard won't use stale/cached models to our detriment.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
