### PR TITLE
fix: allow React elements as notice.message valid values

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1443,24 +1443,26 @@ export default class Creator extends React.Component {
   }
 
   shouldNoticeBeSkipped (notice) {
-    // Assume that any notice without a string isn't usable, so just skip it
-    if (!notice || typeof notice.message !== 'string') {
+    // Assume that any notice without a string or a react element isn't usable, so just skip it
+    if (!notice || typeof notice.message !== 'string' && !React.isValidElement(notice.message)) {
       return true;
     }
 
-    // Ignore Intercom widget errors which are transient and confuse the user
-    if (notice.message.match(/intercom/)) {
-      return true;
-    }
+    if (typeof notice.message === 'string') {
+      // Ignore Intercom widget errors which are transient and confuse the user
+      if (notice.message.match(/intercom/)) {
+        return true;
+      }
 
-    // HACK: Skip human-unfriendly duplicate errors that originate from ActiveComponent action calls
-    if (notice.message.match(/\[active/)) {
-      return true;
-    }
+      // HACK: Skip human-unfriendly duplicate errors that originate from ActiveComponent action calls
+      if (notice.message.match(/\[active/)) {
+        return true;
+      }
 
-    // Avoid scary error messages (752175308356950)
-    if (notice.message.match(/EventEmitter/)) {
-      return true;
+      // Avoid scary error messages (752175308356950)
+      if (notice.message.match(/EventEmitter/)) {
+        return true;
+      }
     }
 
     return false;

--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -202,7 +202,7 @@ class Library extends React.Component {
       return;
     }
 
-    this.setState({isLoading: true, loadingProgress: 80, loadingSpeed: '10s', lockLoadingFromWatchers: true});
+    this.setState({isLoading: true, loadingProgress: 80, loadingSpeed: '20s', lockLoadingFromWatchers: true});
     const projectFolder = this.props.projectModel.folder;
     return this.props.servicesEnvoyClient.figmaImportSVG({url, projectFolder}, this.state.figma.token)
       .then(() => {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes [Some toast messages do not show up](https://app.asana.com/0/768374296244701/782620243519075).

We need React elements because some notices contains [links](https://www.youtube.com/watch?v=dQw4w9WgXcQ) or **bold** elements.

Regressions to look for:

- Not aware of any

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
