### PR TITLE
fix: pass expected component size to ffmpeg

### DIFF
--- a/ci/health.Jenkinsfile
+++ b/ci/health.Jenkinsfile
@@ -59,6 +59,7 @@ pipeline {
                         }
                         failure {
                             setBuildStatus(CONTEXT_TEST_MAC, 'tests are failing', STATUS_FAILURE)
+                            setBuildStatus(CONTEXT_HEALTH, 'not all health checks passed', STATUS_FAILURE)
                             slackSend([
                                 channel: 'engineering-feed',
                                 color: 'danger',

--- a/packages/haiku-common/src/types/index.ts
+++ b/packages/haiku-common/src/types/index.ts
@@ -1,11 +1,5 @@
 export type Maybe<T> = T|null|undefined;
 
-export interface ContextualSize {
-  x: number;
-  y: number;
-  z: number;
-}
-
 export interface CubicCurve {
   type: string;
   x1: number;

--- a/packages/haiku-formats/src/exporters/BaseExporter.ts
+++ b/packages/haiku-formats/src/exporters/BaseExporter.ts
@@ -1,10 +1,12 @@
+import HaikuDOMAdapter from '@haiku/core/lib/adapters/dom/HaikuDOMAdapter';
 import {
   BytecodeTimelineProperties,
   HaikuBytecode,
+  ThreeDimensionalLayoutProperty,
 } from '@haiku/core/lib/api';
 
 export default class BaseExporter {
-  constructor (protected bytecode: HaikuBytecode, protected readonly componentFolder: string) {}
+  constructor (protected readonly bytecode: HaikuBytecode, protected readonly componentFolder: string) {}
 
   /**
    * Internal method for visiting every timeline and applying a callback to it.
@@ -29,5 +31,25 @@ export default class BaseExporter {
         callback(timeline, property);
       }
     });
+  }
+
+  protected getComponentSize (): ThreeDimensionalLayoutProperty {
+    const factory = HaikuDOMAdapter(this.bytecode);
+    const component = factory(
+      null,
+      {
+        mixpanel: false,
+        contextMenu: 'disabled',
+        hotEditingMode: true,
+        autoplay: false,
+      },
+    );
+
+    const size = {...component.size};
+
+    // We only want to run migrations and perform auto-sizing. The component can go out of scope now.
+    component.context.destroy();
+
+    return size;
   }
 }

--- a/packages/haiku-formats/src/exporters/bodymovin/bodymovinExporter.ts
+++ b/packages/haiku-formats/src/exporters/bodymovin/bodymovinExporter.ts
@@ -1,4 +1,3 @@
-import HaikuDOMAdapter from '@haiku/core/lib/adapters/dom/HaikuDOMAdapter';
 import {
   BytecodeNode,
   BytecodeSummonable,
@@ -6,12 +5,12 @@ import {
   BytecodeTimelineProperty,
   Curve,
   HaikuBytecode,
+  ThreeDimensionalLayoutProperty,
 } from '@haiku/core/lib/api';
 import {synchronizePathStructure} from '@haiku/core/lib/helpers/PathUtils';
 import SVGPoints from '@haiku/core/lib/helpers/SVGPoints';
 import {CurveSpec} from '@haiku/core/lib/vendor/svg-points/types';
 import {writeFile} from 'fs-extra';
-import {ContextualSize} from 'haiku-common/lib/types';
 // @ts-ignore
 import * as Template from 'haiku-serialization/src/bll/Template';
 // @ts-ignore
@@ -137,11 +136,7 @@ export class BodymovinExporter extends BaseExporter implements ExporterInterface
   /**
    * The size of the animation.
    */
-  private animationSize: ContextualSize = {
-    x: 0,
-    y: 0,
-    z: 0,
-  };
+  private animationSize: ThreeDimensionalLayoutProperty;
 
   /**
    * The structural node with which we determine the current element's position in the layout hierarchy.
@@ -151,7 +146,7 @@ export class BodymovinExporter extends BaseExporter implements ExporterInterface
   /**
    * The size of the current layer.
    */
-  private currentNodeSize: ContextualSize = {
+  private currentNodeSize: ThreeDimensionalLayoutProperty = {
     x: 0,
     y: 0,
     z: 0,
@@ -1410,21 +1405,7 @@ export class BodymovinExporter extends BaseExporter implements ExporterInterface
       throw new Error(`Unexpected wrapper element: ${this.bytecode.template.elementName}`);
     }
 
-    const factory = HaikuDOMAdapter(this.bytecode);
-    const component = factory(
-      null,
-      {
-        mixpanel: false,
-        contextMenu: 'disabled',
-        hotEditingMode: true,
-        autoplay: false,
-      },
-      );
-
-    this.animationSize.x = component.size.x;
-    this.animationSize.y = component.size.y;
-    // We only want to run migrations and perform auto-sizing. The component can go out of scope now.
-    component.context.destroy();
+    this.animationSize = this.getComponentSize();
 
     // Rewrite timelines to use keyframes instead of millitimes, which is the Bodymovin way. It makes sense to
     // do this step prior to the subsequent ones, since we might end up with fewer keyframes in the later

--- a/packages/haiku-formats/src/exporters/gif/gifExporter.ts
+++ b/packages/haiku-formats/src/exporters/gif/gifExporter.ts
@@ -12,6 +12,7 @@ export class GifExporter extends BaseExporter implements ExporterInterface {
     const workingDirectory = path.join(this.componentFolder, `png-${framerate}`);
     const palettePath = path.join(workingDirectory, 'palette.png');
     const assetPathPattern = path.join(workingDirectory, 'frame-%07d.png');
+    const componentSize = this.getComponentSize();
     return new Promise<void>((resolve, reject) => {
       // First make the palette.
       newFfmpegCommand()
@@ -26,6 +27,7 @@ export class GifExporter extends BaseExporter implements ExporterInterface {
             .withInputOption(['-framerate', `${framerate}`])
             .addInput(palettePath)
             .withOutputOptions(['-lavfi', `fps=${framerate} [x]; [x][1:v] paletteuse`])
+            .withOutputOptions(['-vf', `scale=${componentSize.x}:${componentSize.y}`])
             .on('error', (stdout, stderr) => {
               reject(stderr);
             })

--- a/packages/haiku-formats/src/exporters/layout.ts
+++ b/packages/haiku-formats/src/exporters/layout.ts
@@ -1,8 +1,7 @@
-import {BytecodeTimelineProperties, LayoutSpec} from '@haiku/core/lib/api';
+import {BytecodeTimelineProperties, LayoutSpec, ThreeDimensionalLayoutProperty} from '@haiku/core/lib/api';
 import {LAYOUT_3D_VANITIES} from '@haiku/core/lib/HaikuComponent';
 import composedTransformsToTimelineProperties from '@haiku/core/lib/helpers/composedTransformsToTimelineProperties';
 import Layout3D from '@haiku/core/lib/Layout3D';
-import {ContextualSize} from 'haiku-common/lib/types';
 import {initialValueOr} from './timelineUtils';
 
 const {createLayoutSpec, computeMatrix} = Layout3D;
@@ -78,15 +77,15 @@ const shimLayoutForPseudoElement = (timeline: BytecodeTimelineProperties, elemen
  * We only need to actually calculate affine transformation matrices and multiply them when translation and rotation
  * are composed together.
  *
- * @param {ContextualSize} shapeLayerSize
- * @param {ContextualSize} animationSize
+ * @param {ThreeDimensionalLayoutProperty} shapeLayerSize
+ * @param {ThreeDimensionalLayoutProperty} animationSize
  * @param childTimeline
  * @param parentTimeline
  * @returns {{}}
  */
 export const composeTimelines = (
-  shapeLayerSize: ContextualSize,
-  animationSize: ContextualSize,
+  shapeLayerSize: ThreeDimensionalLayoutProperty,
+  animationSize: ThreeDimensionalLayoutProperty,
   childTimeline: any,
   parentTimeline: any,
 ) => {

--- a/packages/haiku-formats/src/exporters/video/videoExporter.ts
+++ b/packages/haiku-formats/src/exporters/video/videoExporter.ts
@@ -10,13 +10,19 @@ export class VideoExporter extends BaseExporter implements ExporterInterface {
    */
   writeToFile (filename: string, framerate: number) {
     const assetPathPattern = path.join(this.componentFolder, `png-${framerate}`, 'frame-%07d.png');
+    const componentSize = this.getComponentSize();
     return new Promise<void>((resolve, reject) => {
       // First make the palette.
       newFfmpegCommand()
         .addInput(assetPathPattern)
         .withInputOptions(['-framerate', `${framerate}`])
         .withVideoCodec('libx264')
-        .withOutputOptions(['-vf', `fps=${framerate}`, '-pix_fmt', 'yuv420p'])
+        .withOutputOptions([
+          '-vf',
+          `fps=${framerate}, scale=${componentSize.x}:${componentSize.y}`,
+          '-pix_fmt',
+          'yuv420p',
+        ])
         .on('error', (stdout, stderr) => {
           reject(stderr);
         })


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes [Control for retina displays (un-pixel-double) for locally exported assets](https://app.asana.com/0/768374296244701/778618800294418/f)

Regressions to look for:

- None expected.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
