### PR TITLE
Periodic online checks

### DIFF
--- a/packages/@haiku/sdk-inkstone/src/index.ts
+++ b/packages/@haiku/sdk-inkstone/src/index.ts
@@ -69,9 +69,20 @@ export namespace inkstone {
     Collection: T[];
   }
 
-  export function setConfig (newVals: InkstoneConfig) {
+  export const setConfig = (newVals: InkstoneConfig) => {
     Object.assign(inkstoneConfig, newVals);
-  }
+  };
+
+  export const isOnline = (): Promise<boolean> => {
+    return new Promise((resolve) => {
+      // In Haiku, "online" means "able to communicate with inkstone". We can use the /ping endpoint for this purpose.
+      newGetRequest()
+        .withEndpoint(Endpoints.Ping)
+        .call((err, _, body) => {
+          resolve(!err && body === 'pong');
+        });
+    });
+  };
 
   const baseHeaders = {
     'X-Haiku-Version': packageJson.version,

--- a/packages/@haiku/sdk-inkstone/src/services.ts
+++ b/packages/@haiku/sdk-inkstone/src/services.ts
@@ -8,6 +8,9 @@ import {requestInstance} from './transport';
 const INKSTONE_ERROR_HEADER = 'x-inkstone-error-code';
 
 export const enum Endpoints {
+  // Ping.
+  Ping = '/ping',
+
   // Project.
   ProjectResourceCollection = '/project',
   ProjectResource = '/project/:project_name',

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -34,7 +34,7 @@ class ProjectBrowser extends React.Component {
     this.state = {
       username: null,
       error: null,
-      isOffline: false,
+      isOffline: !props.isOnline,
       projectsList: [],
       areProjectsLoading: true,
       isPopoverOpen: false,
@@ -47,6 +47,13 @@ class ProjectBrowser extends React.Component {
       newProjectError: null,
       newProjectIsPublic: true,
     };
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (this.state.isOffline === nextProps.isOnline) {
+      // Value has changed.
+      this.loadProjects();
+    }
   }
 
   componentDidMount () {
@@ -109,6 +116,7 @@ class ProjectBrowser extends React.Component {
       }
       this.setState({
         projectsList,
+        isOffline: false,
         areProjectsLoading: false,
       });
     });

--- a/packages/haiku-creator/src/react/components/ProjectThumbnail.js
+++ b/packages/haiku-creator/src/react/components/ProjectThumbnail.js
@@ -110,7 +110,7 @@ class ProjectThumbnail extends React.Component {
           <span style={DASH_STYLES.title}>
             {this.props.projectName}
           </span>
-          <span
+          {(this.props.allowDelete || this.props.projectExistsLocally) && <span
             title="Show project options"
             style={[DASH_STYLES.titleOptions, {transform: 'translateY(1px)'}]}
             onClick={() => {
@@ -120,7 +120,7 @@ class ProjectThumbnail extends React.Component {
             }}
           >
             <StackMenuSVG color={Palette.SUNSTONE} width="5px" height="12px" />
-          </span>
+          </span>}
         </div>
       </div>
     );

--- a/packages/haiku-sdk-creator/src/bll/User.ts
+++ b/packages/haiku-sdk-creator/src/bll/User.ts
@@ -21,7 +21,6 @@ export interface HaikuIdentity {
   organization?: inkstone.organization.Organization;
   user?: inkstone.user.User;
   lastOnline?: number;
-  isOnline: boolean;
 }
 
 /**
@@ -39,10 +38,10 @@ const nowDate = () =>
   global[String.fromCharCode(0x44, 0x61, 0x74, 0x65)][String.fromCharCode(0b1101110, 0b1101111, 0b1110111)]();
 
 export class UserHandler extends EnvoyHandler {
-  private readonly identity: HaikuIdentity = {
-    // We'll negate this later if we find it to be the case.
-    isOnline: true,
-  };
+  private readonly identity: HaikuIdentity = {};
+
+  // We'll negate this later if we find it to be the case.
+  private isOnline = true;
 
   protected registry = new Registry(FILE_PATHS.HAIKU_HOME);
 
@@ -62,11 +61,18 @@ export class UserHandler extends EnvoyHandler {
     return this.identity.organization;
   }
 
+  private storeOnlineUser () {
+    this.identity.lastOnline = nowDate();
+    this.setConfigObfuscated<HaikuIdentity>(
+      UserSettings.Identity,
+      this.identity,
+    );
+  }
+
   private recoverIdentityOffline (): MaybeAsync<void> {
     Object.assign(
       this.identity,
       this.getConfigObfuscated<HaikuIdentity>(UserSettings.Identity),
-      {isOnline: false},
     );
 
     if (this.identity.user && this.identity.organization) {
@@ -154,8 +160,17 @@ export class UserHandler extends EnvoyHandler {
     return this.getPrivilege(OrganizationPrivilege.PrivateProjectLimit);
   }
 
-  checkOnline (): MaybeAsync<boolean> {
-    return this.identity.isOnline;
+  checkOnline (): Promise<boolean> {
+    return new Promise((resolve) => {
+      inkstone.isOnline().then((isOnline) => {
+        this.isOnline = isOnline;
+        if (this.isOnline) {
+          this.storeOnlineUser();
+        }
+
+        resolve(this.isOnline);
+      });
+    });
   }
 
   load (): Promise<HaikuIdentity> {
@@ -186,11 +201,7 @@ export class UserHandler extends EnvoyHandler {
         inkstone.user.get((userErr, user) => {
           if (!userErr) {
             this.identity.user = user;
-            this.identity.lastOnline = nowDate();
-            this.setConfigObfuscated<HaikuIdentity>(
-              UserSettings.Identity,
-              this.identity,
-            );
+            this.storeOnlineUser();
             this.server.emit(USER_CHANNEL, {
               payload: this.identity,
               name: `${USER_CHANNEL}:load`,

--- a/packages/haiku-sdk-creator/test/bll/User.test.ts
+++ b/packages/haiku-sdk-creator/test/bll/User.test.ts
@@ -83,7 +83,6 @@ tape('User', async (suite) => {
         user: {Username: 'foo@foo.com'},
         organization: {Name: 'Foo'},
         lastOnline: 123456789,
-        isOnline: true,
       }, 'identity remains stored on User model');
       test.true(mockSetConfigObfuscated.calledWith('id', identity));
       unstub();


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes UX pain and edge case incorrectness around offline functionality. Check if user is online by pinging inkstone (functionally, "online" === "can connect to inkstone"). Keep `lastOnline` (stored in the user model) fresh (i.e. actually use the last date we checked if they were online). Subscribe to `'online'` and `'offline'` events and check inkstone connectivity each time. [Video.](https://cl.ly/3E3p233H0N3l)

Regressions to look for:

- Spurious offline false positives might be a thing, but I'm not very concerned about this.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
