### PR TITLE
fix: disable the tour option right after Haikudos is deleted

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1162,6 +1162,10 @@ export default class Creator extends React.Component {
     });
   }
 
+  onProjectDeleted = (projectsList) => {
+    ipcRenderer.send('topmenu:update', {projectsList});
+  };
+
   createProject (projectName, duplicate = false, callback) {
     this.setState({doShowProjectLoader: true});
     this.envoyProject.createProject(projectName).then((newProject) => {
@@ -2020,6 +2024,7 @@ export default class Creator extends React.Component {
             isOnline={this.state.isOnline}
             envoyProject={this.envoyProject}
             onShowProxySettings={this.boundShowProxySettings}
+            onProjectDeleted={this.onProjectDeleted}
             onShowNewProjectModal={(...args) => {
               this.showNewProjectModal(...args);
             }}

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -178,9 +178,9 @@ class ProjectBrowser extends React.Component {
         // Make sure at least 200ms (the duration of the "delete" transition) have passed before actually removing
         // the project.
         setTimeout(() => {
-          this.setState({
-            projectsList: projectsList.filter((project) => project.projectName !== projectToDelete.projectName),
-          });
+          const newList = projectsList.filter((project) => project.projectName !== projectToDelete.projectName);
+          this.setState({projectsList: newList});
+          this.props.onProjectDeleted(newList);
         }, Math.min(200, Date.now() - deleteStart));
       });
     });


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes [I can take the tour right after deleting the haikudos project](https://app.asana.com/0/768374296244701/782620243519078)

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
