### PR TITLE
fix: remove AI double file open

### DIFF
--- a/packages/haiku-serialization/src/bll/Illustrator.js
+++ b/packages/haiku-serialization/src/bll/Illustrator.js
@@ -103,7 +103,6 @@ class Illustrator {
 
     fse.writeFileSync(exportScriptPath, exportScript)
 
-    execSync(Illustrator.openIllustratorFile(abspath))
     execSync(Illustrator.openIllustratorFile(exportScriptPath))
 
     return true


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

I introduced this bug some time ago trying to double the chances to open the correct file before executing the script, but this is causing bugs _in illustrator_ itself, leaving the UI almost frozen.

Fixes [Importing from Ai freezes](https://app.asana.com/0/768374296244701/782620243519080)

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
