### PR TITLE
Respect my integritah

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -858,7 +858,7 @@ export default class Creator extends React.Component {
     );
 
     // Use a lengthy timeout for project channel, which does some CRUD.
-    this.envoyClient.get(PROJECT_CHANNEL, {timeout: 60000}).then(
+    this.envoyClient.get(PROJECT_CHANNEL).then(
 
       (project) => {
         this.envoyProject = project;

--- a/packages/haiku-plumbing/src/Master.js
+++ b/packages/haiku-plumbing/src/Master.js
@@ -340,9 +340,12 @@ export default class Master extends EventEmitter {
       logger.info('[master] merge designs requested');
       if (this.project && this.project.getCurrentActiveComponent()) {
         this._designsPendingMerge = {};
-        this.emit(
-          'merge-designs',
+        this.project.mergeDesigns(
           designs,
+          {from: 'master'},
+          () => {
+            logger.info(`[master] finished merge designs`);
+          },
         );
       }
     }

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -1157,26 +1157,6 @@ Plumbing.prototype.upsertMaster = function ({folder, fileOptions, envoyOptions, 
       });
     });
 
-    master.on('merge-designs', (designs) => {
-      const project = Project.findById(master.folder);
-      if (project) {
-        this.processMethodMessage(
-          'controller',
-          'plumbing',
-          master.folder,
-          {
-            folder: master.folder,
-            type: 'action',
-            method: 'mergeDesigns',
-            params: [master.folder, designs, {from: 'master'}],
-          },
-          () => {
-            logger.info(`[plumbing] finished merge designs`);
-          },
-        );
-      }
-    });
-
     this.masters[folder] = master;
   }
 

--- a/packages/haiku-sdk-creator/src/envoy/index.ts
+++ b/packages/haiku-sdk-creator/src/envoy/index.ts
@@ -52,7 +52,7 @@ export interface RequestOptions {
 }
 
 export const DEFAULT_REQUEST_OPTIONS: RequestOptions = {
-  timeout: 5000,
+  timeout: 60000,
 };
 
 export type MaybeAsync<T> = (T | Promise<T>);


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes [Integrity-related crashes easily triggered by Sketch mergeDesigns](https://app.asana.com/0/768374296244701/780886183120361/f)
- _Probably_ fixes [When logging into my "freeuserstaging" free account for a second I got the "incorrect data" vibration but it did log in.](https://app.asana.com/0/768374296244701/785020185816351/f)

Regressions to look for:

- Mostly a straightforward bugfix. `mergeDesigns` ticket was actually a misnomer…in that it was _always_ broken since putting a real WS in Master due to the hack previously used to emit mergeDesigns out to webviews. (@matthewtoast—are there any other hacks like this hiding in the weeds?)
- Small chance that the longer default Envoy timeout could hang the app when the Envoy server is down…but the Envoy server shouldn't go down without the app going down. The change is to accommodate network latency, which is likely what caused the issue @agustinafeijoo reported. Since `ECONNRESET` should return quickly when the Internet is actually down, I'm not seriously concerned about this.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
