### PR TITLE
Calculate selection BB on demand (759100037963956)

### DIFF
--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -2410,7 +2410,7 @@ const computeAndApplyLayout = (node, parent) => {
   if (node.layout) {
     node.layout.computed = HaikuElement.computeLayout(
       node,
-      parent,
+      parent ? parent.layout : null,
     );
   }
 };

--- a/packages/@haiku/core/src/HaikuElement.ts
+++ b/packages/@haiku/core/src/HaikuElement.ts
@@ -848,7 +848,7 @@ export default class HaikuElement extends HaikuBase implements IHaikuElement {
       this.getRawBoundingBoxPoints(),
       HaikuElement.computeLayout(
         this.node as BytecodeNode,
-        null, // parentNode; none available here
+        null, // parentLayout; none available here
       ).matrix,
     );
   }
@@ -1133,34 +1133,16 @@ export default class HaikuElement extends HaikuBase implements IHaikuElement {
     );
   };
 
-  static computeLayout = (
-    targetNode: BytecodeNode,
-    parentNode: BytecodeNode,
-    calculateAtRuntime: boolean = false,
-  ): ComputedLayoutSpec => {
-    const layoutSpec = targetNode.layout;
-
-    const targetSize = {
-      x: null,
-      y: null,
-      z: null,
-    };
+  static computeLayoutWithParentOffset = (
+    targetLayout: LayoutSpec,
+    parentLayout: LayoutSpec,
+  ) => {
 
     const parentBounds = (
-      parentNode &&
-      parentNode.layout &&
-      parentNode.layout.computed &&
-      parentNode.layout.computed.bounds
+      parentLayout &&
+      parentLayout.computed &&
+      parentLayout.computed.bounds
     );
-
-    const targetBounds = {
-      left: null,
-      top: null,
-      right: null,
-      bottom: null,
-      front: null,
-      back: null,
-    };
 
     let leftOffset = 0;
     let topOffset = 0;
@@ -1175,21 +1157,50 @@ export default class HaikuElement extends HaikuBase implements IHaikuElement {
       }
     }
 
-    const targetElement = HaikuElement.findOrCreateByNode(targetNode);
+    return {
+      ...targetLayout,
+      offset: {
+        x: targetLayout.offset.x - leftOffset,
+        y: targetLayout.offset.y - topOffset,
+        z: targetLayout.offset.z,
+      },
+    };
+  };
+
+  static computeLayout = (
+    targetNode: BytecodeNode,
+    parentLayout: LayoutSpec,
+  ): ComputedLayoutSpec => {
+    const targetLayout = targetNode.layout;
+
+    const targetSize = {
+      x: null,
+      y: null,
+      z: null,
+    };
+
+    const targetBounds = {
+      left: null,
+      top: null,
+      right: null,
+      bottom: null,
+      front: null,
+      back: null,
+    };
 
     // We'll define this later if any axes are requesting SIZE_PROPORTIONAL. It isn't needed for SIZE_ABSOLUTE.
     let parentsizeAbsolute;
 
+    // Calculate targetSize and additionaly targetBounds when useAutoSizing
     for (let i = 0; i < SIZING_AXES.length; i++) {
       const sizeAxis = SIZING_AXES[i] as AxisString;
-      switch (layoutSpec.sizeMode[sizeAxis]) {
+      switch (targetLayout.sizeMode[sizeAxis]) {
         case SIZE_PROPORTIONAL:
           if (!parentsizeAbsolute) {
             parentsizeAbsolute = (
-              parentNode &&
-              parentNode.layout &&
-              parentNode.layout.computed &&
-              parentNode.layout.computed.size
+              parentLayout &&
+              parentLayout.computed &&
+              parentLayout.computed.size
             ) || {x: 0, y: 0, z: 0};
             if (parentsizeAbsolute.z === undefined || parentsizeAbsolute.z === null) {
               parentsizeAbsolute.z = DEFAULT_DEPTH;
@@ -1208,15 +1219,16 @@ export default class HaikuElement extends HaikuBase implements IHaikuElement {
           }
 
           // Size is calculated as: parentSizeValue * sizeProportional + sizeProportional.
-          targetSize[sizeAxis] = parentsizeAbsolute[sizeAxis] * layoutSpec.sizeProportional[sizeAxis] +
-            layoutSpec.sizeDifferential[sizeAxis];
+          targetSize[sizeAxis] = parentsizeAbsolute[sizeAxis] * targetLayout.sizeProportional[sizeAxis] +
+            targetLayout.sizeDifferential[sizeAxis];
           break;
 
         case SIZE_ABSOLUTE:
-          const givenValue = layoutSpec.sizeAbsolute[sizeAxis];
+          const givenValue = targetLayout.sizeAbsolute[sizeAxis];
 
           // Implements "auto"-sizing: Use content size if available, otherwise fallback to parent
           if (HaikuElement.useAutoSizing(givenValue)) {
+            const targetElement = HaikuElement.findOrCreateByNode(targetNode);
             targetSize[sizeAxis] = targetElement.computeSizeForAxis(sizeAxis);
             Object.assign(targetBounds, targetElement.computeBoundsForAxis(sizeAxis));
           } else {
@@ -1227,40 +1239,25 @@ export default class HaikuElement extends HaikuBase implements IHaikuElement {
       }
     }
 
-    if (calculateAtRuntime && targetNode.elementName === 'svg' && targetElement.target) {
-      const bbox = (targetElement.target as any).getBBox();
-      targetSize.x = bbox.width;
-      targetSize.y = bbox.height;
-      targetSize.z = 0;
-      console.log('targetNode', targetNode.elementName, targetNode.attributes['haiku-title'], targetNode.attributes['haiku-id']);
-    }
+    const targetLayoutWithParentOffset = HaikuElement.computeLayoutWithParentOffset(targetLayout, parentLayout);
 
-    const virtualSpec = {
-      ...layoutSpec,
-      offset: {
-        x: layoutSpec.offset.x - leftOffset,
-        y: layoutSpec.offset.y - topOffset,
-        z: layoutSpec.offset.z,
-      },
-    };
-
-    const targetMatrix = Layout3D.computeMatrix(virtualSpec, targetSize);
+    const targetMatrixWithParentOffset = Layout3D.computeMatrix(targetLayoutWithParentOffset, targetSize);
 
     return {
-      shown: layoutSpec.shown,
-      opacity: layoutSpec.opacity,
-      offset: layoutSpec.offset,
-      origin: layoutSpec.origin,
-      translation: layoutSpec.translation,
-      rotation: layoutSpec.rotation,
-      scale: layoutSpec.scale,
-      shear: layoutSpec.shear,
-      sizeMode: layoutSpec.sizeMode,
-      sizeProportional: layoutSpec.sizeProportional,
-      sizeDifferential: layoutSpec.sizeDifferential,
-      sizeAbsolute: layoutSpec.sizeAbsolute,
+      shown: targetLayout.shown,
+      opacity: targetLayout.opacity,
+      offset: targetLayout.offset,
+      origin: targetLayout.origin,
+      translation: targetLayout.translation,
+      rotation: targetLayout.rotation,
+      scale: targetLayout.scale,
+      shear: targetLayout.shear,
+      sizeMode: targetLayout.sizeMode,
+      sizeProportional: targetLayout.sizeProportional,
+      sizeDifferential: targetLayout.sizeDifferential,
+      sizeAbsolute: targetLayout.sizeAbsolute,
       size: targetSize,
-      matrix: targetMatrix,
+      matrix: targetMatrixWithParentOffset,
       bounds: targetBounds,
     };
   };

--- a/packages/@haiku/core/src/HaikuElement.ts
+++ b/packages/@haiku/core/src/HaikuElement.ts
@@ -1136,6 +1136,7 @@ export default class HaikuElement extends HaikuBase implements IHaikuElement {
   static computeLayout = (
     targetNode: BytecodeNode,
     parentNode: BytecodeNode,
+    calculateAtRuntime: boolean = false,
   ): ComputedLayoutSpec => {
     const layoutSpec = targetNode.layout;
 
@@ -1224,6 +1225,14 @@ export default class HaikuElement extends HaikuBase implements IHaikuElement {
 
           break;
       }
+    }
+
+    if (calculateAtRuntime && targetNode.elementName === 'svg' && targetElement.target) {
+      const bbox = (targetElement.target as any).getBBox();
+      targetSize.x = bbox.width;
+      targetSize.y = bbox.height;
+      targetSize.z = 0;
+      console.log('targetNode', targetNode.elementName, targetNode.attributes['haiku-title'], targetNode.attributes['haiku-id']);
     }
 
     const virtualSpec = {

--- a/packages/@haiku/core/test/unit/HaikuElement.computeLayout.test.ts
+++ b/packages/@haiku/core/test/unit/HaikuElement.computeLayout.test.ts
@@ -64,11 +64,67 @@ tape(
           },
         },
       },
-      { // parentNode
-        elementName: 'div',
-        attributes: {},
-        children: [],
-        layout: {
+      { // parentLayout
+        shown: true,
+        opacity: 1,
+        offset: {
+          x: 0,
+          y: 0,
+          z: 0,
+        },
+        origin: {
+          x: 0,
+          y: 0,
+          z: 0,
+        },
+        translation: {
+          x: 33,
+          y: 0,
+          z: 0,
+        },
+        rotation: {
+          x: 0,
+          y: 0,
+          z: 0,
+          // w: 0,
+        },
+        orientation: {
+          x: 0,
+          y: 0,
+          z: 0,
+          w: 0,
+        },
+        scale: {
+          x: 1,
+          y: 1,
+          z: 1,
+        },
+        shear: {
+          xy: 0,
+          xz: 0,
+          yz: 0,
+        },
+        sizeProportional: {
+          x: 0.5,
+          y: 1,
+          z: 1,
+        },
+        sizeMode: {
+          x: 0,
+          y: 0,
+          z: 0,
+        },
+        sizeDifferential: {
+          x: 0,
+          y: 0,
+          z: 0,
+        },
+        sizeAbsolute: {
+          x: 0,
+          y: 0,
+          z: 0,
+        },
+        computed: {
           shown: true,
           opacity: 1,
           offset: {
@@ -122,74 +178,19 @@ tape(
             y: 0,
             z: 0,
           },
-          computed: {
-            shown: true,
-            opacity: 1,
-            offset: {
-              x: 0,
-              y: 0,
-              z: 0,
-            },
-            origin: {
-              x: 0,
-              y: 0,
-              z: 0,
-            },
-            translation: {
-              x: 33,
-              y: 0,
-              z: 0,
-            },
-            rotation: {
-              x: 0,
-              y: 0,
-              z: 0,
-              // w: 0,
-            },
-            scale: {
-              x: 1,
-              y: 1,
-              z: 1,
-            },
-            shear: {
-              xy: 0,
-              xz: 0,
-              yz: 0,
-            },
-            sizeProportional: {
-              x: 0.5,
-              y: 1,
-              z: 1,
-            },
-            sizeMode: {
-              x: 0,
-              y: 0,
-              z: 0,
-            },
-            sizeDifferential: {
-              x: 0,
-              y: 0,
-              z: 0,
-            },
-            sizeAbsolute: {
-              x: 0,
-              y: 0,
-              z: 0,
-            },
-            bounds: {
-              left: null,
-              right: null,
-              bottom: null,
-              top: null,
-              back: null,
-              front: null,
-            },
-            matrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 33, 0, 0, 1],
-            size: {
-              x: 852,
-              y: 839,
-              z: 0,
-            },
+          bounds: {
+            left: null,
+            right: null,
+            bottom: null,
+            top: null,
+            back: null,
+            front: null,
+          },
+          matrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 33, 0, 0, 1],
+          size: {
+            x: 852,
+            y: 839,
+            z: 0,
           },
         },
       },

--- a/packages/@haiku/core/test/unit/HaikuElement.computeLayout.test.ts
+++ b/packages/@haiku/core/test/unit/HaikuElement.computeLayout.test.ts
@@ -88,12 +88,6 @@ tape(
           z: 0,
           // w: 0,
         },
-        orientation: {
-          x: 0,
-          y: 0,
-          z: 0,
-          w: 0,
-        },
         scale: {
           x: 1,
           y: 1,

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -2366,7 +2366,7 @@ export class Glass extends React.Component {
           if (this.state.directSelectionAnchorActivation != null) {
             // Moving a selection of control points
 
-            const indices = this.state.directSelectionAnchorActivation.indices[Element.directlySelected.attributes['haiku-id']];
+            const indices = this.state.directSelectionAnchorActivation.indices[Element.directlySelected.componentId];
             const lastIndex = indices[indices.length - 1];
 
             switch (Element.directlySelected.type) {
@@ -2669,8 +2669,7 @@ export class Glass extends React.Component {
           }
 
           // We get SVG root element here so we can update svg overflow to visible
-          const selectedElement = Element.findByComponentAndHaikuId(this.getActiveComponent(), Element.directlySelected.attributes['haiku-id']);
-          const rootSvgElement = selectedElement.getParentSvgElement();
+          const rootSvgElement = Element.directlySelected.rootSVG;
 
           // Mark root svg as overflow visible
           if (rootSvgElement) {

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -2361,9 +2361,7 @@ export class Glass extends React.Component {
             },
           };
 
-          // We get SVG root element here so we can update svg overflow to visible
-          const selectedElement = Element.findByComponentAndHaikuId(this.getActiveComponent(), Element.directlySelected.attributes['haiku-id']);
-          const rootSvgElement = selectedElement.getParentSvgElement();
+          let serializedDataToUpdate = null;
 
           if (this.state.directSelectionAnchorActivation != null) {
             // Moving a selection of control points
@@ -2373,22 +2371,13 @@ export class Glass extends React.Component {
 
             switch (Element.directlySelected.type) {
               case 'circle': {
-                this.getActiveComponent().updateKeyframes({
-                  [this.getActiveComponent().getCurrentTimelineName()]: {
-                    [rootSvgElement.componentId]: {
-                      'style.overflow': {
-                        0: {value: 'visible'},
-                      },
-                    },
-                    [Element.directlySelected.attributes['haiku-id']]: {
-                      r: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: distance(transformedCurrent, {x: Number(Element.directlySelected.attributes.cx), y: Number(Element.directlySelected.attributes.cy)}),
-                        },
-                      },
+                serializedDataToUpdate = { [Element.directlySelected.attributes['haiku-id']]: {
+                  r: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: distance(transformedCurrent, {x: Number(Element.directlySelected.attributes.cx), y: Number(Element.directlySelected.attributes.cy)}),
                     },
                   },
-                }, keyframeOptions, {from: 'glass'}, () => {});
+                }};
                 break;
               }
               case 'ellipse': {
@@ -2403,22 +2392,14 @@ export class Glass extends React.Component {
                   value = Math.abs(transformedCurrent.y - Number(Element.directlySelected.attributes.cy));
                 }
 
-                this.getActiveComponent().updateKeyframes({
-                  [this.getActiveComponent().getCurrentTimelineName()]: {
-                    [rootSvgElement.componentId]: {
-                      'style.overflow': {
-                        0: {value: 'visible'},
-                      },
-                    },
-                    [Element.directlySelected.attributes['haiku-id']]: {
-                      [property]: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value,
-                        },
-                      },
+                serializedDataToUpdate = { [Element.directlySelected.attributes['haiku-id']]: {
+                  [property]: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value,
                     },
                   },
-                }, keyframeOptions, {from: 'glass'}, () => {});
+                }};
+
                 break;
               }
               case 'rect': {
@@ -2460,37 +2441,28 @@ export class Glass extends React.Component {
                   y = Number(this.selectedOriginalClickState.attributes.y);
                 }
 
-                this.getActiveComponent().updateKeyframes({
-                  [this.getActiveComponent().getCurrentTimelineName()]: {
-                    [rootSvgElement.componentId]: {
-                      'style.overflow': {
-                        0: {value: 'visible'},
-                      },
-                    },
-                    [Element.directlySelected.attributes['haiku-id']]: {
-                      x: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: x,
-                        },
-                      },
-                      y: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: y,
-                        },
-                      },
-                      width: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: width,
-                        },
-                      },
-                      height: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: height,
-                        },
-                      },
+                serializedDataToUpdate = { [Element.directlySelected.attributes['haiku-id']]: {
+                  x: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: x,
                     },
                   },
-                }, keyframeOptions, {from: 'glass'}, () => {});
+                  y: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: y,
+                    },
+                  },
+                  width: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: width,
+                    },
+                  },
+                  height: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: height,
+                    },
+                  },
+                }};
                 break;
               }
               case 'polyline':
@@ -2500,22 +2472,13 @@ export class Glass extends React.Component {
                   points[indices[i]][0] += transformedTotalDelta.x;
                   points[indices[i]][1] += transformedTotalDelta.y;
                 }
-                this.getActiveComponent().updateKeyframes({
-                  [this.getActiveComponent().getCurrentTimelineName()]: {
-                    [rootSvgElement.componentId]: {
-                      'style.overflow': {
-                        0: {value: 'visible'},
-                      },
-                    },
-                    [Element.directlySelected.attributes['haiku-id']]: {
-                      points: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: SVGPoints.pointsToPolyString(points),
-                        },
-                      },
+                serializedDataToUpdate = { [Element.directlySelected.attributes['haiku-id']]: {
+                  points: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: SVGPoints.pointsToPolyString(points),
                     },
                   },
-                }, keyframeOptions, {from: 'glass'}, () => {});
+                }};
                 break;
               }
 
@@ -2530,16 +2493,7 @@ export class Glass extends React.Component {
                   attrUpdate.x2 = {[curTime]: {value: Number(this.selectedOriginalClickState.attributes.x2) + transformedTotalDelta.x}};
                   attrUpdate.y2 = {[curTime]: {value: Number(this.selectedOriginalClickState.attributes.y2) + transformedTotalDelta.y}};
                 }
-                this.getActiveComponent().updateKeyframes({
-                  [this.getActiveComponent().getCurrentTimelineName()]: {
-                    [rootSvgElement.componentId]: {
-                      'style.overflow': {
-                        0: {value: 'visible'},
-                      },
-                    },
-                    [Element.directlySelected.attributes['haiku-id']]: attrUpdate,
-                  },
-                }, keyframeOptions, {from: 'glass'}, () => {});
+                serializedDataToUpdate = {[Element.directlySelected.attributes['haiku-id']]: attrUpdate};
                 break;
               }
 
@@ -2602,23 +2556,13 @@ export class Glass extends React.Component {
                     }
                   }
                 }
-
-                this.getActiveComponent().updateKeyframes({
-                  [this.getActiveComponent().getCurrentTimelineName()]: {
-                    [rootSvgElement.componentId]: {
-                      'style.overflow': {
-                        0: {value: 'visible'},
-                      },
-                    },
-                    [Element.directlySelected.attributes['haiku-id']]: {
-                      d: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: SVGPoints.pointsToPath(points),
-                        },
-                      },
+                serializedDataToUpdate = { [Element.directlySelected.attributes['haiku-id']]: {
+                  d: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: SVGPoints.pointsToPath(points),
                     },
                   },
-                }, keyframeOptions, {from: 'glass'}, () => {});
+                }};
                 break;
               }
             }
@@ -2628,51 +2572,33 @@ export class Glass extends React.Component {
             switch (Element.directlySelected.type) {
               case 'ellipse':
               case 'circle': {
-                this.getActiveComponent().updateKeyframes({
-                  [this.getActiveComponent().getCurrentTimelineName()]: {
-                    [rootSvgElement.componentId]: {
-                      'style.overflow': {
-                        0: {value: 'visible'},
-                      },
-                    },
-                    [Element.directlySelected.attributes['haiku-id']]: {
-                      cx: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: Number(this.selectedOriginalClickState.attributes.cx) + transformedTotalDelta.x,
-                        },
-                      },
-                      cy: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: Number(this.selectedOriginalClickState.attributes.cy) + transformedTotalDelta.y,
-                        },
-                      },
+                serializedDataToUpdate = { [Element.directlySelected.attributes['haiku-id']]: {
+                  cx: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: Number(this.selectedOriginalClickState.attributes.cx) + transformedTotalDelta.x,
                     },
                   },
-                }, keyframeOptions, {from: 'glass'}, () => {});
+                  cy: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: Number(this.selectedOriginalClickState.attributes.cy) + transformedTotalDelta.y,
+                    },
+                  },
+                }};
                 break;
               }
               case 'rect': {
-                this.getActiveComponent().updateKeyframes({
-                  [this.getActiveComponent().getCurrentTimelineName()]: {
-                    [rootSvgElement.componentId]: {
-                      'style.overflow': {
-                        0: {value: 'visible'},
-                      },
-                    },
-                    [Element.directlySelected.attributes['haiku-id']]: {
-                      x: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: Number(this.selectedOriginalClickState.attributes.x) + transformedTotalDelta.x,
-                        },
-                      },
-                      y: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: Number(this.selectedOriginalClickState.attributes.y) + transformedTotalDelta.y,
-                        },
-                      },
+                serializedDataToUpdate = { [Element.directlySelected.attributes['haiku-id']]: {
+                  x: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: Number(this.selectedOriginalClickState.attributes.x) + transformedTotalDelta.x,
                     },
                   },
-                }, keyframeOptions, {from: 'glass'}, () => {});
+                  y: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: Number(this.selectedOriginalClickState.attributes.y) + transformedTotalDelta.y,
+                    },
+                  },
+                }};
                 break;
               }
               case 'polyline':
@@ -2682,57 +2608,39 @@ export class Glass extends React.Component {
                   points[i][0] += transformedTotalDelta.x;
                   points[i][1] += transformedTotalDelta.y;
                 }
-                this.getActiveComponent().updateKeyframes({
-                  [this.getActiveComponent().getCurrentTimelineName()]: {
-                    [rootSvgElement.componentId]: {
-                      'style.overflow': {
-                        0: {value: 'visible'},
-                      },
-                    },
-                    [Element.directlySelected.attributes['haiku-id']]: {
-                      points: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: SVGPoints.pointsToPolyString(points),
-                        },
-                      },
+                serializedDataToUpdate = { [Element.directlySelected.attributes['haiku-id']]: {
+                  points: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: SVGPoints.pointsToPolyString(points),
                     },
                   },
-                }, keyframeOptions, {from: 'glass'}, () => {});
+                }};
                 break;
               }
 
               case 'line': {
-                this.getActiveComponent().updateKeyframes({
-                  [this.getActiveComponent().getCurrentTimelineName()]: {
-                    [rootSvgElement.componentId]: {
-                      'style.overflow': {
-                        0: {value: 'visible'},
-                      },
-                    },
-                    [Element.directlySelected.attributes['haiku-id']]: {
-                      x1: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: Number(this.selectedOriginalClickState.attributes.x1) + transformedTotalDelta.x,
-                        },
-                      },
-                      y1: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: Number(this.selectedOriginalClickState.attributes.y1) + transformedTotalDelta.y,
-                        },
-                      },
-                      x2: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: Number(this.selectedOriginalClickState.attributes.x2) + transformedTotalDelta.x,
-                        },
-                      },
-                      y2: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: Number(this.selectedOriginalClickState.attributes.y2) + transformedTotalDelta.y,
-                        },
-                      },
+                serializedDataToUpdate = { [Element.directlySelected.attributes['haiku-id']]: {
+                  x1: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: Number(this.selectedOriginalClickState.attributes.x1) + transformedTotalDelta.x,
                     },
                   },
-                }, keyframeOptions, {from: 'glass'}, () => {});
+                  y1: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: Number(this.selectedOriginalClickState.attributes.y1) + transformedTotalDelta.y,
+                    },
+                  },
+                  x2: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: Number(this.selectedOriginalClickState.attributes.x2) + transformedTotalDelta.x,
+                    },
+                  },
+                  y2: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: Number(this.selectedOriginalClickState.attributes.y2) + transformedTotalDelta.y,
+                    },
+                  },
+                }};
                 break;
               }
 
@@ -2748,26 +2656,39 @@ export class Glass extends React.Component {
                     points[i].curve.y2 += transformedTotalDelta.y;
                   }
                 }
-                this.getActiveComponent().updateKeyframes({
-                  [rootSvgElement.componentId]: {
-                    'style.overflow': {
-                      0: {value: 'visible'},
+                serializedDataToUpdate = { [Element.directlySelected.attributes['haiku-id']]: {
+                  d: {
+                    [this.getActiveComponent().getCurrentTimelineTime()]: {
+                      value: SVGPoints.pointsToPath(points),
                     },
                   },
-                  [this.getActiveComponent().getCurrentTimelineName()]: {
-                    [Element.directlySelected.attributes['haiku-id']]: {
-                      d: {
-                        [this.getActiveComponent().getCurrentTimelineTime()]: {
-                          value: SVGPoints.pointsToPath(points),
-                        },
-                      },
-                    },
-                  },
-                }, keyframeOptions, {from: 'glass'}, () => {});
+                }};
                 break;
               }
             }
           }
+
+          // We get SVG root element here so we can update svg overflow to visible
+          const selectedElement = Element.findByComponentAndHaikuId(this.getActiveComponent(), Element.directlySelected.attributes['haiku-id']);
+          const rootSvgElement = selectedElement.getParentSvgElement();
+
+          // Mark root svg as overflow visible
+          if (rootSvgElement) {
+            serializedDataToUpdate[rootSvgElement.componentId] = {
+              'style.overflow': {
+                0: {value: 'visible'},
+              },
+            };
+          }
+
+          this.getActiveComponent().updateKeyframes({
+            [this.getActiveComponent().getCurrentTimelineName()]: serializedDataToUpdate,
+          }, keyframeOptions, {from: 'glass'}, () => {
+            // Make sure bouding boxes are reinitialized
+            const proxy = this.fetchProxyElementForSelection();
+            proxy.reinitializeLayout();
+          });
+
         } else {
           const proxy = this.fetchProxyElementForSelection();
 

--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -567,7 +567,7 @@ class Element extends BaseModel {
     return this.getHaikuElement().size
   }
 
-  getComputedLayout () {
+  getComputedLayout (calculateAtRuntime = false) {
     const targetNode = this.getLiveRenderedNode() || {} // Fallback in case of render race
     const parentNode = (this.parent && this.parent.getLiveRenderedNode()) || {} // Fallback in case of render race
 
@@ -599,7 +599,8 @@ class Element extends BaseModel {
         attributes: parentNode.attributes,
         children: parentNode.children,
         __memory: parentNode.__memory
-      }
+      },
+      calculateAtRuntime
     )
   }
 
@@ -704,8 +705,8 @@ class Element extends BaseModel {
     }
   }
 
-  getBoundingBoxPoints () {
-    const layout = this.getComputedLayout()
+  getBoundingBoxPoints (calculateAtRuntime = false) {
+    const layout = this.getComputedLayout(calculateAtRuntime)
     const w = layout.size.x
     const h = layout.size.y
     return [
@@ -715,10 +716,10 @@ class Element extends BaseModel {
     ]
   }
 
-  getBoxPointsTransformed () {
+  getBoxPointsTransformed (calculateAtRuntime = false) {
     return HaikuElement.transformPointsInPlace(
-      this.getBoundingBoxPoints(),
-      this.getOriginOffsetComposedMatrix()
+      this.getBoundingBoxPoints(calculateAtRuntime),
+      this.getOriginOffsetComposedMatrix(calculateAtRuntime)
     )
   }
 
@@ -744,7 +745,7 @@ class Element extends BaseModel {
 
   getOriginOffsetComposedMatrix () {
     return this.cache.fetch('getOriginOffsetComposedMatrix', () => {
-      return Layout3D.multiplyArrayOfMatrices(this.getComputedLayoutAncestry().reverse().map(
+      return Layout3D.multiplyArrayOfMatrices(this.getComputedLayoutAncestry(calculateAtRuntime).reverse().map(
         (layout) => layout.matrix
       ))
     })
@@ -756,9 +757,9 @@ class Element extends BaseModel {
     return ancestors
   }
 
-  getComputedLayoutAncestry () {
+  getComputedLayoutAncestry (calculateAtRuntime = false) {
     return this.getAncestry().map((ancestor) => {
-      return ancestor.getComputedLayout()
+      return ancestor.getComputedLayout(calculateAtRuntime)
     })
   }
 

--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -608,12 +608,27 @@ class Element extends BaseModel {
       const bbox = targetElement.target.getBBox()
       const targetSize = { x: bbox.width, y: bbox.height, z: 0 }
 
+      console.log(`bbox ${JSON.stringify(bbox)}`)
+      console.log(`t offset ${JSON.stringify(targetRenderedNode.layout)} `)
+      console.log(`p ${JSON.stringify(parentLayout)}`)
+      
+      // const targetLayout = {...targetRenderedNode.layout}
+      // targetLayout.offset.x = targetLayout.offset.x - bbox.x;
+      // targetLayout.offset.y = targetLayout.offset.y - bbox.y;
+      // targetLayout.translation.x = targetLayout.translation.x - bbox.x;
+      // targetLayout.translation.y = targetLayout.translation.y - bbox.y;
+
       const targetLayoutWithParentOffset = HaikuElement.computeLayoutWithParentOffset(targetRenderedNode.layout, parentLayout)
       const targetMatrixWithParentOffset = Layout3D.computeMatrix(targetLayoutWithParentOffset, targetSize)
+
+      // targetMatrixWithParentOffset[12] = targetMatrixWithParentOffset[12] - bbox.x;
+      // targetMatrixWithParentOffset[13] = targetMatrixWithParentOffset[13] - bbox.y;
+
 
       // Update computed layout with values from runtime BB
       layout.size = targetSize
       layout.matrix = targetMatrixWithParentOffset
+      layout.bbOffset = {x: bbox.x, y: bbox.y};
     }
 
     return layout
@@ -724,10 +739,11 @@ class Element extends BaseModel {
     const layout = this.getComputedLayout()
     const w = layout.size.x
     const h = layout.size.y
+    const bb = layout.bbOffset? layout.bbOffset : {x:0, y:0};
     return [
-      {x: 0, y: 0, z: 0}, {x: w / 2, y: 0, z: 0}, {x: w, y: 0, z: 0},
-      {x: 0, y: h / 2, z: 0}, {x: w / 2, y: h / 2, z: 0}, {x: w, y: h / 2, z: 0},
-      {x: 0, y: h, z: 0}, {x: w / 2, y: h, z: 0}, {x: w, y: h, z: 0}
+      {x: 0+bb.x, y: 0+bb.y, z: 0}, {x: w / 2+bb.x, y: 0+bb.y, z: 0}, {x: w+bb.x, y: 0+bb.y, z: 0},
+      {x: 0+bb.x, y: h / 2+bb.y, z: 0}, {x: w / 2+bb.x, y: h / 2+bb.y, z: 0}, {x: w+bb.x, y: h / 2+bb.y, z: 0},
+      {x: 0+bb.x, y: h+bb.y, z: 0}, {x: w / 2+bb.x, y: h+bb.y, z: 0}, {x: w+bb.x, y: h+bb.y, z: 0}
     ]
   }
 

--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -1644,17 +1644,6 @@ class Element extends BaseModel {
     return HaikuElement.findOrCreateByNode(this.getLiveRenderedNode())
   }
 
-  getParentSvgElement () {
-    let currElem = this
-    while (currElem) {
-      if (currElem.getNameString() === 'svg') {
-        return currElem
-      }
-      currElem = currElem.parent
-    }
-    return null
-  }
-
   getUngroupables () {
     const haikuElement = this.getHaikuElement()
     switch (haikuElement.tagName) {

--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -567,7 +567,7 @@ class Element extends BaseModel {
     return this.getHaikuElement().size
   }
 
-  getComputedLayout (calculateAtRuntime = false) {
+  getComputedLayout () {
     const targetNode = this.getLiveRenderedNode() || {} // Fallback in case of render race
 
     const targetRenderedNode = { // targetNode
@@ -592,33 +592,31 @@ class Element extends BaseModel {
         bounds: (this.parent && this.parent.getHaikuElement().computeContentBounds()) || {},
         size: (this.parent && this.parent.getComputedSize()) || this.getComputedSize()
       }
-    };
+    }
 
     const layout = HaikuElement.computeLayout(targetRenderedNode, parentLayout)
 
     // If we want runtime calculation, update layout.size and layout.matrix
-    if (calculateAtRuntime && targetRenderedNode.elementName === 'svg') {
-      const targetElement = HaikuElement.findOrCreateByNode(targetRenderedNode);
+    if (targetRenderedNode.elementName === 'svg') {
+      const targetElement = HaikuElement.findOrCreateByNode(targetRenderedNode)
 
       if (!targetElement.target) {
-        return layout;
+        return layout
       }
-      
+
       // Calculate BB using DOM. TODO: Use svg primitives to calculate it
-      const bbox = targetElement.target.getBBox();
-      const targetSize = { x: bbox.width, y: bbox.height, z: 0};
-      
-      console.log('targetRenderedNode', targetRenderedNode.elementName, targetRenderedNode.attributes['haiku-title'], targetRenderedNode.attributes['haiku-id']);
-      
-      const targetLayoutWithParentOffset = HaikuElement.computeLayoutWithParentOffset(targetRenderedNode.layout, parentLayout);
-      const targetMatrixWithParentOffset = Layout3D.computeMatrix(targetLayoutWithParentOffset, targetSize);
-  
+      const bbox = targetElement.target.getBBox()
+      const targetSize = { x: bbox.width, y: bbox.height, z: 0 }
+
+      const targetLayoutWithParentOffset = HaikuElement.computeLayoutWithParentOffset(targetRenderedNode.layout, parentLayout)
+      const targetMatrixWithParentOffset = Layout3D.computeMatrix(targetLayoutWithParentOffset, targetSize)
+
       // Update computed layout with values from runtime BB
       layout.size = targetSize
       layout.matrix = targetMatrixWithParentOffset
     }
 
-    return layout;
+    return layout
   }
 
   getLayoutSpec () {
@@ -722,8 +720,8 @@ class Element extends BaseModel {
     }
   }
 
-  getBoundingBoxPoints (calculateAtRuntime = false) {
-    const layout = this.getComputedLayout(calculateAtRuntime)
+  getBoundingBoxPoints () {
+    const layout = this.getComputedLayout()
     const w = layout.size.x
     const h = layout.size.y
     return [
@@ -733,10 +731,10 @@ class Element extends BaseModel {
     ]
   }
 
-  getBoxPointsTransformed (calculateAtRuntime = false) {
+  getBoxPointsTransformed () {
     return HaikuElement.transformPointsInPlace(
-      this.getBoundingBoxPoints(calculateAtRuntime),
-      this.getOriginOffsetComposedMatrix(calculateAtRuntime)
+      this.getBoundingBoxPoints(),
+      this.getOriginOffsetComposedMatrix()
     )
   }
 
@@ -762,7 +760,7 @@ class Element extends BaseModel {
 
   getOriginOffsetComposedMatrix () {
     return this.cache.fetch('getOriginOffsetComposedMatrix', () => {
-      return Layout3D.multiplyArrayOfMatrices(this.getComputedLayoutAncestry(calculateAtRuntime).reverse().map(
+      return Layout3D.multiplyArrayOfMatrices(this.getComputedLayoutAncestry().reverse().map(
         (layout) => layout.matrix
       ))
     })
@@ -774,9 +772,9 @@ class Element extends BaseModel {
     return ancestors
   }
 
-  getComputedLayoutAncestry (calculateAtRuntime = false) {
+  getComputedLayoutAncestry () {
     return this.getAncestry().map((ancestor) => {
-      return ancestor.getComputedLayout(calculateAtRuntime)
+      return ancestor.getComputedLayout()
     })
   }
 

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -592,16 +592,14 @@ class ElementSelectionProxy extends BaseModel {
         { // targetNode
           layout: this.getLayoutSpec()
         },
-        { // parentNode
-          layout: {
-            computed: {
-              bounds,
-              matrix: Layout3D.createMatrix(),
-              size: {
-                x: width,
-                y: height,
-                z: 0
-              }
+        { // parentLayout
+          computed: {
+            bounds,
+            matrix: Layout3D.createMatrix(),
+            size: {
+              x: width,
+              y: height,
+              z: 0
             }
           }
         }

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -71,7 +71,7 @@ class ElementSelectionProxy extends BaseModel {
     if (elements.length === 1) {
       // It's assumed that this list of points is *not* transformed here but downstream
       // as the return value of this.getBoxPointsTransformed
-      this._proxyBoxPoints = elements[0].getBoundingBoxPoints().map((p) => p)
+      this._proxyBoxPoints = elements[0].getBoundingBoxPoints(true).map((p) => p)
 
       Object.assign(
         this._proxyProperties,
@@ -86,7 +86,7 @@ class ElementSelectionProxy extends BaseModel {
     }
 
     const boxPoints = HaikuElement.getBoundingBoxPoints(
-      elements.map((element) => element.getBoxPointsTransformed()).reduce((accumulator, boxPoints) => {
+      elements.map((element) => element.getBoxPointsTransformed(true)).reduce((accumulator, boxPoints) => {
         accumulator.push(...boxPoints)
         return accumulator
       }, [])

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -71,7 +71,7 @@ class ElementSelectionProxy extends BaseModel {
     if (elements.length === 1) {
       // It's assumed that this list of points is *not* transformed here but downstream
       // as the return value of this.getBoxPointsTransformed
-      this._proxyBoxPoints = elements[0].getBoundingBoxPoints(true).map((p) => p)
+      this._proxyBoxPoints = elements[0].getBoundingBoxPoints().map((p) => p)
 
       Object.assign(
         this._proxyProperties,
@@ -86,7 +86,7 @@ class ElementSelectionProxy extends BaseModel {
     }
 
     const boxPoints = HaikuElement.getBoundingBoxPoints(
-      elements.map((element) => element.getBoxPointsTransformed(true)).reduce((accumulator, boxPoints) => {
+      elements.map((element) => element.getBoxPointsTransformed()).reduce((accumulator, boxPoints) => {
         accumulator.push(...boxPoints)
         return accumulator
       }, [])


### PR DESCRIPTION
WIP.

 - `Element.getComputedLayout` calculates bounding box on demand for svg objects to solve https://app.asana.com/0/777535458715338/759100037963956
 - I did some refactor so I could use `HaikuElement.computeLayout` code (`computeLayoutWithParentOffset` method )  on `Element.js`
 - The last commit https://github.com/HaikuTeam/mono/commit/d44aa6f2d96fb6f7c6f5dc3cec4f83105f21cf20 enables BB calculation on demand everywhere when `getComputedLayout` is used. Although I've done some benchmarks and didn't find any performance regression, we could revert it, so BB calculation on demand would work only for `ElementSelectionProxy.reinitializeLayout`
 - Some of refactor on `HaikuElement.computeLayout`, made the method cleaner and changed parameter type from `BytecodeNode` node to `LayoutSpec`, so we can have smaller gc for the parameter.
 - Probably this PR deprecate the BB calculation on ungroup (and it will make svg ungroup sync easier).



### Performance benchmark:
 - Master
![master](https://user-images.githubusercontent.com/800493/44325194-7567fc00-a42e-11e8-862d-9fa0e603e4d6.png)

  - BB calculation on demand
![bb_on_demand](https://user-images.githubusercontent.com/800493/44325128-3e91e600-a42e-11e8-86fc-0bc7a3c8b141.png)

Due to hardware it is pretty difficult to compare due Turbo boost. (base 1.8ghz, max turbo 4ghz) But a good parameter is that for `Element.getComputedLayout` on both situations the majority of time is spend on `getLayoutSpec`


Regressions to look for:
- Performance issues

Completed checkin tasks:
- [x] Did manual testing of interrelated functionality
