### PR TITLE
fix: try to do our best to open the Illustrator file before import

### DIFF
--- a/packages/haiku-plumbing/src/Master.js
+++ b/packages/haiku-plumbing/src/Master.js
@@ -441,7 +441,7 @@ export default class Master extends EventEmitter {
 
         if (Illustrator.isIllustratorFile(abspath)) {
           logger.info('[master] illustrator pipeline running; please wait');
-          Illustrator.importSVG(abspath);
+          Illustrator.importSVG({abspath});
           logger.info('[master] illustrator import done');
           return;
         }
@@ -488,7 +488,7 @@ export default class Master extends EventEmitter {
 
         if (Illustrator.isIllustratorFile(abspath)) {
           logger.info('[master] illustrator pipeline running; please wait');
-          Illustrator.importSVG(abspath);
+          Illustrator.importSVG({abspath, tryToOpenFile: true});
           logger.info('[master] illustrator import done');
         }
       });

--- a/packages/haiku-serialization/src/bll/Illustrator.js
+++ b/packages/haiku-serialization/src/bll/Illustrator.js
@@ -76,7 +76,7 @@ class Illustrator {
    * @param {string} abspath
    * @returns {Boolean}
    */
-  static importSVG (abspath) {
+  static importSVG ({abspath, tryToOpenFile}) {
     if (!Illustrator.isIllustratorFile(abspath)) return false
 
     logger.info('[illustrator] got', abspath)
@@ -103,7 +103,14 @@ class Illustrator {
 
     fse.writeFileSync(exportScriptPath, exportScript)
 
-    execSync(Illustrator.openIllustratorFile(exportScriptPath))
+    if (tryToOpenFile) {
+      execSync(Illustrator.openIllustratorFile(abspath))
+      // Try to do our best to wait until the file is open before running the
+      // script.
+      setTimeout(() => Illustrator.openIllustratorFile(exportScriptPath), 5000)
+    } else {
+      execSync(Illustrator.openIllustratorFile(exportScriptPath))
+    }
 
     return true
   }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

After #657 and #700 (both related to opening Illustrator to import files) were merged, @agustinafeijoo found another edge case in "[After import, the Illustrator file's artboard(s) are not available in the library](https://app.asana.com/0/777535458715338/785020185816350)".

Hopefully this wraps all edge cases, by opening Illustrator  _only_ when the user imports a new file.

Note that we are waiting 5s to run the export script before the file is open, which may still let some users without auto-import when the file is added, but we think that this edge case is covered with the message in the library:

<img width="288" alt="screen shot 2018-08-20 at 12 16 05 pm" src="https://user-images.githubusercontent.com/4419992/44349193-d31e3780-a472-11e8-9979-7570a03bce9f.png">


Regressions to look for:

- Illustrator import

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
