### PR TITLE
tweak: ensure critical-testing-path URLs are controllable via ~/.haiku/.env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
 HAIKU_API=http://localhost:8080/
+HAIKU_WWW=http://localhost:8000/
+HAIKU_ACCOUNT=http://localhost:3001/

--- a/HaikuHelper.js
+++ b/HaikuHelper.js
@@ -1,3 +1,4 @@
+const {inkstone} = require('@haiku/sdk-inkstone');
 const {default: Plumbing} = require('haiku-plumbing/lib/Plumbing');
 const {default: ReplBase} = require('haiku-plumbing/lib/ReplBase');
 const {default: envInfo} = require('haiku-plumbing/lib/envInfo');
@@ -63,6 +64,9 @@ function go () {
       if (!error) {
         Object.assign(global.process.env, dotenv);
         Object.assign(haiku, {dotenv});
+        if (dotenv.HAIKU_API) {
+          inkstone.setConfig({baseUrl: dotenv.HAIKU_API});
+        }
       }
       plumbing.launch(haiku, () => {
         logger.info('Haiku plumbing running');

--- a/packages/haiku-common/src/environments/index.ts
+++ b/packages/haiku-common/src/environments/index.ts
@@ -37,3 +37,7 @@ export const getEnvironmentType = () => {
 
 export const isProduction = () => getEnvironmentType() === EnvironmentType.Production;
 export const isDevelopment = () => getEnvironmentType() === EnvironmentType.Development;
+
+export const getUrl = (path: string) => `${global.process.env.HAIKU_WWW || 'https://www.haiku.ai/'}${path}`;
+export const getAccountUrl = (path: string) =>
+  `${global.process.env.HAIKU_ACCOUNT || 'https://account.haiku.ai/'}${path}`;

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -49,6 +49,7 @@ import * as logger from 'haiku-serialization/src/utils/LoggerInstance';
 import * as opn from 'opn';
 import {crashReport} from 'haiku-serialization/src/utils/carbonite';
 import ConfirmGroupUngroupPopup from './components/Popups/ConfirmGroupUngroup';
+import {getUrl} from 'haiku-common/lib/environments';
 
 // Useful debugging originator of calls in shared model code
 process.env.HAIKU_SUBPROCESS = 'creator';
@@ -80,6 +81,9 @@ const FIGMA_IMPORT_TIMEOUT = 1000 * 60 * 5; /* 5 minutes */
 export default class Creator extends React.Component {
   constructor (props) {
     super(props);
+    if (props.haiku && props.haiku.dotenv) {
+      Object.assign(global.process.env, props.haiku.dotenv);
+    }
     this.authenticateUser = this.authenticateUser.bind(this);
     this.resendEmailConfirmation = this.resendEmailConfirmation.bind(this);
     this.authenticationComplete = this.authenticationComplete.bind(this);
@@ -499,7 +503,7 @@ export default class Creator extends React.Component {
   }
 
   explorePro = () => {
-    shell.openExternal('https://www.haiku.ai/pricing/');
+    shell.openExternal(getUrl('pricing/'));
   };
 
   isTextInputFocused () {

--- a/packages/haiku-creator/src/react/components/AuthenticationUI.js
+++ b/packages/haiku-creator/src/react/components/AuthenticationUI.js
@@ -6,6 +6,7 @@ import {shake} from 'react-animations';
 import {FadingCircle} from 'better-react-spinkit';
 import Palette from 'haiku-ui-common/lib/Palette';
 import {LogoGradientSVG, UserIconSVG, PasswordIconSVG} from 'haiku-ui-common/lib/react/OtherIcons';
+import {getAccountUrl, getUrl} from 'haiku-common/lib/environments';
 
 const STYLES = {
   container: {
@@ -334,7 +335,7 @@ class AuthenticationUI extends React.Component {
             <span
               style={STYLES.link}
               onClick={() => {
-                shell.openExternal('https://www.haiku.ai/account/new');
+                shell.openExternal(getAccountUrl('new'));
               }}
             >
               Sign up
@@ -345,7 +346,7 @@ class AuthenticationUI extends React.Component {
             <span
               style={STYLES.link}
               onClick={() => {
-                shell.openExternal('https://www.haiku.ai/account/reset-password');
+                shell.openExternal(getAccountUrl('reset-password'));
               }}
             >
               forgot your password?
@@ -359,7 +360,7 @@ class AuthenticationUI extends React.Component {
           color: Palette.ROCK,
         }}>
           By logging into Haiku you agree to our <span style={{...STYLES.link, marginTop: '30px'}} onClick={() => {
-            shell.openExternal('https://www.haiku.ai/terms-of-service.html');
+            shell.openExternal(getUrl('terms-of-service.html'));
           }}>terms and conditions</span>
         </div>
       </div>

--- a/packages/haiku-creator/src/react/components/ChangelogModal.js
+++ b/packages/haiku-creator/src/react/components/ChangelogModal.js
@@ -12,6 +12,7 @@ import {DASH_STYLES} from '../styles/dashShared';
 import Palette from 'haiku-ui-common/lib/Palette';
 import {PrettyScroll} from 'haiku-ui-common/lib/react/PrettyScroll';
 import * as Changelog from 'haiku-serialization/src/bll/Changelog';
+import {getUrl} from 'haiku-common/lib/environments';
 
 const STYLES = {
   modalWrapper: {
@@ -109,7 +110,7 @@ class ChangelogModal extends React.PureComponent {
             <span
               style={STYLES.link}
               onClick={() => {
-                shell.openExternal('https://www.haiku.ai/release-notes');
+                shell.openExternal(getUrl('release-notes'));
               }}
             >
               Full Changelog


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- As title implies, ensure `~/.haiku/.env` can be used to output correct URLs, both in the main process and the renderers.

Regressions to look for:

- None expected.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality