### PR TITLE
Fix monaco autocomplete

### DIFF
--- a/packages/haiku-creator/package.json
+++ b/packages/haiku-creator/package.json
@@ -43,7 +43,7 @@
     "lodash.debounce": "4.0.8",
     "marked": "^0.3.17",
     "mixpanel": "0.6.0",
-    "monaco-editor": "^0.13.1",
+    "monaco-editor": "^0.14.3",
     "node-fetch": "^2.0.0-alpha.9",
     "opn": "^5.3.0",
     "qs": "6.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6411,9 +6411,9 @@ moment@2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
-monaco-editor@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.13.1.tgz#6b9ce20e4d1c945042d256825eb133cb23315a52"
+monaco-editor@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.14.3.tgz#7cc4a4096a3821f52fea9b10489b527ef3034e22"
 
 "mout@>=0.9 <2.0":
   version "1.1.0"


### PR DESCRIPTION
OK to merge.

I was able to repro in a consistent way probably the same issue as @stristr, described on https://app.asana.com/0/777535458715338/776617977997482.

By updating monaco version, I can no longer repro it. I took a look at breaking changes **(https://github.com/Microsoft/monaco-editor/blob/master/CHANGELOG.md#0140-10082018)** that we might use and didn't find any.


Completed checkin tasks:
- [x] Did manual testing of interrelated functionality
