### PR TITLE
tweak: import Figma items by priority based on type

### DIFF
--- a/packages/haiku-serialization/src/bll/Figma.js
+++ b/packages/haiku-serialization/src/bll/Figma.js
@@ -14,6 +14,7 @@ const FIGMA_URL = 'https://www.figma.com/'
 const FIGMA_CLIENT_ID = 'tmhDo4V12I3fEiQ9OG8EHh'
 const IS_FIGMA_FILE_RE = /\.figma$/
 const IS_FIGMA_FOLDER_RE = /\.figma\.contents/
+
 const VALID_TYPES = {
   SLICE: 'SLICE',
   GROUP: 'GROUP',
@@ -28,6 +29,13 @@ const FOLDERS = {
 }
 
 const MAX_ITEMS_TO_IMPORT = 100
+
+const PRIORITY_TO_IMPORT = [
+  VALID_TYPES.SLICE,
+  VALID_TYPES.GROUP,
+  VALID_TYPES.FRAME,
+  VALID_TYPES.COMPONENT
+]
 
 const uniqueNameResolver = {}
 
@@ -70,6 +78,7 @@ class Figma {
     return this.createFolders(assetBaseFolder)
       .then(() => this.fetchDocument(id))
       .then((document) => this.findInstantiableElements(document, id))
+      .then((elements) => this.sortElementsByPriorityToImport(elements))
       .then((elements) => this.getSVGLinks(elements, id))
       .then((elements) => this.getSVGContents(elements))
       .then((elements) => this.writeSVGInDisk(elements, assetBaseFolder))
@@ -199,6 +208,10 @@ class Figma {
         })
         .catch(reject)
     })
+  }
+
+  sortElementsByPriorityToImport (arr) {
+    return arr.sort((a, b) => PRIORITY_TO_IMPORT.indexOf(a.type) - PRIORITY_TO_IMPORT.indexOf(b.type))
   }
 
   findItems (arr, fileId) {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Provide an escape hatch for users to prioritize what to import from Figma (due to the current 100 element limit) by importing elements in order by type, the order is:

1- Slices
2- Groups
3- Frames
4- Components

For more details, check the convo in [this task](https://app.asana.com/0/777535458715338/652937227229030)

Regressions to look for:

- Not aware of any

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
