### PR TITLE
Fix GPU-Related Freezes/System Crashes

### DIFF
--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -33,5 +33,6 @@
   "UserFacingDevTools": false,
   "ControlFlowIf": false,
   "ControlFlowRepeat": false,
-  "ExpandTimelinePropertiesFromStageChanges": true
+  "ExpandTimelinePropertiesFromStageChanges": true,
+  "GlassControlPointShadows": false
 }

--- a/packages/haiku-common/src/experiments/index.ts
+++ b/packages/haiku-common/src/experiments/index.ts
@@ -42,6 +42,7 @@ export enum Experiment {
   ControlFlowIf = 'ControlFlowIf',
   ControlFlowRepeat = 'ControlFlowRepeat',
   ExpandTimelinePropertiesFromStageChanges = 'ExpandTimelinePropertiesFromStageChanges',
+  GlassControlPointShadows = 'GlassControlPointShadows',
 }
 
 /**

--- a/packages/haiku-glass/src/overlays/controlPointMana.js
+++ b/packages/haiku-glass/src/overlays/controlPointMana.js
@@ -6,7 +6,7 @@
  * @param cursor
  * @returns {*}
  */
-export default (scale, {x, y}, index, cursor) => ({
+export default (scale, {x, y}, index, cursor, doUseFilters) => ({
   elementName: 'g',
   attributes: {
     transform: `scale(${scale}) translate(${x - 12.5} ${y - 12.5})`,
@@ -26,7 +26,7 @@ export default (scale, {x, y}, index, cursor) => ({
         cy: 12.5,
         r: 3.5,
         fill: '#000',
-        filter: 'url(#a)',
+        filter: (doUseFilters) ? 'url(#a)' : undefined,
       },
     },
     {

--- a/packages/haiku-glass/src/overlays/originMana.js
+++ b/packages/haiku-glass/src/overlays/originMana.js
@@ -6,7 +6,7 @@
  * @param isDraggable
  * @returns {*}
  */
-export default (scale, x, y, isDraggable) => isDraggable
+export default (scale, x, y, isDraggable, doUseFilters) => isDraggable
   ? {
     elementName: 'g',
     attributes: {
@@ -22,7 +22,7 @@ export default (scale, x, y, isDraggable) => isDraggable
         attributes: {
           d: 'M13 12h3.5a.5.5 0 0 1 0 1H13v3.5a.5.5 0 0 1-1 0V13h-3.5a.5.5 0 0 1 0-1h3.5v-3.5a.5.5 0 0 1 1 0v3.5z',
           fill: '#000',
-          filter: 'url(#b)',
+          filter: (doUseFilters) ? 'url(#b)' : undefined,
         },
       },
       {
@@ -39,7 +39,7 @@ export default (scale, x, y, isDraggable) => isDraggable
           cy: 12.5,
           r: 2.5,
           fill: '#000',
-          filter: 'url(#a)',
+          filter: (doUseFilters) ? 'url(#a)' : undefined,
         },
       },
       {
@@ -79,7 +79,7 @@ export default (scale, x, y, isDraggable) => isDraggable
         attributes: {
           d: 'M6 5h3.5a.5.5 0 0 1 0 1H6v3.5a.5.5 0 0 1-1 0V6h-3.5a.5.5 0 0 1 0-1h3.5v-3.5a.5.5 0 0 1 1 0v3.5z',
           fill: '#000',
-          filter: 'url(#b)',
+          filter: (doUseFilters) ? 'url(#b)' : undefined,
         },
       },
       {

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -3060,7 +3060,9 @@ export class Glass extends React.Component {
       return;
     }
 
-    overlays.push(defsMana);
+    if (experimentIsEnabled(Experiment.GlassControlPointShadows)) {
+      overlays.push(defsMana);
+    }
 
     const zoom = this.getActiveComponent().getArtboard().getZoom();
     const points = proxy.getBoxPointsTransformed();
@@ -3112,13 +3114,20 @@ export class Glass extends React.Component {
           point,
           index,
           canControlHandles ? 'none' : this.getCursorCssRule(),
+          experimentIsEnabled(Experiment.GlassControlPointShadows),
         ));
       }
     });
 
     if (canRotate && pointDisplayMode !== POINT_DISPLAY_MODES.NONE) {
       if (!this.pointHasNaN(origin)) {
-        overlays.push(originMana(scale, origin.x, origin.y, Globals.isSpecialKeyDown()));
+        overlays.push(originMana(
+          scale,
+          origin.x,
+          origin.y,
+          Globals.isSpecialKeyDown(),
+          experimentIsEnabled(Experiment.GlassControlPointShadows),
+        ));
       }
     }
 

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -869,7 +869,6 @@ export class Glass extends React.Component {
       children.push({
         elementName: 'line',
         attributes: {
-          key: 'h-' + i,
           x1: '-5000',
           x2: '5000',
           y1: snap.positionWorld,
@@ -884,7 +883,6 @@ export class Glass extends React.Component {
       children.push({
         elementName: 'line',
         attributes: {
-          key: 'v-' + i,
           x1: snap.positionWorld,
           x2: snap.positionWorld,
           y1: '-5000',

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -847,6 +847,7 @@ export class Glass extends React.Component {
 
     const horizSnaps = [];
     const vertSnaps = [];
+
     if (
       this.state.isMouseDown &&
       ElementSelectionProxy.snaps.length > 0 &&

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -1689,7 +1689,10 @@ class ActiveComponent extends BaseModel {
       if (a > b) return 1
       return 0
     })
-    if (!designsAsArray.length) return cb()
+
+    if (!designsAsArray.length) {
+      return cb()
+    }
 
     // Each series is important so we don't inadvertently create a race and thus unstable insertion point hashes
     return async.eachSeries(designsAsArray, (relpath, next) => {

--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -722,25 +722,31 @@ class Element extends BaseModel {
   }
 
   getOriginNotTransformed () {
-    const layout = this.getComputedLayout()
-    return {
-      x: layout.size.x * layout.origin.x,
-      y: layout.size.y * layout.origin.y,
-      z: layout.size.z * layout.origin.z
-    }
+    return this.cache.fetch('getOriginNotTransformed', () => {
+      const layout = this.getComputedLayout()
+      return {
+        x: layout.size.x * layout.origin.x,
+        y: layout.size.y * layout.origin.y,
+        z: layout.size.z * layout.origin.z
+      }
+    })
   }
 
   getOriginTransformed () {
-    return HaikuElement.transformPointInPlace(
-      this.getOriginNotTransformed(),
-      this.getOriginOffsetComposedMatrix()
-    )
+    return this.cache.fetch('getOriginTransformed', () => {
+      return HaikuElement.transformPointInPlace(
+        this.getOriginNotTransformed(),
+        this.getOriginOffsetComposedMatrix()
+      )
+    })
   }
 
   getOriginOffsetComposedMatrix () {
-    return Layout3D.multiplyArrayOfMatrices(this.getComputedLayoutAncestry().reverse().map(
-      (layout) => layout.matrix
-    ))
+    return this.cache.fetch('getOriginOffsetComposedMatrix', () => {
+      return Layout3D.multiplyArrayOfMatrices(this.getComputedLayoutAncestry().reverse().map(
+        (layout) => layout.matrix
+      ))
+    })
   }
 
   getAncestry () {

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -11,7 +11,7 @@ const {Experiment, experimentIsEnabled} = require('haiku-common/lib/experiments'
 const {Figma} = require('./Figma')
 const Sketch = require('./Sketch')
 const Illustrator = require('./Illustrator')
-const _ = require('lodash')
+const lodash = require('lodash')
 
 const PI_OVER_12 = Math.PI / 12
 
@@ -889,7 +889,7 @@ class ElementSelectionProxy extends BaseModel {
     })
 
     // Execute the sort
-    const elementsSortedByBoundingEdge = _.cloneDeep(this.selection).sort((elemA, elemB) => {
+    const elementsSortedByBoundingEdge = lodash.cloneDeep(this.selection).sort((elemA, elemB) => {
       return elemA._distributeBoundingEdge - elemB._distributeBoundingEdge
     })
 
@@ -1333,7 +1333,7 @@ class ElementSelectionProxy extends BaseModel {
     const baseProxyBox = Object.assign({}, this._lastProxyBox)
 
     // note an Object.assign({}, ...) doesn't suffice here because computeScalePropertyGroup mutates properties deeply
-    const getBaseTransform = () => _.cloneDeep(this.transformCache.peek('CONTROL_ACTIVATION'))
+    const getBaseTransform = () => lodash.cloneDeep(this.transformCache.peek('CONTROL_ACTIVATION'))
 
     const baseTransform = getBaseTransform()
 
@@ -1363,7 +1363,7 @@ class ElementSelectionProxy extends BaseModel {
     updatedLayout.scale.y = scalePropertyGroup['scale.y'].value
     updatedLayout.translation.x = scalePropertyGroup['translation.x'].value
     updatedLayout.translation.y = scalePropertyGroup['translation.y'].value
-    let transformedPoints = _.cloneDeep(this._baseBoxPointsNotTransformed)
+    let transformedPoints = lodash.cloneDeep(this._baseBoxPointsNotTransformed)
     ElementSelectionProxy.transformPointsByLayoutInPlace(transformedPoints, updatedLayout)
     // find axis-aligned bounding box; add each edge
     let axisAlignedBbox = [
@@ -2054,7 +2054,7 @@ ElementSelectionProxy.computeScalePropertyGroup = (
   // Make a copy of inbound points so we can transform them in place.
   const fixedPoint = Object.assign({}, fixedPointIn)
   const translatedPoint = Object.assign({}, translatedPointIn)
-  const delta = _.cloneDeep(deltaIn)
+  const delta = lodash.cloneDeep(deltaIn)
   // We compute the entire scale property group by fixing a point (the *temporary* transform origin) and translating a
   // point (the point being dragged). These are represented by `fixedPoint` and `translatedPoint` respectively.
 

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -1262,6 +1262,7 @@ class ElementSelectionProxy extends BaseModel {
       this.component.project.getMetadata(),
       () => {} // no-op
     )
+
     if (overrides && overrides.groupOrigin && overrides.groupOrigin.x !== undefined) {
       this.applyPropertyValue('translation.x', overrides.groupOrigin.x - this.computePropertyValue('offset.x'))
     } else {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

After many hours of debugging and trial-and-error, I found one safe change that seems to fix the crash: **Don't render shadows/blurs on the on-stage control points. (See commit `39b80ec`.)** To be specific, I hid the shadow-rendering behind an experiment flag.

**Here are all of the other things I tried which did _not_ work:**

- Cache various hot `Element` methods such as `getBoxPointsTransformed` (and friends)
- Cache `Element` method `getComputedLayout`
- Remove `element.cache.clear()` from `ElementSelectionProxy#clearAllRelatedCaches`
- Avoid calling `ElementSelectionProxy#clearAllRelatedCaches` on all `ElementSelectionProxy#applyPropertyValue` and `ElementSelectionProxy#applyPropertyDelta` calls and instead call it surgically
- Comment out call to `updateKeyframes` that results from `ElementSelectionProxy#move`
- Completely disable/comment out all snapping-related logic (including snap-line drawing)
- Don't draw very long snap-lines that go outside of the viewport (the theory being that the long lines might be resulting in oversize GPU buffers) 
- Exclude the `onmouseenter`/`onmouseleave` listener attributes from the `controlPointMana`
- Exclude calls to `ActiveComponent#getContextSize` from `ElementSelectionProxy#getComputedLayout`
- Exclude calls to `HaikuElement#computeContentBounds()` from `ElementSelectionProxy#getComputedLayout`
- Exclude everything to do with "auto"-sizing from `ElementSelectionProxy#getComputedLayout`
- Comment out all "auto"-sizing related logic from `HaikuElement.computeLayout`
- Not include the `<Image>` component in the `primitives-misc-1` testbed project
- Not include any subcomponents in the `primitives-misc-1` testbed project
- Reduce calls to `HaikuElement.findOrCreateByNode`

I.e., the _only_ changes upstream of my `filter`-related fix that seem to _completely_ stop the crashes from occurring are changes that entirely prevent animation of [rapid re-rendering of] the control points on stage. But obviously those changes won't be viable since the result is that the user can move elements but the control box remains in the same place.

So, although we have rendered the control points with these shadows for a few months apparently without issue (?), my conclusion today is that we've now got the perfect storm of GPU-bombarding behavior with the inclusion of snap-lines, and perhaps some other stuff.