### PR TITLE
More ui tweaks/fixes from QA

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -2086,10 +2086,13 @@ export default class Creator extends React.Component {
           {this.renderChangelogModal()}
           {this.renderOfflineExportUpgradeModal()}
           {this.renderNewProjectModal()}
-          <Tour
-            projectsList={this.state.projectsList}
-            envoyClient={this.envoyClient}
-            startTourOnMount={true} />
+          {!this.state.tearingDown &&
+            <Tour
+              projectsList={this.state.projectsList}
+              envoyClient={this.envoyClient}
+              startTourOnMount={true}
+            />
+          }
           <AutoUpdater
             onComplete={this.onAutoUpdateCheckComplete}
             check={this.state.updater.shouldCheck}
@@ -2116,9 +2119,12 @@ export default class Creator extends React.Component {
           skipOptIn={this.state.updater.shouldSkipOptIn}
           runOnBackground={this.state.updater.shouldRunOnBackground}
         />
-        <Tour
-          projectsList={this.state.projectsList}
-          envoyClient={this.envoyClient} />
+        {!this.state.tearingDown &&
+          <Tour
+            projectsList={this.state.projectsList}
+            envoyClient={this.envoyClient}
+          />
+        }
         <div style={{position: 'absolute', width: '100%', height: '100%', top: 0, left: 0}}>
           <div className="layout-box" style={{overflow: 'visible'}}>
             <CSSTransition

--- a/packages/haiku-creator/src/react/components/library/DesignFileCreator.tsx
+++ b/packages/haiku-creator/src/react/components/library/DesignFileCreator.tsx
@@ -1,11 +1,16 @@
+import {shell} from 'electron';
+import {isMac} from 'haiku-common/lib/environments/os';
 // @ts-ignore
 import * as mixpanel from 'haiku-serialization/src/utils/Mixpanel';
+// @ts-ignore
+import * as sketchUtils from 'haiku-serialization/src/utils/sketchUtils';
 import Palette from 'haiku-ui-common/lib/Palette';
 import {
   FigmaIconSVG,
   IllustratorIconSVG,
   SketchIconSVG,
 } from 'haiku-ui-common/lib/react/OtherIcons';
+import * as path from 'path';
 import * as React from 'react';
 // @ts-ignore
 import FigmaPopover from './importers/FigmaPopover';
@@ -38,7 +43,17 @@ class DesignFileCreator extends React.PureComponent<any, any> {
 
     return this.props.websocket.request(
       {method: 'copyDefaultSketchFile', params: [projectPath, primaryAssetPath]},
-      (err: any) => {},
+      (err: any) => {
+        if (!isMac()) {
+          return;
+        }
+
+        sketchUtils.checkIfInstalled().then((isSketchInstalled: boolean) => {
+          if (isSketchInstalled) {
+            shell.openItem(path.join(projectPath, primaryAssetPath));
+          }
+        });
+      },
     );
   };
 
@@ -49,6 +64,9 @@ class DesignFileCreator extends React.PureComponent<any, any> {
 
     return this.props.websocket.request(
       {method: 'copyDefaultIllustratorFile', params: [projectPath, defaultIllustratorAssetPath]},
+      // Please note that Illustrator files are opened by default during the first import
+      // because we need to run a jsx script inside Illustrator, thus we don't need to do anything
+      // here. If you want to disable auto open, check Illustrator#importSVG
       (err: any) => {},
     );
   };

--- a/packages/haiku-timeline/src/components/PostMaxKeyframeArea.jsx
+++ b/packages/haiku-timeline/src/components/PostMaxKeyframeArea.jsx
@@ -26,7 +26,7 @@ export default class PostMaxKeyframeArea extends React.Component {
       <div style={{
         background: Color(Palette.COAL).fade(0.7),
         zIndex: zIndex.areaPostMaxKeyframe.base,
-        marginLeft: Math.round((this.frameInfo.maxf + 1) * this.frameInfo.pxpf) + this.props.propertiesPixelWidth + this.props.timelineOffsetPadding,
+        marginLeft: Math.round(this.frameInfo.maxf * this.frameInfo.pxpf) + this.props.propertiesPixelWidth + this.props.timelineOffsetPadding,
         position: 'sticky',
         pointerEvents: 'none',
         height: 'calc(100% - 35px)',


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- [Off-by-one with the timeline-boundary shading](https://app.asana.com/0/777535458715338/789536081500701)
- [Tour is over 'disco H' if I click '< DASHBOARD' in the middle of the tour](https://app.asana.com/0/777535458715338/790017791187725)
- [When presented with initial library state if the user clicks [ sketch] or [ai], immediately open the file after creating it](https://app.asana.com/0/777535458715338/789275054861241)

Regressions to look for:

- None

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
