### PR TITLE
Oh <Hai />

### DIFF
--- a/packages/haiku-creator/haiku.html
+++ b/packages/haiku-creator/haiku.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html>
+<head>
+  <style>
+    html,
+    body {
+      margin: 0;
+      width: 100%;
+      height: 100%;
+    }
+
+    body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+  </style>
+</head>
+<body>
+  <div id="mount"></div>
+  <script>
+    const mount = document.getElementById('mount');
+    const {ipcRenderer} = require('electron');
+    const {requireFromFile} = require('haiku-serialization/src/bll/ModuleWrapper');
+    const {default: HaikuDOMAdapter} = require('@haiku/core/lib/adapters/dom/HaikuDOMAdapter');
+    let bytecode, component;
+
+    ipcRenderer.on('mount', (_, {bytecodePath, width, height, options}) => {
+      if (component) {
+        ipcRenderer.sendToHost('haiku-webview-ready');
+        return;
+      }
+
+      try {
+        bytecode = requireFromFile(bytecodePath);
+        mount.style.width = width;
+        mount.style.height = height;
+
+        component = HaikuDOMAdapter(bytecode)(
+          mount,
+          {
+            ...options,
+            onComponentDidMount: () => {
+              ipcRenderer.sendToHost('haiku-webview-ready');
+            },
+          },
+        );
+
+        ipcRenderer.once('unmount', () => {
+          component.context.destroy();
+          component = undefined;
+        });
+      } catch (error) {
+        console.error(error);
+      }
+    });
+  </script>
+</body>
+</html>

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/HandlerManager.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/HandlerManager.js
@@ -8,8 +8,8 @@ const isHandlerEmpty = (handler) => {
   return (
     !handler.body ||
     /^\s*$/.test(handler.body)
-  )
-}
+  );
+};
 
 /*
  * The purpose of this clas is to abstract all the logic related to
@@ -76,7 +76,7 @@ class HandlerManager {
    */
   replaceEvent ({id, event, handler, evaluator}, oldEventName) {
     if (isHandlerEmpty(handler)) {
-      this.delete(event)
+      this.delete(event);
     } else {
       this.appliedEventHandlers.set(event, {id, handler, evaluator});
     }

--- a/packages/haiku-creator/src/react/components/ProjectLoader.js
+++ b/packages/haiku-creator/src/react/components/ProjectLoader.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import * as Hai from '@haiku/taylor-hai/react';
+import * as path from 'path';
+import {ipcRenderer} from 'electron';
 import Palette from 'haiku-ui-common/lib/Palette';
 
 const STYLES = {
@@ -20,31 +21,79 @@ const STYLES = {
     textAlign: 'center',
   },
   loadingScreen: {
-    height: '450px',
+    height: '100%',
     width: '100%',
+    position: 'absolute',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
     backgroundColor: Palette.COAL,
+    transition: 'opacity 0.5s ease-in-out',
+  },
+  message: {
+    marginTop: 450,
+    zIndex: 1,
   },
 };
 
+const mountArguments = {
+  options: {
+    loop: true,
+    sizing: 'contain',
+    contextMenu: 'disabled',
+    alwaysComputeSizing: true,
+  },
+  bytecodePath: require.resolve('@haiku/taylor-hai/code/main/code'),
+  width: '100%',
+  height: '450px',
+};
+
 class ProjectLoader extends React.PureComponent {
-  static defaultProps = {
-    message: 'Initializing project....',
-  };
+  destroyMountChildren () {
+    while (this.mount.firstChild) {
+      this.mount.removeChild(this.mount.firstChild);
+    }
+  }
+
+  componentDidMount () {
+    this.webview = document.createElement('webview');
+    this.webview.setAttribute('src', require.resolve(path.join('haiku-creator', 'haiku.html')));
+    this.webview.setAttribute('nodeintegration', true);
+    this.webview.style.width = '100%';
+    this.webview.style.height = '100%';
+    this.webview.addEventListener('dom-ready', () => {
+      this.webview.send('mount', mountArguments);
+    });
+
+    this.destroyMountChildren();
+    this.mount.appendChild(this.webview);
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (!this.webview) {
+      return;
+    }
+
+    if (this.props.show ^ nextProps.show) {
+      if (nextProps.show) {
+        this.webview.send('mount', mountArguments);
+      } else {
+        this.webview.send('unmount');
+      }
+    }
+  }
+
+  componentWillUnmount () {
+    this.destroyMountChildren();
+  }
+
+  persistMount = (element) => this.mount = element;
 
   render () {
     return (
-      <div style={STYLES.fullScreenCenterWrap} id="js-helper-project-loader">
-        <div style={STYLES.loadingScreen}>
-          <Hai
-            loop={true}
-            sizing={'contain'}
-            contextMenu={'disabled'}
-            onHaikuComponentWillUnmount={(component) => {
-              component.context.destroy();
-            }}
-          />
-        </div>
-        <span>{this.props.message}</span>
+      <div style={{...STYLES.fullScreenCenterWrap, transform: this.props.show ? 'none' : 'translateX(-100%)'}} id="js-helper-project-loader">
+        <span style={STYLES.message}>Initializing project....</span>
+        <div style={{...STYLES.loadingScreen}} ref={this.persistMount} />
       </div>
     );
   }

--- a/packages/haiku-creator/src/react/components/SideBar.js
+++ b/packages/haiku-creator/src/react/components/SideBar.js
@@ -96,10 +96,6 @@ class SideBar extends React.Component {
     window.removeEventListener('resize', this.windowResizeHandler);
   }
 
-  goToDashboard () {
-    this.props.onNavigateToDashboard();
-  }
-
   render () {
     // The State Inspector UI only makes sense in the context of a component,
     // hence the conditional presence-check before rendering it
@@ -112,9 +108,7 @@ class SideBar extends React.Component {
           <button
             id="go-to-dashboard"
             key="dashboard"
-            onClick={() => {
-              this.goToDashboard();
-            }}
+            onClick={this.props.onNavigateToDashboard}
             style={[
               BTN_STYLES.btnIcon, BTN_STYLES.btnIconHover, BTN_STYLES.btnText,
               {width: 'auto', position: 'absolute', right: 6},

--- a/packages/haiku-creator/src/react/styles/dashShared.js
+++ b/packages/haiku-creator/src/react/styles/dashShared.js
@@ -11,6 +11,16 @@ export const DASH_STYLES = {
     height: '100%',
     backgroundColor: Palette.GRAY,
   },
+  dashOverlay: {
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
+    backgroundColor: Palette.COAL,
+    zIndex: 999,
+    userSelect: 'none',
+    mouseEvents: 'none',
+    opacity: 0.6,
+  },
   frame: {
     position: 'absolute',
     top: 0,

--- a/packages/haiku-serialization/src/utils/requestElementCoordinates.js
+++ b/packages/haiku-serialization/src/utils/requestElementCoordinates.js
@@ -8,7 +8,9 @@ module.exports = function requestElementCoordinates (
   if (currentWebview !== requestedWebview) return
 
   // if the loading screen is present, wait 300ms and try again
-  if (document.getElementById('js-helper-project-loader')) {
+  const loader = document.getElementById('js-helper-project-loader')
+  // When the loader transform style is "none", that means it's visible.
+  if (loader && loader.style.transform === 'none') {
     return setTimeout(() => {
       requestElementCoordinates.apply(this, [
         ...arguments,


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Puts `<Hai />` loader in a webview, which prevents skipping. [Fixes UI lag on the loading-screen H](https://app.asana.com/0/777535458715338/789536081500700/f). (Creates a reuseable `haiku.html` that can be used to mount any Haiku, theoretically.)
- Hoists project loading state to creator (it was awkwardly pushed down into `<ProjectBrowser />`.
- Instead of `<Hai />`, show opaque overlay when tearing down master.
- Kills the weird/duplicative conditionals in Creator's `render()`, which made the above much more difficult.

Regressions to look for:

- If there are any, I'm sure we'll spot them in QA.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality