### PR TITLE
Restored action editor heading padding. Do not overlap horizontal scroll bar

### DIFF
--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/Editor.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/Editor.js
@@ -9,6 +9,7 @@ const STYLES = {
     backgroundColor: Palette.SPECIAL_COAL,
     fontFamily: 'Fira Mono',
     fontSize: '11px',
+    padding: '3px 13px',
   },
   preamble: {
     borderTopLeftRadius: 7,

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/Snippets.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/Snippets.js
@@ -28,7 +28,8 @@ const STYLES = {
     position: 'absolute',
     top: '0px',
     width: '30px',
-    height: '100%',
+    // 10px is the default monaco horizontal scroll bar height
+    height: 'calc(100% - 10px)',
     right: '0px',
     background: `linear-gradient(to right, transparent, ${Palette.DARKEST_COAL} 40%)`,
   },


### PR DESCRIPTION
OK to merge.

That was my fault, thanks for noticing it @roperzh !

Also found and fixed another bug.. the gradient div on right of monaco was overlapping horizontal scroll bar. 


Completed checkin tasks:

- [x] Did manual testing of interrelated functionality