### PR TITLE
Trost Direct Selection Fixes Aug 24

### DIFF
--- a/packages/haiku-glass/src/overlays/directSelectionMana.js
+++ b/packages/haiku-glass/src/overlays/directSelectionMana.js
@@ -257,7 +257,7 @@ export const path = (id, {d}, layoutAncestry, controlPointScale, selectedAnchorI
       },
       {
         elementName: 'g',
-        attributes {}, // Don't remove this. Needed to clear stale attributes from previous node.
+        attributes: {}, // Don't remove this. Needed to clear stale attributes from previous node.
         children: [
           ...handles.map((handle) => {
             const anchor = points[handle.handleIndex === 0 ? handle.pointIndex - 1 : handle.pointIndex];

--- a/packages/haiku-glass/src/overlays/directSelectionMana.js
+++ b/packages/haiku-glass/src/overlays/directSelectionMana.js
@@ -103,7 +103,6 @@ export const rect = (id, {x, y, width, height, rx, ry}, layoutAncestry, controlP
 };
 
 export const circle = (id, {cx, cy, r}, layoutAncestry, controlPointScale, selectedAnchorIndices) => {
-
   const transform = Layout3D.multiplyArrayOfMatrices(layoutAncestry.reverse());
   const transposed = Layout3D.createMatrix();
   transpose(transposed, transform);
@@ -288,7 +287,6 @@ export const path = (id, {d}, layoutAncestry, controlPointScale, selectedAnchorI
 };
 
 export const line = (id, {x1, y1, x2, y2}, layoutAncestry, controlPointScale, selectedAnchorIndices) => {
-
   const transform = Layout3D.multiplyArrayOfMatrices(layoutAncestry.reverse());
   transpose(transform, transform);
   const p1 = mat4_multiply_vec4(transform, {x: Number(x1), y: Number(y1), z: 0, w: 1});

--- a/packages/haiku-glass/src/overlays/directSelectionMana.js
+++ b/packages/haiku-glass/src/overlays/directSelectionMana.js
@@ -257,6 +257,7 @@ export const path = (id, {d}, layoutAncestry, controlPointScale, selectedAnchorI
       },
       {
         elementName: 'g',
+        attributes {}, // Don't remove this. Needed to clear stale attributes from previous node.
         children: [
           ...handles.map((handle) => {
             const anchor = points[handle.handleIndex === 0 ? handle.pointIndex - 1 : handle.pointIndex];

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -2932,7 +2932,8 @@ export class Glass extends React.Component {
         Element.directlySelected,
         this.state.directSelectionAnchorActivation
           ? this.state.directSelectionAnchorActivation.indices[Element.directlySelected.attributes['haiku-id']]
-          : undefined, overlays,
+          : undefined,
+        overlays,
       );
 
       return overlays;

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -2928,7 +2928,13 @@ export class Glass extends React.Component {
         return overlays;
       }
 
-      this.renderDirectSelection(Element.directlySelected, this.state.directSelectionAnchorActivation ? this.state.directSelectionAnchorActivation.indices[Element.directlySelected.attributes['haiku-id']] : undefined, overlays);
+      this.renderDirectSelection(
+        Element.directlySelected,
+        this.state.directSelectionAnchorActivation
+          ? this.state.directSelectionAnchorActivation.indices[Element.directlySelected.attributes['haiku-id']]
+          : undefined, overlays,
+      );
+
       return overlays;
     }
 
@@ -2966,7 +2972,17 @@ export class Glass extends React.Component {
 
     switch (element.type) {
       case 'rect':
-        overlays.push(directSelectionMana[element.type](element.id, {...element.attributes, width: element.sizeX, height: element.sizeY}, original.layoutAncestryMatrices, scale, selectedAnchorIndices || []));
+        overlays.push(directSelectionMana[element.type](
+          element.id,
+          {
+            ...element.attributes,
+            width: element.sizeX,
+            height: element.sizeY,
+          },
+          original.layoutAncestryMatrices,
+          scale,
+          selectedAnchorIndices || [],
+        ));
         break;
       case 'circle':
       case 'ellipse':
@@ -2974,7 +2990,13 @@ export class Glass extends React.Component {
       case 'polyline':
       case 'path':
       case 'polygon':
-        overlays.push(directSelectionMana[element.type](element.id, element.attributes, original.layoutAncestryMatrices, scale, selectedAnchorIndices || []));
+        overlays.push(directSelectionMana[element.type](
+          element.id,
+          element.attributes,
+          original.layoutAncestryMatrices,
+          scale,
+          selectedAnchorIndices || [],
+        ));
         break;
       default:
         // ...noop.

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -940,6 +940,9 @@ export class Glass extends React.Component {
     // Find the value of every attribute at every unique ms
     const uniqueInterpolatedKeys = {};
     for (const i in attributes) {
+      if (!curKeys[attributes[i]]) {
+        continue;
+      }
       uniqueInterpolatedKeys[attributes[i]] = {};
       for (const ms in uniqueMs) {
         uniqueInterpolatedKeys[attributes[i]][ms] = calculateValue(

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -1657,17 +1657,24 @@ export class Glass extends React.Component {
                 };
 
                 const originalEl = Element.findByComponentAndHaikuId(this.getActiveComponent(), Element.directlySelected.attributes['haiku-id']);
+
                 switch (Element.directlySelected.type) {
                   case 'rect': {
+                    const elSize = Element.directlySelected.size;
+
                     const newKeys = this.interpolateAttributesAtKeyframes(originalEl, ['x', 'y', 'rx', 'ry']);
                     const pathKeys = {d: {}, x: {}, y: {}, rx: {}, ry: {}};
+
                     for (const ms in newKeys.x) {
                       pathKeys.d[ms] = {value: SVGPoints.pointsToPath(SVGPoints.rectToPoints(
-                        Number(newKeys.x[ms]), Number(newKeys.y[ms]),
-                        Element.directlySelected.layout.sizeAbsolute.x,
-                        Element.directlySelected.layout.sizeAbsolute.y,
-                        Number(newKeys.rx[ms]), Number(newKeys.ry[ms]),
+                        Number(newKeys.x[ms]),
+                        Number(newKeys.y[ms]),
+                        elSize.x,
+                        elSize.y,
+                        Number((newKeys.rx && newKeys.rx[ms]) || 0),
+                        Number((newKeys.ry && newKeys.ry[ms]) || 0),
                       ))},
+
                       pathKeys.x[ms] = null;
                       pathKeys.y[ms] = null;
                       pathKeys.rx[ms] = null;

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -3527,8 +3527,8 @@ export class Glass extends React.Component {
             if (publicComponentModel && internalElementModel) {
               const publicElementModel = publicComponentModel.querySelector(`haiku:${internalElementModel.getComponentId()}`);
               window.element = publicElementModel;
-              console.log('element', publicElementModel);
-              console.log('element.target', publicElementModel.target);
+              console.info('element', publicElementModel);
+              console.info('element.target', publicElementModel.target);
             }
           }
         },


### PR DESCRIPTION
Going to merge; PR for visibility.

Summary of changes:

- Fix two known causes of `TypeError` crashes on direct selection (https://app.asana.com/0/777535458715338/792996784459367)
- Fix bugs with original implementation of direct selection (https://app.asana.com/0/785272717735380/792761893423636)
- Fix positioning bugs on initial draw of direct selection vertices (related to the above)
- Format some code to be more readable for bespectacled 35-year-olds using small screens