### PR TITLE
Direct selection fixes.

### DIFF
--- a/packages/@haiku/core/src/vendor/svg-points/toPoints.ts
+++ b/packages/@haiku/core/src/vendor/svg-points/toPoints.ts
@@ -7,7 +7,7 @@
  * Permission to use, copy, modify, and/or distribute this software for any purpose
  * with or without fee is hereby granted, provided that the above copyright notice
  * and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
  * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
  * FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT,
@@ -17,8 +17,23 @@
  */
 
 import {
-  CurveSpec, ShapeSpec, CircleSpec, EllipseSpec, LineSpec, PathSpec, PolygonSpec, PolylineSpec, RectSpec,
+  CircleSpec, CurveSpec, EllipseSpec, LineSpec, PathSpec, PolygonSpec, PolylineSpec, RectSpec, ShapeSpec,
 } from './types';
+
+const convertQuadraticToCubicBezier = (spec: CurveSpec, prevSpec: CurveSpec): CurveSpec => prevSpec ?
+{
+  curve: {
+    type: 'cubic',
+    x1: prevSpec.x + 2 / 3 * (spec.curve.x1 - prevSpec.x),
+    y1: prevSpec.y + 2 / 3 * (spec.curve.y1 - prevSpec.y),
+    x2: spec.x + 2 / 3 * (spec.curve.x1 - spec.x),
+    y2: spec.y + 2 / 3 * (spec.curve.y1 - spec.y),
+  },
+  x: spec.x,
+  y: spec.y,
+} :
+  // This should never happen, but just return the original spec if we didn't have a starting point.
+  spec;
 
 const toPoints = (spec: ShapeSpec): CurveSpec[] => {
   switch (spec.type) {
@@ -155,12 +170,12 @@ const optionalArcKeys = ['xAxisRotation', 'largeArcFlag', 'sweepFlag'];
 
 const getCommands = (d: string): string[] => d.match(validCommands);
 
-type Token = {
+interface Token {
   type: string;
   raw: string;
-};
+}
 
-function tokenize(d: string): Token[] {
+function tokenize (d: string): Token[] {
   const tokens = [];
   let chunk = d;
   while (chunk.length > 0) {
@@ -293,8 +308,8 @@ const getPointsFromPath = ({d}: PathSpec): CurveSpec[] => {
             });
 
             for (const k of optionalArcKeys) {
-              if (points[points.length - 1]['curve'][k] === 0) {
-                delete points[points.length - 1]['curve'][k];
+              if (points[points.length - 1].curve[k] === 0) {
+                delete points[points.length - 1].curve[k];
               }
             }
 
@@ -356,7 +371,7 @@ const getPointsFromPath = ({d}: PathSpec): CurveSpec[] => {
             break;
 
           case 'Q':
-            points.push({
+            points.push(convertQuadraticToCubicBezier({
               curve: {
                 type: 'quadratic',
                 x1: (relative ? prevPoint.x : 0) + commandParams.shift(),
@@ -364,7 +379,7 @@ const getPointsFromPath = ({d}: PathSpec): CurveSpec[] => {
               },
               x: (relative ? prevPoint.x : 0) + commandParams.shift(),
               y: (relative ? prevPoint.y : 0) + commandParams.shift(),
-            });
+            }, points[points.length - 1]));
 
             break;
 
@@ -388,7 +403,7 @@ const getPointsFromPath = ({d}: PathSpec): CurveSpec[] => {
               ty1 = prevPoint.y;
             }
 
-            points.push({
+            points.push(convertQuadraticToCubicBezier({
               curve: {
                 type: 'quadratic',
                 x1: tx1,
@@ -396,7 +411,7 @@ const getPointsFromPath = ({d}: PathSpec): CurveSpec[] => {
               },
               x: tx,
               y: ty,
-            });
+            }, points[points.length - 1]));
 
             break;
         }

--- a/packages/@haiku/core/src/vendor/svg-points/toPoints.ts
+++ b/packages/@haiku/core/src/vendor/svg-points/toPoints.ts
@@ -379,7 +379,7 @@ const getPointsFromPath = ({d}: PathSpec): CurveSpec[] => {
               },
               x: (relative ? prevPoint.x : 0) + commandParams.shift(),
               y: (relative ? prevPoint.y : 0) + commandParams.shift(),
-            }, points[points.length - 1]));
+            }, prevPoint));
 
             break;
 
@@ -411,7 +411,7 @@ const getPointsFromPath = ({d}: PathSpec): CurveSpec[] => {
               },
               x: tx,
               y: ty,
-            }, points[points.length - 1]));
+            }, prevPoint));
 
             break;
         }

--- a/packages/@haiku/core/test/unit/SVGPoints.pathToPoints.test.ts
+++ b/packages/@haiku/core/test/unit/SVGPoints.pathToPoints.test.ts
@@ -6,8 +6,6 @@ import * as tape from 'tape';
 tape(
   'SVGPoints.pathToPoints',
   (t) => {
-    t.plan(5);
-
     const ps1 = SVGPoints.pathToPoints('M250,100L400,400L100,400Z');
     t.equal(
       JSON.stringify(ps1),
@@ -37,5 +35,25 @@ tape(
       JSON.stringify(ps5),
       '[{"x":296.3,"y":73.5,"moveTo":true},{"curve":{"type":"cubic","x1":296.3,"y1":73.5,"x2":397.35,"y2":33},"x":429.67,"y":88.5},{"curve":{"type":"cubic","x1":461.99,"y1":144,"x2":513,"y2":201},"x":457.48,"y":222},{"curve":{"type":"cubic","x1":401.96000000000004,"y1":243,"x2":218.99,"y2":307.5},"x":244.48000000000002,"y":255},{"curve":{"type":"cubic","x1":269.97,"y1":202.5,"x2":392.83000000000004,"y2":141},"x":353.91,"y":130.49},{"curve":{"type":"cubic","x1":314.99,"y1":119.98000000000002,"x2":279.11,"y2":121.49000000000001},"x":296.3,"y":73.5,"closed":true}]',
     );
+
+    const ps6 = SVGPoints.pathToPoints('M20,230 Q40,205 50,230 T90,230');
+    t.deepEqual(
+      ps6,
+      [
+        {x: 20, y: 230, moveTo: true},
+        {
+          curve: {type: 'cubic', x1: 33.33333333333333, y1: 213.33333333333334, x2: 43.333333333333336, y2: 213.33333333333334},
+          x: 50,
+          y: 230,
+        },
+        {
+          curve: {type: 'cubic', x1: 50, y1: 230, x2: 63.333333333333336, y2: 230},
+          x: 90,
+          y: 230,
+        },
+      ],
+    );
+
+    t.end();
   },
 );

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -1860,14 +1860,14 @@ export class Glass extends React.Component {
                     // Calculate t value and surrounding points, and split
                     const t = minIdx % approximationResolution / approximationResolution;
 
-                    const newPoints = splitSegmentInSVGPoints(points, Math.floor(minIdx / approximationResolution), Math.ceil(minIdx / approximationResolution), t);
-                    if (newPoints) {
+                    splitSegmentInSVGPoints(points, Math.floor(minIdx / approximationResolution), Math.ceil(minIdx / approximationResolution), t);
+                    if (points) {
                       this.getActiveComponent().updateKeyframes({
                         [this.getActiveComponent().getCurrentTimelineName()]: {
                           [Element.directlySelected.attributes['haiku-id']]: {
                             d: {
                               [this.getActiveComponent().getCurrentTimelineTime()]: {
-                                value: SVGPoints.pointsToPath(newPoints),
+                                value: SVGPoints.pointsToPath(points),
                               },
                             },
                           },

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -2517,12 +2517,12 @@ export class Glass extends React.Component {
                 const attrUpdate = {};
                 const curTime = this.getActiveComponent().getCurrentTimelineTime();
                 if (indices.includes(0)) {
-                  attrUpdate.x1 = {[curTime]: Number(this.selectedOriginalClickState.attributes.x1) + transformedTotalDelta.x};
-                  attrUpdate.y1 = {[curTime]: Number(this.selectedOriginalClickState.attributes.y1) + transformedTotalDelta.y};
+                  attrUpdate.x1 = {[curTime]: {value: Number(this.selectedOriginalClickState.attributes.x1) + transformedTotalDelta.x}};
+                  attrUpdate.y1 = {[curTime]: {value: Number(this.selectedOriginalClickState.attributes.y1) + transformedTotalDelta.y}};
                 }
                 if (indices.includes(1)) {
-                  attrUpdate.x2 = {[curTime]: Number(this.selectedOriginalClickState.attributes.x2) + transformedTotalDelta.x};
-                  attrUpdate.y2 = {[curTime]: Number(this.selectedOriginalClickState.attributes.y2) + transformedTotalDelta.y};
+                  attrUpdate.x2 = {[curTime]: {value: Number(this.selectedOriginalClickState.attributes.x2) + transformedTotalDelta.x}};
+                  attrUpdate.y2 = {[curTime]: {value: Number(this.selectedOriginalClickState.attributes.y2) + transformedTotalDelta.y}};
                 }
                 this.getActiveComponent().updateKeyframes({
                   [this.getActiveComponent().getCurrentTimelineName()]: {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes @jonaias's broken `basic_shapes` direct selection of the squiggly line. Also fixes a sneaky flaw with assuming effective stroke-width will be the same as the value of the stroke-width of the targeted element in direct selection (e.g. we might have `<g stroke-width="5"><path d="..." /></g>`).

Regressions to look for:

- Bugfixes only!

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test for existing and modified functionality
