### PR TITLE
fix: notify property rows when their element is locked

### DIFF
--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -242,6 +242,7 @@ class Element extends BaseModel {
 
   toggleLocked (metadata, cb) {
     this.component.setLockedStatusForComponent(this.getComponentId(), !this.getStaticTemplateNode().attributes[HAIKU_LOCKED_ATTRIBUTE], metadata, cb)
+    this.emit('update', 'element-locked-toggle')
   }
 
   getStaticTemplateNode () {

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -49,7 +49,8 @@ export default class ComponentHeadingRow extends React.Component {
     if (
       what === 'drag-group-start' ||
       what === 'drag-group-end' ||
-      what === 'row-rehydrated'
+      what === 'row-rehydrated' ||
+      what === 'element-locked-toggle'
     ) {
       this.forceUpdate();
     }
@@ -126,7 +127,6 @@ export default class ComponentHeadingRow extends React.Component {
   toggleLock () {
     this.props.row.element.toggleLocked({from: 'timeline'}, () => {
       mixpanel.haikuTrack('creator:timeline:layer:lock-toggled');
-      this.forceUpdate();
     });
   }
 

--- a/packages/haiku-timeline/src/components/PropertyRow.js
+++ b/packages/haiku-timeline/src/components/PropertyRow.js
@@ -24,11 +24,13 @@ export default class PropertyRow extends React.Component {
 
   componentWillUnmount () {
     this.mounted = false;
+    this.props.row.element.removeListener('update', this.handleUpdate);
     this.props.row.removeListener('update', this.handleUpdate);
   }
 
   componentDidMount () {
     this.mounted = true;
+    this.props.row.element.on('update', this.handleUpdate);
     this.props.row.on('update', this.handleUpdate);
   }
 
@@ -39,7 +41,8 @@ export default class PropertyRow extends React.Component {
     if (
       what === 'row-selected' ||
       what === 'row-deselected' ||
-      what === 'row-set-title'
+      what === 'row-set-title' ||
+      what === 'element-locked-toggle'
      ) {
       this.forceUpdate();
     }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes [Seeing a 'Cannot select' cursor when hovering keyframe](https://app.asana.com/0/777535458715338/793889279256068)

Regressions to look for:

- None

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
