### PR TITLE
POC: use styled aria-label instead of titles

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -42,6 +42,7 @@ import {
   isPreviewMode,
 } from 'haiku-ui-common/lib/interactionModes';
 import Palette from 'haiku-ui-common/lib/Palette';
+import TooltipStyles from 'haiku-ui-common/lib/react/TooltipStyles';
 import ActivityMonitor from '../utils/activityMonitor.js';
 import * as requestElementCoordinates from 'haiku-serialization/src/utils/requestElementCoordinates';
 import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
@@ -2298,6 +2299,7 @@ export default class Creator extends React.Component {
           </div>
         </div>}
         {this.state.tearingDown && <div style={DASH_STYLES.dashOverlay} />}
+        <TooltipStyles />
       </div>
     );
   }

--- a/packages/haiku-creator/src/react/components/AlignToolBox.js
+++ b/packages/haiku-creator/src/react/components/AlignToolBox.js
@@ -230,6 +230,8 @@ export default class AlignToolBox extends React.PureComponent {
       >
         <button
             key="show-align-panel-button"
+            aria-label="Show align options"
+            data-tooltip-bottom-right={true}
             id="show-align-panel-button"
             onClick={this.clickPopover}
             style={STYLES.alignDistributeBtn}>

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/EditorActions.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/EditorActions.js
@@ -34,7 +34,7 @@ class EditorActions extends React.PureComponent {
             }
           }}
           style={{...STYLES.button, ...STYLES.doneButton, opacity: this.props.isSaveDisabled ? 0.5 : 1}}
-          title={this.props.title}
+          aria-label={this.props.title}
         >
           Done
         </button>

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
@@ -286,7 +286,7 @@ class EventHandlerEditor extends React.PureComponent {
           <ModalHeader>
             <ElementTitle
               element={this.props.element}
-              title={
+              aria-label={
                 isNumeric(this.props.options.frame)
                   ? `Frame ${this.props.options.frame}`
                   : null
@@ -386,7 +386,7 @@ class EventHandlerEditor extends React.PureComponent {
                   this.doSave();
                   this.doClose();
                 }}
-                title={
+                aria-label={
                   this.state.editorWithErrors
                     ? 'an event handler has a syntax error'
                     : ''

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -398,7 +398,7 @@ class ProjectBrowser extends React.Component {
               option: 'show-changelog',
             });
           }}>
-          <span style={DASH_STYLES.popover.icon} title="Show changelog">
+          <span style={DASH_STYLES.popover.icon} aria-label="Show changelog" data-tooltip-bottom={true}>
             <PresentIconSVG />
           </span>
           <span style={[DASH_STYLES.popover.text, DASH_STYLES.upcase]}>What's New</span>

--- a/packages/haiku-creator/src/react/components/SideBar.js
+++ b/packages/haiku-creator/src/react/components/SideBar.js
@@ -124,13 +124,13 @@ class SideBar extends React.Component {
             this.props.activeNav === 'state_inspector' && STYLES.activeSecond,
             this.props.activeNav === 'component_info_inspector' && STYLES.activeThird,
           ]} />
-          <div key="library" title="Show Library panel"
+          <div key="library" aria-label="Show Library panel" data-tooltip-right={true}
             style={[STYLES.btnNav, this.props.activeNav === 'library' && STYLES.activeBtnNav]}
             onClick={() => this.props.switchActiveNav('library')}>
             <LibraryIconSVG color={Palette.ROCK} />
           </div>
           {(activeComponent)
-            ? <div id="state-inspector" key="state_inspector" title="Show State Inspector panel"
+            ? <div id="state-inspector" key="state_inspector" aria-label="Show State Inspector panel" data-tooltip-right={true}
               style={[STYLES.btnNav, this.props.activeNav === 'state_inspector' && STYLES.activeBtnNav]}
               onClick={() => this.props.switchActiveNav('state_inspector')}>
               <StateInspectorIconSVG color={Palette.ROCK} />

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -659,6 +659,8 @@ class StageTitleBar extends React.Component {
         <button
           key="conglomerate-component-button"
           id="conglomerate-component-button"
+          aria-label="Create a new Component"
+          data-tooltip-bottom-right={true}
           onClick={this.handleConglomerateComponent}
           style={[
             BTN_STYLES.btnIcon,
@@ -671,7 +673,8 @@ class StageTitleBar extends React.Component {
           <button
             key="show-event-handlers-editor-button"
             id="show-event-handlers-editor-button"
-            title="Edit element Actions"
+            aria-label="Edit element Actions"
+            data-tooltip-bottom-right={true}
             onClick={this.handleShowEventHandlersEditor}
             style={[
               BTN_STYLES.btnIcon,
@@ -734,7 +737,8 @@ class StageTitleBar extends React.Component {
         <button
           key="save"
           id="publish"
-          title="Publish project"
+          aria-label="Publish project"
+          data-tooltip-bottom={true}
           onClick={this.handleSaveSnapshotClick}
           disabled={!this.props.isTimelineReady && this.state.snapshotSyndicated === false}
           style={[

--- a/packages/haiku-creator/src/react/components/Toggle.js
+++ b/packages/haiku-creator/src/react/components/Toggle.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as Radium from 'radium';
 import * as IPreview from '@haiku/taylor-ipreview2/react';
-import {Tooltip} from 'haiku-ui-common/lib/react/Tooltip';
 
 const STYLES = {
   disabled: {
@@ -33,32 +32,32 @@ class Toggle extends React.Component {
 
   render () {
     return (
-      <Tooltip content="Toggle preview" style={this.props.style}>
-        <a
-          href="#"
-          style={[
-            this.props.disabled && STYLES.disabled,
-            this.props.style,
-            {marginTop: -5},
-          ]}
-          onClick={() => {
-            this.onToggle();
-          }}
-        >
-          <div>
-            <IPreview
-              haikuStates={{isOn: {value: this.props.active}}}
-              onHaikuComponentDidMount={(component) => {
-                this.previewHaiku = component;
-              }}
-              onHaikuComponentWillUnmount={(component) => {
-                component.context.destroy();
-              }}
-              contextMenu="disabled"
-            />
-          </div>
-        </a>
-      </Tooltip>
+      <a
+        href="#"
+        aria-label="Toggle preview"
+        data-tooltip-bottom={true}
+        style={[
+          this.props.disabled && STYLES.disabled,
+          this.props.style,
+          {marginTop: -5},
+        ]}
+        onClick={() => {
+          this.onToggle();
+        }}
+      >
+        <div>
+          <IPreview
+            haikuStates={{isOn: {value: this.props.active}}}
+            onHaikuComponentDidMount={(component) => {
+              this.previewHaiku = component;
+            }}
+            onHaikuComponentWillUnmount={(component) => {
+              component.context.destroy();
+            }}
+            contextMenu="disabled"
+          />
+        </div>
+      </a>
     );
   }
 }

--- a/packages/haiku-creator/src/react/components/library/FileImporter.js
+++ b/packages/haiku-creator/src/react/components/library/FileImporter.js
@@ -132,7 +132,8 @@ class FileImporter extends React.PureComponent {
         body={this.popoverBody}
       >
         <button
-          title="Import file"
+          aria-label="Import file"
+          data-tooltip-bottom={true}
           style={STYLES.button}
           onClick={() => {
             this.showPopover();

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -20,6 +20,7 @@ import CreateComponentModal from './modals/CreateComponentModal';
 import * as Comments from './Comments';
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu';
 import {ComponentIconSVG} from 'haiku-ui-common/lib/react/OtherIcons';
+import TooltipStyles from 'haiku-ui-common/lib/react/TooltipStyles';
 import * as requestElementCoordinates from 'haiku-serialization/src/utils/requestElementCoordinates';
 import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
 import originMana from '../overlays/originMana';
@@ -3906,6 +3907,7 @@ export class Glass extends React.Component {
             </div>
             : ''}
         </div>
+        <TooltipStyles />
       </div>
     );
   }

--- a/packages/haiku-timeline/package.json
+++ b/packages/haiku-timeline/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@haiku/core": "3.5.2",
+    "balloon-css": "^0.5.0",
     "classnames": "2.2.5",
     "codemirror": "^5.28.0",
     "color": "^2.0.1",

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -328,7 +328,8 @@ export default class ComponentHeadingRow extends React.Component {
                 }
               </div>
               <div
-                title="Edit element Actions"
+                aria-label="Edit element Actions"
+                data-tooltip-right={true}
                 className="event-handler-triggerer-button light-on-hover"
                 style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
                   ...STYLES.actionButton,
@@ -348,7 +349,8 @@ export default class ComponentHeadingRow extends React.Component {
                   : ''}
               </div>
               <div
-                title="Add property"
+                aria-label="Add property"
+                data-tooltip-right={true}
                 className="property-manager-button light-on-hover"
                 style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
                   ...STYLES.actionButton,

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -13,6 +13,7 @@ import * as Keyframe from 'haiku-serialization/src/bll/Keyframe';
 import * as requestElementCoordinates from 'haiku-serialization/src/utils/requestElementCoordinates';
 import * as EmitterManager from 'haiku-serialization/src/utils/EmitterManager';
 import Palette from 'haiku-ui-common/lib/Palette';
+import TooltipStyles from 'haiku-ui-common/lib/react/TooltipStyles';
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu';
 import ControlsArea from './ControlsArea';
 import ExpressionInput from './ExpressionInput';
@@ -1250,6 +1251,7 @@ class Timeline extends React.Component {
             <TrackedExporterRequests trackedExporterRequests={this.state.trackedExporterRequests} />
           }
           <IntercomWidget user={this.state.userDetails} onShow={this.setIntercomOpen} onHide={this.setIntercomClosed} />
+          <TooltipStyles />
         </div>
       </div>
     );

--- a/packages/haiku-ui-common/src/react/ExternalLink.tsx
+++ b/packages/haiku-ui-common/src/react/ExternalLink.tsx
@@ -26,7 +26,7 @@ export class ExternalLink extends React.PureComponent<ExternalLinkProps> {
       <a
         target="_blank"
         rel="noopener noreferrer"
-        title={this.props.title}
+        aria-label={this.props.title}
         style={this.props.style}
         onClick={this.boundOnClick}
       >

--- a/packages/haiku-ui-common/src/react/TooltipStyles.tsx
+++ b/packages/haiku-ui-common/src/react/TooltipStyles.tsx
@@ -1,0 +1,206 @@
+import * as React from 'react';
+
+export default () => {
+  return (
+    <style>
+      {`
+        /**
+        * Tooltip Styles
+        */
+
+        /* Base styles for the element that has a tooltip */
+        [aria-label] {
+          position: relative;
+          cursor: pointer;
+        }
+
+        /* Base styles for the entire tooltip */
+        [aria-label]:before,
+        [aria-label]:after {
+          position: absolute;
+          visibility: hidden;
+          opacity: 0;
+          transition: opacity 0.2s ease-in-out,
+            visibility 0.2s ease-in-out,
+            transform 0.2s cubic-bezier(0.71, 1.7, 0.77, 1.24);
+          transition-delay: 0;
+          transform: translate3d(0, 0, 0);
+          pointer-events: none;
+          text-transform: none!important;
+          font-family: 'Fira Sans';
+          line-height: 15px;
+          letter-spacing: initial;
+        }
+
+        [aria-label]:hover {
+          z-index: 999999999999!important;
+        }
+
+        /* Show the entire tooltip on hover and focus */
+        [aria-label]:hover:before,
+        [aria-label]:hover:after,
+        [aria-label]:focus:before,
+        [aria-label]:focus:after {
+          visibility: visible;
+          opacity: 1;
+          transition-delay: 600ms;
+        }
+
+        /* Base styles for the tooltip's directional arrow */
+        [aria-label]:before {
+          z-index: 1001;
+          border: 6px solid transparent;
+          background: transparent;
+          content: "";
+        }
+
+        /* Base styles for the tooltip's content area */
+        [aria-label]:after {
+          z-index: 1000;
+          padding: 3px 10px;
+          background-color: #0C0C0C;
+          color: #fff;
+          content: attr(aria-label);
+          font-size: 11px;
+          white-space: nowrap;
+          border-radius: 4px;
+        }
+
+        /* Directions */
+
+        /* Top (default) */
+        [aria-label]:before,
+        [aria-label]:after {
+          bottom: 100%;
+          left: 50%;
+        }
+
+        [aria-label]:before {
+          margin-left: -6px;
+          margin-bottom: -12px;
+          border-top-color: #0C0C0C;
+        }
+
+        [aria-label]:hover:before,
+        [aria-label]:hover:after,
+        [aria-label]:focus:before,
+        [aria-label]:focus:after {
+          transform: translateY(-12px) translateX(0);
+        }
+
+        /* Left */
+        [data-tooltip-left]:before,
+        [data-tooltip-left]:after {
+          right: 100%;
+          bottom: 50%;
+          left: auto;
+        }
+
+        [data-tooltip-left]:before {
+          margin-left: 0;
+          margin-right: -12px;
+          margin-bottom: 0;
+          border-top-color: transparent;
+          border-left-color: #0C0C0C;
+        }
+
+        [data-tooltip-left]:hover:before,
+        [data-tooltip-left]:hover:after,
+        [data-tooltip-left]:focus:before,
+        [data-tooltip-left]:focus:after {
+          transform: translateX(-12px);
+        }
+
+        /* Bottom */
+        [data-tooltip-bottom]:before,
+        [data-tooltip-bottom]:after {
+          top: 100%;
+          bottom: auto;
+          left: 50%;
+        }
+
+        [data-tooltip-bottom]:after {
+          transform: translateY(0) translateX(-50%);
+        }
+
+        [data-tooltip-bottom]:before {
+          margin-top: -12px;
+          margin-bottom: 0;
+          border-top-color: transparent;
+          border-bottom-color: #0C0C0C;
+        }
+
+
+        [data-tooltip-bottom]:hover:before,
+        [data-tooltip-bottom]:focus:before {
+          transform: translateY(12px);
+        }
+
+        [data-tooltip-bottom]:hover:after,
+        [data-tooltip-bottom]:focus:after {
+          transform: translateY(12px) translateX(-50%);
+        }
+
+        /* Bottom-Right */
+        [data-tooltip-bottom-right]:before,
+        [data-tooltip-bottom-right]:after {
+          top: 100%;
+          bottom: auto;
+          left: 0;
+        }
+
+        [data-tooltip-bottom-right]:before {
+          margin-top: -10px;
+          margin-bottom: 0;
+          border-top-color: transparent;
+          border-bottom-color: #0C0C0C;
+        }
+
+        [data-tooltip-bottom-right]:hover:after,
+        [data-tooltip-bottom-right]:focus:after {
+          transform: translateY(12px);
+        }
+
+        [data-tooltip-bottom-right]:hover:before,
+        [data-tooltip-bottom-right]:focus:before {
+          transform: translateY(12px) translateX(50%);
+        }
+
+        [data-tooltip-bottom-right]:after {
+          margin-left: 0;
+        }
+
+        [data-tooltip-bottom-right]:before {
+          margin-left: 0;
+        }
+
+        /* Right */
+        [data-tooltip-right]:before,
+        [data-tooltip-right]:after {
+          bottom: 50%;
+          left: 100%;
+        }
+
+        [data-tooltip-right]:before {
+          margin-bottom: 0;
+          margin-left: -12px;
+          border-top-color: transparent;
+          border-right-color: #0C0C0C;;
+        }
+
+        [data-tooltip-right]:hover:before,
+        [data-tooltip-right]:hover:after,
+        [data-tooltip-right]:focus:before,
+        [data-tooltip-right]:focus:after {
+          transform: translateX(12px) translateY(50%);
+        }
+
+        /* Vertically center tooltip content for left/right tooltips */
+        [data-tooltip-left]:after,
+        [data-tooltip-right]:after {
+          margin-left: 0;
+        }
+      `}
+    </style>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1558,6 +1558,10 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+balloon-css@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/balloon-css/-/balloon-css-0.5.0.tgz#6a3c065efab9ea5f509a95d4315df00aae114fa3"
+
 base64-js@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.0.tgz#a39992d723584811982be5e290bb6a53d86700f1"
@@ -6537,7 +6541,7 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
-node-abi@2.4.1, node-abi@^2.0.0:
+node-abi@^2.0.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.4.1.tgz#7628c4d4ec4e9cd3764ceb3652f36b2e7f8d4923"
   dependencies:


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

@taylorpoe suggested in our last meeting the idea of using tool-tips instead of the titles so we can style and control the delay until they appear.

This is a random idea to avoid using a `<Tooltip />` component, mainly because I have the feeling that will be so cumbersome to add a title in that way that nobody will do it.

So, the idea is to style elements with the attribute `aria-label` and add a tooltip with pseudo elements (this is not an idea of mine at all).

Where this approach falls short:

- A tooltip may have z-index problems, because we are tied to the stacking context of the target element.
- The position of the tooltip is not dynamically updated

![2018-08-24 20-56-54 2018-08-24 20_57_51](https://user-images.githubusercontent.com/4419992/44612649-67c0c680-a7e0-11e8-8810-a5bf1946fad5.gif)


If we decide that this is a good idea I can clean up and test this properly.

PS: @taylorpoe agreed to buy a new toy to Jiggs if we get to implement tooltips, so let's push this forward! (_note: he didn't_)


Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
