### PR TITLE
fix: unselect all elements before creating a component from the + sign

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -2031,6 +2031,16 @@ export default class Creator extends React.Component {
     this.showProxySettings();
   };
 
+  conglomerateComponent = ({isBlankComponent} = {isBlankComponent: false}) => {
+    this.props.websocket.send({
+      type: 'broadcast',
+      from: 'creator',
+      folder: this.state.projectModel.getFolder(),
+      name: 'conglomerate-component',
+      isBlankComponent,
+    });
+  };
+
   render () {
     if (this.state.showProxySettings) {
       return (
@@ -2168,6 +2178,7 @@ export default class Creator extends React.Component {
                     onDragStart={this.onLibraryDragStart}
                     createNotice={this.createNotice}
                     removeNotice={this.removeNotice}
+                    conglomerateComponent={this.conglomerateComponent}
                     visible={this.state.activeNav === 'library'} />
                   <StateInspector
                     projectModel={this.state.projectModel}
@@ -2241,6 +2252,7 @@ export default class Creator extends React.Component {
                     setGlassInteractionToCodeEditorMode={this.setGlassInteractionToCodeEditorMode}
                     tryToChangeCurrentActiveComponent={this.tryToChangeCurrentActiveComponent}
                     showEventHandlerEditor={this.state.showEventHandlerEditor}
+                    conglomerateComponent={this.conglomerateComponent}
                   />
                   {(this.state.assetDragging)
                     ? <div style={{width: '100%', height: '100%', backgroundColor: 'white', opacity: 0.01, position: 'absolute', top: 0, left: 0}} />

--- a/packages/haiku-creator/src/react/components/ComponentMenu/ComponentMenu.js
+++ b/packages/haiku-creator/src/react/components/ComponentMenu/ComponentMenu.js
@@ -58,13 +58,8 @@ class ComponentMenu extends React.Component {
     return tabs.filter((tab) => tab.scenename !== 'main');
   }
 
-  showNewComponentDialog = () => {
-    this.props.websocket.send({
-      type: 'broadcast',
-      from: 'creator',
-      folder: this.props.projectModel.getFolder(),
-      name: 'conglomerate-component',
-    });
+  conglomerateComponent = () => {
+    this.props.conglomerateComponent({isBlankComponent: true});
   };
 
   render () {
@@ -92,7 +87,7 @@ class ComponentMenu extends React.Component {
           );
         }))}
         {this.props.showGlass &&
-          <button style={STYLES.newComponentButton} onClick={this.showNewComponentDialog}>
+          <button style={STYLES.newComponentButton} onClick={this.conglomerateComponent}>
             +
           </button>
         }

--- a/packages/haiku-creator/src/react/components/Stage.js
+++ b/packages/haiku-creator/src/react/components/Stage.js
@@ -269,6 +269,10 @@ class Stage extends React.Component {
     this.refs.codeeditor.saveCodeFromEditorToDisk();
   }
 
+  assignStageRef = (element) => {
+    this.mount = element;
+  };
+
   render () {
     const interactionModeColor = isPreviewMode(this.props.interactionMode)
       ? Palette.LIGHTEST_PINK
@@ -307,6 +311,7 @@ class Stage extends React.Component {
             saveCodeFromEditorToDisk={this.saveCodeFromEditorToDisk}
             onShowEventHandlerEditor={this.props.onShowEventHandlerEditor}
             showEventHandlerEditor={this.props.showEventHandlerEditor}
+            conglomerateComponent={this.props.conglomerateComponent}
           />
           <ComponentMenu
             ref="component-menu"
@@ -315,12 +320,11 @@ class Stage extends React.Component {
             nonSavedContentOnCodeEditor={this.state.nonSavedContentOnCodeEditor}
             tryToChangeCurrentActiveComponent={this.props.tryToChangeCurrentActiveComponent}
             websocket={this.props.websocket}
+            conglomerateComponent={this.props.conglomerateComponent}
           />
           <div
             id="stage-mount"
-            ref={(element) => {
-              this.mount = element;
-            }}
+            ref={this.assignStageRef}
             style={[{
               position: 'absolute',
               overflow: 'auto',

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -585,12 +585,7 @@ class StageTitleBar extends React.Component {
         folder: this.props.projectModel.getFolder(), // required when sent via Creator
       });
     } else {
-      this.props.websocket.send({
-        type: 'broadcast',
-        from: 'creator',
-        name: 'conglomerate-component',
-        folder: this.props.projectModel.getFolder(), // required when sent via Creator
-      });
+      this.props.conglomerateComponent();
     }
   }
 

--- a/packages/haiku-creator/src/react/components/library/AssetItem.js
+++ b/packages/haiku-creator/src/react/components/library/AssetItem.js
@@ -185,15 +185,6 @@ class AssetItem extends React.Component {
     this.endDragInCaseItWasStartedInadvertently();
   }
 
-  handleCreateComponent () {
-    this.props.websocket.send({
-      type: 'broadcast',
-      from: 'creator',
-      folder: this.props.projectModel.getFolder(),
-      name: 'conglomerate-component',
-    });
-  }
-
   renderChevy () {
     if (this.props.asset.getChildAssets().length < 1) {
       // An 'invisible' chevron; I don't recall why we do this
@@ -237,7 +228,7 @@ class AssetItem extends React.Component {
       items.push({
         label: 'Create Component',
         icon: ComponentIconSVG,
-        onClick: this.handleCreateComponent.bind(this),
+        onClick: this.props.conglomerateComponent,
       });
     }
 

--- a/packages/haiku-creator/src/react/components/library/AssetList.js
+++ b/packages/haiku-creator/src/react/components/library/AssetList.js
@@ -23,6 +23,7 @@ class AssetList extends React.Component {
               onAskForFigmaAuth={this.props.onAskForFigmaAuth}
               onImportFigmaAsset={this.props.onImportFigmaAsset}
               onRefreshFigmaAsset={this.props.onRefreshFigmaAsset}
+              conglomerateComponent={this.props.conglomerateComponent}
               />
           );
         })}

--- a/packages/haiku-creator/src/react/components/library/FileImporter.js
+++ b/packages/haiku-creator/src/react/components/library/FileImporter.js
@@ -93,14 +93,7 @@ class FileImporter extends React.PureComponent {
         <div style={STYLES.popover.item}>
           <div
             style={STYLES.popover.text}
-            onClick={() => {
-              this.props.websocket.send({
-                type: 'broadcast',
-                from: 'creator',
-                folder: this.props.projectModel.getFolder(),
-                name: 'conglomerate-component',
-              });
-            }}
+            onClick={this.props.conglomerateComponent}
           >
             Create Component
           </div>

--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -369,7 +369,7 @@ class Library extends React.Component {
     );
   }
 
-  handleFileDrop (filePaths) {
+  handleFileDrop = (filePaths) => {
     this.setState({isLoading: true});
 
     this.props.projectModel.bulkLinkAssets(
@@ -380,7 +380,7 @@ class Library extends React.Component {
         }
       },
     );
-  }
+  };
 
   shouldDisplayAssetCreator () {
     const designsFolder = this.state.assets.find((asset) => asset.isDesignsHostFolder());
@@ -416,9 +416,8 @@ class Library extends React.Component {
             onImportFigmaAsset={this.importFigmaAsset}
             onAskForFigmaAuth={this.askForFigmaAuth}
             figma={this.state.figma}
-            onFileDrop={(filePaths) => {
-              this.handleFileDrop(filePaths);
-            }}
+            conglomerateComponent={this.props.conglomerateComponent}
+            onFileDrop={this.handleFileDrop}
           />
         </div>
         <div
@@ -448,6 +447,7 @@ class Library extends React.Component {
                   deleteAsset={this.handleAssetDeletion}
                   indent={0}
                   assets={this.state.assets}
+                  conglomerateComponent={this.props.conglomerateComponent}
                 />
               )}
             </div>

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -771,7 +771,7 @@ export class Glass extends React.Component {
           break;
 
         case 'conglomerate-component':
-          this.launchComponentNameModal();
+          this.launchComponentNameModal({isBlankComponent: message.isBlankComponent});
           break;
 
         case 'perform-align':
@@ -1094,7 +1094,13 @@ export class Glass extends React.Component {
     }
   };
 
-  launchComponentNameModal () {
+  launchComponentNameModal ({isBlankComponent} = {isBlankComponent: false}) {
+    if (isBlankComponent) {
+      Element.unselectAllElements({
+        component: this.getActiveComponent(),
+      }, {from: 'glass'});
+    }
+
     this.setState({
       isCreateComponentModalOpen: true,
     });


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

As the title says, this includes a very thin refactor to use a single function passed as prop, instead of multiple `websocket.send` calls in various components.

Regressions to look for:

- If any, creating components

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
