### PR TITLE
Jonas ui aug 27

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -4,6 +4,8 @@
     "What's new": [
       "Creating a component with the + sign now always creates an empty component."
     ],
-    "Fixes": []
+    "Fixes": [
+      "Fix action editor cancel button not working with syntax errors."
+    ]
   }
 }

--- a/packages/haiku-creator/src/react/components/AlignToolBox.js
+++ b/packages/haiku-creator/src/react/components/AlignToolBox.js
@@ -1,3 +1,4 @@
+import * as Radium from 'radium';
 import * as React from 'react';
 import * as Popover from 'react-popover';
 import * as mixpanel from 'haiku-serialization/src/utils/Mixpanel';
@@ -28,7 +29,7 @@ const STYLES = {
   },
 };
 
-export default class AlignToolBox extends React.PureComponent {
+class AlignToolBox extends React.PureComponent {
   constructor (props) {
     super(props);
 
@@ -246,3 +247,5 @@ AlignToolBox.propTypes = {
   websocket: React.PropTypes.object.isRequired,
   projectModel: React.PropTypes.object.isRequired,
 };
+
+export default Radium(AlignToolBox);

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
@@ -196,6 +196,11 @@ class EventHandlerEditor extends React.PureComponent {
     });
   }
 
+  doCloseIgnoringErrors () {
+    // Hide and close without checking for errors (this.state.editorWithErrors)
+    this.setState({currentEvent: null}, this.props.close);
+  }
+
   doSave () {
     if (!this.state.editorWithErrors && this.state.currentEvent) {
       this.handlerManager.replaceEvent(
@@ -380,7 +385,7 @@ class EventHandlerEditor extends React.PureComponent {
             <ModalFooter>
               <EditorActions
                 onCancel={() => {
-                  this.doClose();
+                  this.doCloseIgnoringErrors();
                 }}
                 onSave={() => {
                   this.doSave();

--- a/packages/haiku-creator/src/react/components/NewProjectModal.js
+++ b/packages/haiku-creator/src/react/components/NewProjectModal.js
@@ -97,7 +97,7 @@ class NewProjectModal extends React.PureComponent {
               (!this.state.recordedNewProjectName || this.state.newProjectError) && BTN_STYLES.btnDisabled,
               {marginRight: 0},
             ]}>
-            {duplicate ? 'Duplicate Project' : 'Name Project'}
+            {duplicate ? 'Duplicate Project' : 'Create Project'}
           </button>
           <span style={[DASH_STYLES.upcase, BTN_STYLES.btnCancel, BTN_STYLES.rightBtns]}
             onClick={() => {

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -323,7 +323,7 @@ export default class ComponentHeadingRow extends React.Component {
               >
                 {
                   this.props.row.element.isLocked()
-                    ? LockIconSVG({color: Palette.DARK_ROCK})
+                    ? LockIconSVG({color: Palette.LIGHT_BLUE})
                     : UnlockIconSVG({color: Palette.DARK_ROCK})
                 }
               </div>


### PR DESCRIPTION
OK to merge.

- When element layer is locked, show icon color the same active blue as when it has actions https://app.asana.com/0/785272717735380/793889279256073

Minimal details (found them on Friday testing but didn't bring up due release focus) :
    - Animation on AlignToolBox buttons are gone 
    - Change create new project button label from "Name project" to "Create project"
    - Cannot exit action editor with cancel button if it has syntax error

About the button renaming, @taylorpoe gave a green light for it, but if anyone else don't like the idea feel free to comment

Completed checkin tasks:
- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`
