### PR TITLE
fix: disable distributing single elements

### DIFF
--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -856,15 +856,7 @@ class ElementSelectionProxy extends BaseModel {
     yEdge,
     toStage
   ) {
-    if (!this.selection) {
-      return
-    }
-
-    if (!toStage && this.selection.length < 2) {
-      return
-    }
-
-    if (toStage && !this.selection.length) {
+    if (!this.selection || this.selection.length < 2) {
       return
     }
 


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Disables distribution of single elements.  Is not 100% formally correct, in that distributing of a single element to stage should be equivalent to aligning that single element to stage, but I feel OK about simply disabling single-element distribution, since the user can simply use align to achieve that end.  That's what this commit does.

Completed checkin tasks:

- [x ] Did manual testing of interrelated functionality