### PR TITLE
_pro rata_

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -506,7 +506,10 @@ export default class Creator extends React.Component {
     }
   }
 
-  explorePro = () => {
+  explorePro = (source) => {
+    if (source) {
+      mixpanel.haikuTrack(`creator:upgrade-cta-click:${source}`);
+    }
     shell.openExternal(getAccountUrl('checkout'));
   };
 
@@ -808,7 +811,13 @@ export default class Creator extends React.Component {
       ipcRenderer.on('global-menu:save-as', (_, extension, request) => {
         exporterChannel.checkOfflinePrivileges().then((allowOffline) => {
           if (!allowOffline) {
-            this.setState({showOfflineExportUpgradeModal: true});
+            this.setState({
+              showOfflineExportUpgradeModal: true,
+              offlineExportUpgradeModalMetadata: {
+                extension,
+                framerate: request.framerate,
+              },
+            });
             return;
           }
 
@@ -1832,6 +1841,7 @@ export default class Creator extends React.Component {
           this.setState({showOfflineExportUpgradeModal: false});
         }}
         explorePro={this.explorePro}
+        metadata={this.state.offlineExportUpgradeModalMetadata}
       />
     ) : null;
   }

--- a/packages/haiku-creator/src/react/components/OfflineExportUpgradeModal.tsx
+++ b/packages/haiku-creator/src/react/components/OfflineExportUpgradeModal.tsx
@@ -1,3 +1,5 @@
+// @ts-ignore
+import * as mixpanel from 'haiku-serialization/src/utils/Mixpanel';
 import Palette from 'haiku-ui-common/lib/Palette';
 import ExternalLinkIconSVG from 'haiku-ui-common/lib/react/icons/ExternalLinkIconSVG';
 import {ModalFooter, ModalHeader, ModalWrapper} from 'haiku-ui-common/lib/react/Modal';
@@ -39,11 +41,24 @@ const STYLES: React.CSSProperties = {
 };
 
 export interface OfflineExportUpgradeModalProps {
-  explorePro: () => void;
+  explorePro: (source?: string) => void;
+  metadata: {extension: string, framerate: number};
   onClose: () => void;
 }
 
 export class OfflineExportUpgradeModal extends React.PureComponent<OfflineExportUpgradeModalProps> {
+  private get source () {
+    return `offline-export:${this.props.metadata.extension}:${this.props.metadata.framerate}`;
+  }
+
+  private explorePro = () => {
+    this.props.explorePro(this.source);
+  };
+
+  componentDidMount () {
+    mixpanel.haikuTrack(`creator:upgrade-cta-shown:${this.source}`);
+  }
+
   render () {
     return (
       <ModalWrapper style={STYLES.wrapper} onEsc={this.props.onClose}>
@@ -51,7 +66,7 @@ export class OfflineExportUpgradeModal extends React.PureComponent<OfflineExport
         <div style={STYLES.inner}>
           <div style={STYLES.upgradeWrap}>
             <div>Haiku Pro is required to export local assets and videos.</div>
-            <span onClick={this.props.explorePro} style={STYLES.btnSecondary}>Go Pro
+            <span onClick={this.explorePro} style={STYLES.btnSecondary}>Go Pro
               <span
                 style={{
                   width: 11,

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -51,6 +51,10 @@ class ProjectBrowser extends React.Component {
       // Value has changed.
       // This reload should be silent iff offline is allowed.
       this.loadProjects(nextProps.allowOffline);
+
+      if (!nextProps.isOnline && !nextProps.allowOffline) {
+        mixpanel.haikuTrack('creator:upgrade-cta-shown:project-browser-offline');
+      }
     }
   }
 
@@ -231,6 +235,14 @@ class ProjectBrowser extends React.Component {
     return !this.props.isOnline && !this.props.allowOffline;
   }
 
+  exploreProOffline = () => {
+    this.props.explorePro('project-browser-offline');
+  };
+
+  exploreProTitlebar = () => {
+    this.props.explorePro('project-browser-titlebar');
+  };
+
   offlineElement () {
     if (!this.shouldShowOfflineNotice) {
       return null;
@@ -249,7 +261,7 @@ class ProjectBrowser extends React.Component {
                 DASH_STYLES.btn,
               ]}
               title="Upgrade to Haiku Pro"
-              onClick={this.props.explorePro}>Go Pro
+              onClick={this.exploreProOffline}>Go Pro
               <span style={{width:14, height:14, transform: 'translateY(-2px)', marginLeft: 4}}>
                 <ExternalLinkSVG color={Palette.SUNSTONE}/>
               </span>
@@ -523,7 +535,7 @@ class ProjectBrowser extends React.Component {
                 <span
                   title="Upgrade to Haiku Pro"
                   style={DASH_STYLES.bannerNotice}
-                  onClick={this.props.explorePro}>
+                  onClick={this.exploreProTitlebar}>
                   Go Pro
                   <span style={{width: 11, height: 11, display: 'inline-block', marginLeft: 4, transform: 'translateY(1px)'}}>
                     <ExternalLinkSVG color={Palette.LIGHT_BLUE}/>

--- a/packages/haiku-creator/src/react/components/PublicPrivateOptInModal.tsx
+++ b/packages/haiku-creator/src/react/components/PublicPrivateOptInModal.tsx
@@ -1,3 +1,5 @@
+// @ts-ignore
+import * as mixpanel from 'haiku-serialization/src/utils/Mixpanel';
 import Palette from 'haiku-ui-common/lib/Palette';
 import {ExternalLink} from 'haiku-ui-common/lib/react/ExternalLink';
 import ExternalLinkIconSVG from 'haiku-ui-common/lib/react/icons/ExternalLinkIconSVG';
@@ -79,14 +81,16 @@ export interface PublicPrivateOptInModalProps {
   onToggle: () => void;
   onContinue: () => void;
   onClose: () => void;
-  explorePro: () => void;
+  explorePro: (source?: string) => void;
   privateProjectCount: number;
   privateProjectLimit: number;
 }
 
+const SOURCE = 'public-private-opt-in-modal';
+
 export class PublicPrivateOptInModal extends React.PureComponent<PublicPrivateOptInModalProps> {
   private initiallyPrivate = false;
-  get shouldDisablePrivate () {
+  private get shouldDisablePrivate () {
     return !this.initiallyPrivate &&
       this.props.privateProjectLimit !== null &&
       this.props.privateProjectCount >= this.props.privateProjectLimit;
@@ -95,6 +99,16 @@ export class PublicPrivateOptInModal extends React.PureComponent<PublicPrivateOp
   constructor (props: PublicPrivateOptInModalProps) {
     super(props);
     this.initiallyPrivate = !props.isPublic;
+  }
+
+  private explorePro = () => {
+    this.props.explorePro(SOURCE);
+  };
+
+  componentDidMount () {
+    if (this.shouldDisablePrivate) {
+      mixpanel.haikuTrack(`creator:upgrade-cta-shown:${SOURCE}`);
+    }
   }
 
   render () {
@@ -151,7 +165,7 @@ export class PublicPrivateOptInModal extends React.PureComponent<PublicPrivateOp
                 </span>
               </div>
               <div>Upgrade for unlimited private projects and pro features.</div>
-              <span onClick={this.props.explorePro} style={STYLES.btnSecondary}>Go Pro
+              <span onClick={this.explorePro} style={STYLES.btnSecondary}>Go Pro
                   <span
                     style={{
                       width: 11,

--- a/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
@@ -144,7 +144,7 @@ export interface ProjectShareDetailsProps {
   shouldShowPrivateWarning: boolean;
   togglePublic: () => void;
   mixpanel: any;
-  explorePro: () => void;
+  explorePro: (source?: string) => void;
   privateProjectCount: number;
   privateProjectLimit: number;
   hasError: boolean;
@@ -187,6 +187,10 @@ export class ProjectShareDetails extends React.PureComponent<ProjectShareDetails
       from: 'app',
       event: 'open-share-link',
     });
+  };
+
+  private explorePro = () => {
+    this.props.explorePro('publish-modal-toggle');
   };
 
   render () {
@@ -291,7 +295,7 @@ export class ProjectShareDetails extends React.PureComponent<ProjectShareDetails
                 </span>
               </div>
               <div>Upgrade for unlimited private projects and pro features.</div>
-              <span onClick={this.props.explorePro} style={STYLES.btnSecondary}>Go Pro
+              <span onClick={this.explorePro} style={STYLES.btnSecondary}>Go Pro
                   <span style={{width: 11, height: 11, display: 'inline-block', marginLeft: 4, transform: 'translateY(1px)'}}>
                     <ExternalLinkIconSVG color={Palette.LIGHT_BLUE}/>
                   </span>

--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -33,7 +33,7 @@ export interface ShareModalProps {
   folder: string;
   mixpanel: any;
   urls: HaikuShareUrls;
-  explorePro: () => void;
+  explorePro: (source?: string) => void;
   privateProjectCount: number;
   privateProjectLimit: number;
   supportOfflineExport: boolean;
@@ -122,6 +122,7 @@ export class ShareModal extends React.Component<ShareModalProps, ShareModalState
     }
 
     if (this.shouldDisablePrivate) {
+      this.props.mixpanel.haikuTrack('creator:upgrade-cta-shown:publish-modal-toggle');
       this.setState({shouldShowPrivateWarning: true});
       return;
     }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Track mixpanel events for upgrade CTAs appearing (`creator:upgrade-cta-shown:public-private-opt-in-modal`) and actually being clicked on (`creator:upgrade-cta-click:public-private-opt-in-modal`). The sources tracked are:
  - `offline-export:<format>:<framerate>`
  - `project-browser-offline`
  - `project-browser-titlebar`
  - `public-private-opt-in-modal`
  - `publish-modal-toggle`

Not my finest work, but it works!

Regressions to look for:

- Zippo.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Added measurement instrumentation (Mixpanel, etc.)