### PR TITLE
fix: use 'data-tooltip' instead of 'aria-label' for tooltips

### DIFF
--- a/packages/haiku-creator/src/react/components/AlignToolBox.js
+++ b/packages/haiku-creator/src/react/components/AlignToolBox.js
@@ -244,6 +244,7 @@ class AlignToolBox extends React.PureComponent {
         <button
             key="show-align-panel-button"
             aria-label="Show align options"
+            data-tooltip={true}
             data-tooltip-bottom-right={true}
             id="show-align-panel-button"
             onClick={this.clickPopover}

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/EditorActions.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/EditorActions.js
@@ -35,6 +35,7 @@ class EditorActions extends React.PureComponent {
           }}
           style={{...STYLES.button, ...STYLES.doneButton, opacity: this.props.isSaveDisabled ? 0.5 : 1}}
           aria-label={this.props.title}
+          data-tooltip={true}
         >
           Done
         </button>

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
@@ -325,6 +325,7 @@ class EventHandlerEditor extends React.PureComponent {
           <ModalHeader>
             <ElementTitle
               element={this.props.element}
+              data-tooltip={true}
               aria-label={
                 isNumeric(this.props.options.frame)
                   ? `Frame ${this.props.options.frame}`
@@ -425,6 +426,7 @@ class EventHandlerEditor extends React.PureComponent {
                   this.doSave();
                   this.doClose();
                 }}
+                data-tooltip={true}
                 aria-label={
                   this.state.editorWithErrors
                     ? 'an event handler has a syntax error'

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -439,7 +439,7 @@ class ProjectBrowser extends React.Component {
               option: 'show-changelog',
             });
           }}>
-          <span style={DASH_STYLES.popover.icon} aria-label="Show changelog" data-tooltip-bottom={true}>
+          <span style={DASH_STYLES.popover.icon} aria-label="Show changelog"  data-tooltip={true} data-tooltip-bottom={true}>
             <PresentIconSVG />
           </span>
           <span style={[DASH_STYLES.popover.text, DASH_STYLES.upcase]}>What's New</span>

--- a/packages/haiku-creator/src/react/components/SideBar.js
+++ b/packages/haiku-creator/src/react/components/SideBar.js
@@ -125,13 +125,13 @@ class SideBar extends React.Component {
             this.props.activeNav === 'state_inspector' && STYLES.activeSecond,
             this.props.activeNav === 'component_info_inspector' && STYLES.activeThird,
           ]} />
-          <div key="library" aria-label="Show Library panel" data-tooltip-right={true}
+          <div key="library" aria-label="Show Library panel" data-tooltip={true} data-tooltip-right={true}
             style={[STYLES.btnNav, this.props.activeNav === 'library' && STYLES.activeBtnNav]}
             onClick={() => this.props.switchActiveNav('library')}>
             <LibraryIconSVG color={Palette.ROCK} />
           </div>
           {(activeComponent)
-            ? <div id="state-inspector" key="state_inspector" aria-label="Show State Inspector panel" data-tooltip-right={true}
+            ? <div id="state-inspector" key="state_inspector" aria-label="Show State Inspector panel"  data-tooltip={true} data-tooltip-right={true}
               style={[STYLES.btnNav, this.props.activeNav === 'state_inspector' && STYLES.activeBtnNav]}
               onClick={() => this.props.switchActiveNav('state_inspector')}>
               <StateInspectorIconSVG color={Palette.ROCK} />

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -633,6 +633,7 @@ class StageTitleBar extends React.Component {
           key="conglomerate-component-button"
           id="conglomerate-component-button"
           aria-label="Create a new Component"
+          data-tooltip={true}
           data-tooltip-bottom-right={true}
           onClick={this.handleConglomerateComponent}
           style={[
@@ -647,6 +648,7 @@ class StageTitleBar extends React.Component {
             key="show-event-handlers-editor-button"
             id="show-event-handlers-editor-button"
             aria-label="Edit element Actions"
+            data-tooltip={true}
             data-tooltip-bottom-right={true}
             onClick={this.handleShowEventHandlersEditor}
             style={[
@@ -712,6 +714,7 @@ class StageTitleBar extends React.Component {
           key="save"
           id="publish"
           aria-label="Publish project"
+          data-tooltip={true}
           data-tooltip-bottom={true}
           onClick={this.handleSaveSnapshotClick}
           disabled={!this.props.isTimelineReady && this.state.snapshotSyndicated === false}

--- a/packages/haiku-creator/src/react/components/Toggle.js
+++ b/packages/haiku-creator/src/react/components/Toggle.js
@@ -35,6 +35,7 @@ class Toggle extends React.Component {
       <a
         href="#"
         aria-label="Toggle preview"
+        data-tooltip={true}
         data-tooltip-bottom={true}
         style={[
           this.props.disabled && STYLES.disabled,

--- a/packages/haiku-creator/src/react/components/library/FileImporter.js
+++ b/packages/haiku-creator/src/react/components/library/FileImporter.js
@@ -126,6 +126,7 @@ class FileImporter extends React.PureComponent {
       >
         <button
           aria-label="Import file"
+          data-tooltip={true}
           data-tooltip-bottom={true}
           style={STYLES.button}
           onClick={() => {

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -329,6 +329,7 @@ export default class ComponentHeadingRow extends React.Component {
               </div>
               <div
                 aria-label="Edit element Actions"
+                data-tooltip={true}
                 data-tooltip-right={true}
                 className="event-handler-triggerer-button light-on-hover"
                 style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {
@@ -350,6 +351,7 @@ export default class ComponentHeadingRow extends React.Component {
               </div>
               <div
                 aria-label="Add property"
+                data-tooltip={true}
                 data-tooltip-right={true}
                 className="property-manager-button light-on-hover"
                 style={(experimentIsEnabled(Experiment.NativeTimelineScroll) ? {

--- a/packages/haiku-ui-common/css/tooltips.css
+++ b/packages/haiku-ui-common/css/tooltips.css
@@ -3,14 +3,14 @@
  */
 
 /* Base styles for the element that has a tooltip */
-[aria-label]:not(.monaco-list-row) {
+[data-tooltip] {
   position: relative;
   cursor: pointer;
 }
 
 /* Base styles for the entire tooltip */
-[aria-label]:not(.monaco-list-row):before,
-[aria-label]:not(.monaco-list-row):after {
+[data-tooltip]:before,
+[data-tooltip]:after {
   position: absolute;
   visibility: hidden;
   opacity: 0;
@@ -26,22 +26,22 @@
   letter-spacing: initial;
 }
 
-[aria-label]:not(.monaco-list-row):hover {
+[data-tooltip]:hover {
   z-index: 999999999999!important;
 }
 
 /* Show the entire tooltip on hover and focus */
-[aria-label]:not(.monaco-list-row):hover:before,
-[aria-label]:not(.monaco-list-row):hover:after,
-[aria-label]:not(.monaco-list-row):focus:before,
-[aria-label]:not(.monaco-list-row):focus:after {
+[data-tooltip]:hover:before,
+[data-tooltip]:hover:after,
+[data-tooltip]:focus:before,
+[data-tooltip]:focus:after {
   visibility: visible;
   opacity: 1;
   transition-delay: 600ms;
 }
 
 /* Base styles for the tooltip's directional arrow */
-[aria-label]:not(.monaco-list-row):before {
+[data-tooltip]:before {
   z-index: 1001;
   border: 6px solid transparent;
   background: transparent;
@@ -49,7 +49,7 @@
 }
 
 /* Base styles for the tooltip's content area */
-[aria-label]:not(.monaco-list-row):after {
+[data-tooltip]:after {
   z-index: 1000;
   padding: 3px 10px;
   background-color: #0C0C0C;
@@ -63,22 +63,22 @@
 /* Directions */
 
 /* Top (default) */
-[aria-label]:not(.monaco-list-row):before,
-[aria-label]:not(.monaco-list-row):after {
+[data-tooltip]:before,
+[data-tooltip]:after {
   bottom: 100%;
   left: 50%;
 }
 
-[aria-label]:not(.monaco-list-row):before {
+[data-tooltip]:before {
   margin-left: -6px;
   margin-bottom: -12px;
   border-top-color: #0C0C0C;
 }
 
-[aria-label]:not(.monaco-list-row):hover:before,
-[aria-label]:not(.monaco-list-row):hover:after,
-[aria-label]:not(.monaco-list-row):focus:before,
-[aria-label]:not(.monaco-list-row):focus:after {
+[data-tooltip]:hover:before,
+[data-tooltip]:hover:after,
+[data-tooltip]:focus:before,
+[data-tooltip]:focus:after {
   transform: translateY(-12px) translateX(0);
 }
 


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Instead of assuming that all elements with `aria-label` are intended to be tooltips, this forces elements to also have a `data-tooltip` attribute, preventing clashes with monaco, other libraries and ourselves if we put more efforts into a11y in the future.

Regressions to look for:

- None

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
