### PR TITLE
feat: add endpoint for user email update.

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -2,7 +2,7 @@
   "date": "September 10, 2018",
   "sections": {
     "What's new": [
-      "First!"
+      "You can now change the email address you use to sign in at [account.haiku.ai](https://account.haiku.ai/)."
     ],
     "Fixes": [
       "First!"

--- a/packages/@haiku/sdk-inkstone/src/errors.ts
+++ b/packages/@haiku/sdk-inkstone/src/errors.ts
@@ -3,8 +3,8 @@ export enum ErrorCode {
   ErrorOffline = 'E_OFFLINE',
   ErrorUncategorized = 'E_UNCATEGORIZED',
 
-  ErrorCodeUserMissingParams      = 'E_USER_MISSING_PARAMS',
-	ErrorCodeUserEmailAlreadyExists = 'E_USER_EMAIL_ALREADY_EXISTS',
+  ErrorCodeUserMissingParams = 'E_USER_MISSING_PARAMS',
+  ErrorCodeUserEmailAlreadyExists = 'E_USER_EMAIL_ALREADY_EXISTS',
   ErrorCodeAuthorizationRequired = 'E_AUTHORIZATION_REQUIRED',
   ErrorCodePrivilegesPrivateProjectLimitExceeded = 'E_PRIVILEGES_PRIVATE_PROJECT_LIMIT_EXCEEDED',
   ErrorCodeProjectNameRequired = 'E_PROJECT_NAME_REQUIRED',

--- a/packages/@haiku/sdk-inkstone/src/errors.ts
+++ b/packages/@haiku/sdk-inkstone/src/errors.ts
@@ -3,6 +3,8 @@ export enum ErrorCode {
   ErrorOffline = 'E_OFFLINE',
   ErrorUncategorized = 'E_UNCATEGORIZED',
 
+  ErrorCodeUserMissingParams      = 'E_USER_MISSING_PARAMS',
+	ErrorCodeUserEmailAlreadyExists = 'E_USER_EMAIL_ALREADY_EXISTS',
   ErrorCodeAuthorizationRequired = 'E_AUTHORIZATION_REQUIRED',
   ErrorCodePrivilegesPrivateProjectLimitExceeded = 'E_PRIVILEGES_PRIVATE_PROJECT_LIMIT_EXCEEDED',
   ErrorCodeProjectNameRequired = 'E_PROJECT_NAME_REQUIRED',

--- a/packages/@haiku/sdk-inkstone/src/index.ts
+++ b/packages/@haiku/sdk-inkstone/src/index.ts
@@ -169,7 +169,18 @@ export namespace inkstone {
 
     export const get = (cb: inkstone.Callback<User>) => {
       newGetRequest()
-        .withEndpoint(Endpoints.OrganizationUserDetail)
+        .withEndpoint(Endpoints.UserDetailResource)
+        .callWithCallback(cb);
+    };
+
+    export interface UserUpdateParams {
+      Username: string;
+    }
+
+    export const update = (params: UserUpdateParams, cb: inkstone.Callback<User>) => {
+      newPutRequest()
+        .withEndpoint(Endpoints.UserDetailResource)
+        .withJson(params)
         .callWithCallback(cb);
     };
 

--- a/packages/@haiku/sdk-inkstone/src/services.ts
+++ b/packages/@haiku/sdk-inkstone/src/services.ts
@@ -25,7 +25,7 @@ export const enum Endpoints {
   OrganizationResourceCollection = '/organization',
 
   // User.
-  OrganizationUserDetail = '/user/detail',
+  UserDetailResource = '/user/detail',
 
   // Billing.
   BillingDescribe = '/billing',


### PR DESCRIPTION
PR 1 of 3 ([inkstone](https://github.com/HaikuTeam/inkstone/pull/50), [account](https://github.com/HaikuTeam/account/pull/2) PRs)

OK to merge.

Short review.

Summary of changes:

- Adds ability to self-update email via `@haiku/sdk-inkstone`.

Regressions to look for:

- None.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
