### PR TITLE
Fix snap crash

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -6,7 +6,8 @@
     ],
     "Fixes": [
       "Fixed an issue where ungrouping SVGs containing inline CSS caused a loss of styles.",
-      "Fixed an issue preventing ungrouped SVG elements from receiving display properties from the original SVG."
+      "Fixed an issue preventing ungrouped SVG elements from receiving display properties from the original SVG.",
+      "Fixed a rare crash triggered by quickly dragging or scaling elements on stage immediately after instantiation."
     ]
   }
 }

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -41,6 +41,7 @@ class ElementSelectionProxy extends BaseModel {
 
     // When representing multiple elements, we apply changes to our proxy properties
     this.reinitializeLayout()
+    this.cacheOrigins()
 
     // Allows transforms to be recalled on demand, e.g. during Alt+drag
     this.transformCache = new TransformCache(this)


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes [Uncaught TypeError: Cannot read property 'groupOrigin' of undefined](https://app.asana.com/0/785272717735380/803720498732764/f).

Regressions to look for:

- None are expected, but PR'ing so @zackbrown can confirm this is fine.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`
