### PR TITLE
Refactor: Use state machine to switch between dashboard/loader/editor

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -520,8 +520,10 @@ export default class Creator extends React.Component {
 
   // Controls viewToDisplay state machine
   setViewToDisplay (viewToDisplay, cb) {
-    // In the future, we can create hooks here. e.g. onProjectLaunching
-    mixpanel.haikuTrack(`creator:set-view-to-display:${viewToDisplay}`);
+    if (this.state.viewToDisplay !== viewToDisplay) {
+      // In the future, we can create hooks here. e.g. onProjectLaunching
+      mixpanel.haikuTrack(`creator:set-view-to-display:${viewToDisplay}`);
+    }
     return this.setState({viewToDisplay}, cb);
   }
 
@@ -900,7 +902,7 @@ export default class Creator extends React.Component {
         if (this.state.projectModel) {
           this.teardownMaster({shouldFinishTour: false});
         } else {
-          this.setViewToDisplay(DASHBOARD)
+          this.setViewToDisplay(DASHBOARD);
         }
 
         // Put it at the bottom of the event loop
@@ -1631,10 +1633,7 @@ export default class Creator extends React.Component {
     // Redundant with a future call, but ensures we will show the loading spinner ASAP.
     this.setState({tearingDown: true});
     this.user.load().then(({user, organization}) => {
-      this.setState({
-        readyForAuth: true,
-        isUserAuthenticated: user && organization,
-      });
+      this.setState({readyForAuth: true});
       this.teardownMaster({shouldFinishTour: true});
       ipcRenderer.send('topmenu:update', {subComponents: [], isProjectOpen: false});
     });


### PR DESCRIPTION
OK to merge.

When doing https://app.asana.com/0/785272717735380/802753785269501, I spotted some state duplication/overlap that could be simplified. I went for it, as a fun exercise for holiday ahhahahahah

The refactoring uses a state machine (`userDisplay` state) instead of states `dashboardVisible, doShowProjectLoader, projectLaunching`. The state `isUserAuthenticated` was kind of redundant in relation to 'username' state, so it was also refactored and `INTRO` state was created. 

What do you think about this refactor? I would be happy anyway if you want to cherry pick only https://github.com/HaikuTeam/mono/pull/780/commits/051533ab353c959de87bb0f0cc978f5fc1084575 

Any suggestions for renaming `userDisplay`? I didn't like the name

Regressions to look for:

- Initialization breakage (e.g. not going from intro to dashboard)

Completed checkin tasks:
- [x] Did manual testing of interrelated functionality
