### PR TITLE
feat: add a link to the user profile in the publish modal

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -2,7 +2,8 @@
   "date": "September 10, 2018",
   "sections": {
     "What's new": [
-      "You can now change the email address you use to sign in at [account.haiku.ai](https://account.haiku.ai/)."
+      "You can now change the email address you use to sign in at [account.haiku.ai](https://account.haiku.ai/).",
+      "You can now find a link to your public profile when publishing a public project."
     ],
     "Fixes": [
       "Fixed bug that could cause some subcomponents' overridden states not to be rendered while editing.",

--- a/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ProjectShareDetails.tsx
@@ -3,6 +3,7 @@ import {shell} from 'electron';
 import * as os from 'os';
 import * as React from 'react';
 import Palette from '../../Palette';
+import {ExternalLink} from '../ExternalLink';
 import ExternalLinkIconSVG from '../icons/ExternalLinkIconSVG';
 import {TooltipBasic} from '../TooltipBasic';
 import {LinkHolster} from './LinkHolster';
@@ -132,6 +133,10 @@ const STYLES = {
     backgroundColor: 'transparent',
     border: '1px solid ' + Palette.LIGHT_BLUE,
   },
+  externalLink: {
+    color: Palette.BLUE,
+    cursor: 'pointer',
+  },
 } as React.CSSProperties;
 
 export interface ProjectShareDetailsProps {
@@ -148,6 +153,7 @@ export interface ProjectShareDetailsProps {
   privateProjectCount: number;
   privateProjectLimit: number;
   hasError: boolean;
+  organizationName: string;
 }
 
 export interface ProjectShareDetailsStates {
@@ -191,6 +197,13 @@ export class ProjectShareDetails extends React.PureComponent<ProjectShareDetails
 
   private explorePro = () => {
     this.props.explorePro('publish-modal-toggle');
+  };
+
+  private trackPublicProfileClick = () => {
+    this.props.mixpanel.haikuTrack('install-options', {
+      from: 'app',
+      event: 'open-public-profile',
+    });
   };
 
   render () {
@@ -279,9 +292,21 @@ export class ProjectShareDetails extends React.PureComponent<ProjectShareDetails
                 !this.props.isPublic && <span>with the link&nbsp;</span>
               }
               <strong>can view and install</strong> your project&nbsp;
-              {
-                this.props.isPublic && <span><br />from your public profile</span> /*TODO: link to public profile */
-              }
+              {this.props.isPublic && (
+                <span>
+                  <br />
+                  from your{' '}
+                  <ExternalLink
+                    style={STYLES.externalLink}
+                    href={`https://share.haiku.ai/u/${
+                      this.props.organizationName
+                    }`}
+                    onClick={this.trackPublicProfileClick}
+                  >
+                    public profile
+                  </ExternalLink>
+                </span>
+              )}
             </p>
           </div>
         </div>

--- a/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/PublishStyles.ts
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/PublishStyles.ts
@@ -2,7 +2,7 @@ import * as Color from 'color';
 import * as React from 'react';
 import Palette from '../../../Palette';
 
-export const PUBLISH_SHARED = {
+export const PUBLISH_SHARED: React.CSSProperties = {
   codebox: {
     color: Palette.ROCK,
     userSelect: 'all',
@@ -23,11 +23,10 @@ export const PUBLISH_SHARED = {
     lineHeight: '18px',
     fontWeight: 'bold',
     fontSize: '11px',
-  } as React.CSSProperties,
+  },
   block: {
     display: 'inline-block',
     verticalAlign: 'top',
-    // fontSize: 14,
     width: '100%',
   },
   nav: {
@@ -56,7 +55,7 @@ export const PUBLISH_SHARED = {
     ':hover': {
       color: Color(Palette.ROCK).fade(0.3),
     },
-  } as React.CSSProperties,
+  },
   active: {
     fontWeight: 'bold',
     color: Palette.ROCK,
@@ -71,7 +70,7 @@ export const PUBLISH_SHARED = {
     MozUserSelect: 'all',
     WebkitUserSelect: 'all',
     userSelect: 'all',
-  } as React.CSSProperties,
+  },
   instructionsRow: {
     width: '100%',
     marginBottom: '15px',

--- a/packages/haiku-ui-common/src/react/ShareModal/index.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/index.tsx
@@ -171,6 +171,7 @@ export class ShareModal extends React.Component<ShareModalProps, ShareModalState
             privateProjectCount={this.props.privateProjectCount}
             privateProjectLimit={this.props.privateProjectLimit}
             hasError={hasError}
+            organizationName={organizationName}
           />
         </ModalHeader>
 


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

I found this TODO in a code comment while doing other stuff and I couldn't resist, this adds a link to the user profile page in the Publish UI

<img width="237" alt="screen shot 2018-09-04 at 3 31 48 pm" src="https://user-images.githubusercontent.com/4419992/45050940-ef1bfe80-b058-11e8-9bb8-2b232ee86c0b.png">

Regressions to look for:

- None

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [x] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
