### PR TITLE
fix: use the correct variable name

### DIFF
--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1393,7 +1393,7 @@ class Timeline extends React.Component {
       return;
     }
 
-    this.getActiveComponent().getCurrentTimeline().seek(newFrame);
+    this.getActiveComponent().getCurrentTimeline().seek(frameX);
   }
 
   mouseUpListener () {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes ['Crash while editing Rotation Y field'](https://app.asana.com/0/792819786955677/805775560714539).

Please note that this bug is a leftover of retiring the NativeTimelineScroll experiment, and fortunately has not affected prod

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
