### PR TITLE
Restore directly selected elements on undo/redo (801712328420396)

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -13,7 +13,8 @@
       "Fixed a rare crash triggered by quickly dragging or scaling elements on stage immediately after instantiation.",
       "Fixed an issue where the library won't show the buttons to create design assets if you have a component defined.",
       "Fixed an issue where sometimes a published project might show the wrong version.",
-      "Fixed a bug causing the Frame Actions Editor to display the wrong title."
+      "Fixed a bug causing the Frame Actions Editor to display the wrong title.",
+      "Keep element direct selection on undo/redo"
     ]
   }
 }

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -958,10 +958,21 @@ export class Glass extends React.Component {
   handleUndo (payload) {
     if (this.project) {
       mixpanel.haikuTrack('creator:glass:undo');
-      Element.unselectAllElements({component: this.getActiveComponent()}, {from: 'glass'});
+      const directlySelectedComponentId = Element.directlySelected && Element.directlySelected.componentId;
+      const component = this.getActiveComponent();
+      Element.unselectAllElements({component}, {from: 'glass'});
       this.project.undo({}, {from: 'glass'}, () => {
         // Important: purge the element selection proxy so that our box points can be reestablished.
         ElementSelectionProxy.purge();
+
+        // Restore directly selected element if it still exists
+        if (!directlySelectedComponentId) {
+          return;
+        }
+        const selectedElement = component.findElementByComponentId(directlySelectedComponentId);
+        if (selectedElement) {
+          Element.directlySelected = selectedElement.getHaikuElement();
+        }
       });
     }
   }
@@ -969,10 +980,21 @@ export class Glass extends React.Component {
   handleRedo (payload) {
     if (this.project) {
       mixpanel.haikuTrack('creator:glass:redo');
-      Element.unselectAllElements({component: this.getActiveComponent()}, {from: 'glass'});
+      const directlySelectedComponentId = Element.directlySelected && Element.directlySelected.componentId;
+      const component = this.getActiveComponent();
+      Element.unselectAllElements({component}, {from: 'glass'});
       this.project.redo({}, {from: 'glass'}, () => {
         // Important: purge the element selection proxy so that our box points can be reestablished.
         ElementSelectionProxy.purge();
+
+        // Restore directly selected element if it still exists
+        if (!directlySelectedComponentId) {
+          return;
+        }
+        const selectedElement = component.findElementByComponentId(directlySelectedComponentId);
+        if (selectedElement) {
+          Element.directlySelected = selectedElement.getHaikuElement();
+        }
       });
     }
   }


### PR DESCRIPTION
OK to merge.

About the review given on another PR, I tested undo independently and didn't catch that mentioned case of deleting. Anyway, thanks @stristr for review, it is more robust now.

Summary of changes:

Regressions to look for:

- Any direct selection bug on undo/redo

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`
