### PR TITLE
fix: correct a typo in props causing frame actions to have the wrong title

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -11,7 +11,8 @@
       "Fixed an issue where ungrouping SVGs containing inline CSS caused a loss of styles.",
       "Fixed an issue preventing ungrouped SVG elements from receiving display properties from the original SVG.",
       "Fixed a rare crash triggered by quickly dragging or scaling elements on stage immediately after instantiation.",
-      "Fixed an issue where the library won't show the buttons to create design assets if you have a component defined."
+      "Fixed an issue where the library won't show the buttons to create design assets if you have a component defined.",
+      "Fixed a bug causing the Frame Actions Editor to display the wrong title"
     ]
   }
 }

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
@@ -326,7 +326,7 @@ class EventHandlerEditor extends React.PureComponent {
             <ElementTitle
               element={this.props.element}
               data-tooltip={true}
-              aria-label={
+              title={
                 isNumeric(this.props.options.frame)
                   ? `Frame ${this.props.options.frame}`
                   : null

--- a/packages/haiku-timeline/src/components/FrameAction.js
+++ b/packages/haiku-timeline/src/components/FrameAction.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as Radium from 'radium';
 import Bolt from 'haiku-ui-common/lib/react/icons/Bolt';
 import Palette from 'haiku-ui-common/lib/Palette';
 
@@ -41,44 +40,49 @@ const HOVER_INTENT_TIME = 190;
 class FrameAction extends React.Component {
   constructor () {
     super();
-    this.openFrameActionsEditor = this.openFrameActionsEditor.bind(this);
     this.timeout = null;
     this.state = {
       achievedHover: false,
     };
   }
 
-  setHover () {
+  setHover = () => {
     if (!this.timeout) {
       this.timeout = setTimeout(() => {
         this.timeout = null;
         this.setState({achievedHover: true});
       }, HOVER_INTENT_TIME);
     }
-  }
+  };
 
-  unsetTimeout () {
+  unsetTimeout = () => {
     this.setState({achievedHover: false});
 
     if (this.timeout) {
       clearTimeout(this.timeout);
       this.timeout = null;
     }
-  }
+  };
 
   componentWillUnmount () {
     this.unsetTimeout();
   }
 
-  openFrameActionsEditor (e) {
-    e.stopPropagation();
+  openFrameActionsEditor = (clickEvent) => {
+    clickEvent.stopPropagation();
     this.props.onShowFrameActionsEditor(this.props.frame);
-  }
+  };
+
+  openFrameActionsEditorIfAchievedHover = (event) => {
+    if (this.state.achievedHover) {
+      this.openFrameActionsEditor(event);
+    }
+  };
 
   render () {
     if (this.props.hasActions) {
       return (
-        <div onMouseDown={(e) => this.openFrameActionsEditor(e)} style={STYLE.base}>
+        <div onMouseDown={this.openFrameActionsEditor} style={STYLE.base}>
           <Bolt color={Palette.LIGHT_BLUE} />
         </div>
       );
@@ -87,17 +91,11 @@ class FrameAction extends React.Component {
     return (
       <div
         className="frame-action-box"
-        onMouseOver={() => this.setHover()}
-        onMouseLeave={() => this.unsetTimeout()}
-        onMouseDown={(event) => {
-          if (this.state.achievedHover) {
-            this.openFrameActionsEditor(event);
-          }
-        }
-        }
-        style={[STYLE.base, STYLE.addAction, this.state.achievedHover && STYLE.show]}>
-        <div
-          style={STYLE.plus}>
+        onMouseOver={this.setHover}
+        onMouseLeave={this.unsetTimeout}
+        onMouseDown={this.openFrameActionsEditorIfAchievedHover}
+        style={{...STYLE.base, ...STYLE.addAction, ...(this.state.achievedHover && STYLE.show)}}>
+        <div style={STYLE.plus}>
           +
         </div>
       </div>
@@ -110,4 +108,4 @@ FrameAction.propTypes = {
   onShowFrameActionsEditor: React.PropTypes.func.isRequired,
 };
 
-export default Radium(FrameAction);
+export default FrameAction;


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

An user reported in Intercom today that the Frame Actions Editor has `Main` as the title of the modal instead of `Frame N` (N ϵ ℕ 😂).

I also did a bit of refactor in the `FrameAction` component.

Regressions to look for:

- None

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
