### PR TITLE
feat: add the ability to tween strings that look like percents.

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -3,7 +3,8 @@
   "sections": {
     "What's new": [
       "You can now change the email address you use to sign in at [account.haiku.ai](https://account.haiku.ai/).",
-      "You can now find a link to your public profile when publishing a public project."
+      "You can now find a link to your public profile when publishing a public project.",
+      "Added the ability to tween percent values (e.g. `\"25%\"` to `\"50%\"`)."
     ],
     "Fixes": [
       "Creating a project with the same name as a previously deleted project no longer shows shadow copies of the old project's design files in the asset library.",

--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -2352,7 +2352,7 @@ const reduceNodeMemoryChildren = (children, out = [], doIncludeRepeatees = false
   }
 
   return out;
-}
+};
 
 const assembleNodeMemoryChildren = (node: BytecodeNode, subtree) => {
   if (subtree) {

--- a/packages/@haiku/core/src/StateTransitionManager.ts
+++ b/packages/@haiku/core/src/StateTransitionManager.ts
@@ -1,6 +1,6 @@
 import {BytecodeStateType, Curve, CurveDefinition, IHaikuComponent} from './api';
 import HaikuClock from './HaikuClock';
-import Interpolate from './Interpolate';
+import {interpolate} from './Interpolate';
 
 export interface StateTransitionParameters {
   curve: CurveDefinition;
@@ -188,7 +188,7 @@ export default class StateTransitionManager {
           // Calculate interpolated states.
           Object.assign(
             interpolatedStates,
-            Interpolate.interpolate(
+            interpolate(
               currentTime, transition.transitionParameter.curve, transition.startTime,
               transition.endTime, transition.transitionStart, transition.transitionEnd,
             ),

--- a/packages/@haiku/core/src/Transitions.ts
+++ b/packages/@haiku/core/src/Transitions.ts
@@ -3,7 +3,7 @@
  */
 import {BytecodeTimelineProperty} from './api';
 import {getSortedKeyframes} from './helpers/KeyframeUtils';
-import Interpolate from './Interpolate';
+import {interpolate} from './Interpolate';
 
 // 0:    { value: { ... } }
 // 2500: { value: { ... } }
@@ -61,7 +61,7 @@ const getTransitionValue = (currentKeyframe, currentTransition, nextKeyframe, ne
     return currentValue;
   } // We have gone past the final transition
 
-  const finalValue = Interpolate.interpolate(
+  const finalValue = interpolate(
     nowValue,
     currentTransition.curve,
     currentKeyframe,

--- a/packages/@haiku/core/test/unit/Interpolate.test.ts
+++ b/packages/@haiku/core/test/unit/Interpolate.test.ts
@@ -1,0 +1,106 @@
+import {Curve} from '@core/api';
+import {interpolate} from '@core/Interpolate';
+import * as tape from 'tape';
+
+tape('Interpolate', (suite) => {
+  suite.test('number', (test) => {
+    test.is(interpolate(0, Curve.Linear, 0, 1, 0, 1), 0);
+    test.is(interpolate(0.5, Curve.Linear, 0, 1, 0, 1), 0.5);
+    test.is(interpolate(1, Curve.Linear, 0, 1, 0, 1), 1);
+    test.end();
+  });
+
+  suite.test('array', (test) => {
+    test.deepEqual(interpolate(0, Curve.Linear, 0, 1, [0, 10], [1, 11]), [0, 10]);
+    test.deepEqual(interpolate(0.5, Curve.Linear, 0, 1, [0, 10], [1, 11]), [0.5, 10.5]);
+    test.deepEqual(interpolate(1, Curve.Linear, 0, 1, [0, 10], [1, 11]), [1, 11]);
+    test.end();
+  });
+
+  suite.test('object', (test) => {
+    test.deepEqual(interpolate(0, Curve.Linear, 0, 1, {a: 0, b: 10}, {a: 1, b: 11}), {a: 0, b: 10});
+    test.deepEqual(interpolate(0.5, Curve.Linear, 0, 1, {a: 0, b: 10}, {a: 1, b: 11}), {a: 0.5, b: 10.5});
+    test.deepEqual(interpolate(1, Curve.Linear, 0, 1, {a: 0, b: 10}, {a: 1, b: 11}), {a: 1, b: 11});
+    test.end();
+  });
+
+  suite.test('untweenable string', (test) => {
+    test.is(interpolate(0, Curve.Linear, 0, 1, 'foo', 'bar'), 'foo');
+    test.is(interpolate(0.5, Curve.Linear, 0, 1, 'foo', 'bar'), 'foo');
+    test.is(interpolate(1, Curve.Linear, 0, 1, 'foo', 'bar'), 'foo');
+    test.end();
+  });
+
+  suite.test('tweenable string', (test) => {
+    test.is(interpolate(0, Curve.Linear, 0, 1, '0%', '100%'), '0%');
+    test.is(interpolate(0.5, Curve.Linear, 0, 1, '0%', '100%'), '50%');
+    test.is(interpolate(1, Curve.Linear, 0, 1, '0%', '100%'), '100%');
+    test.end();
+  });
+
+  suite.test('e2e', (test) => {
+    test.deepEqual(
+      interpolate(
+        0,
+        Curve.Linear,
+        0,
+        1,
+        {
+          a: [0, 10],
+          b: '0%',
+        },
+        {
+          a: [1, 11],
+          b: '100%',
+        },
+      ),
+      {
+        a: [0, 10],
+        b: '0%',
+      },
+    );
+    test.deepEqual(
+      interpolate(
+        0.5,
+        Curve.Linear,
+        0,
+        1,
+        {
+          a: [0, 10],
+          b: '0%',
+        },
+        {
+          a: [1, 11],
+          b: '100%',
+        },
+      ),
+      {
+        a: [0.5, 10.5],
+        b: '50%',
+      },
+    );
+    test.deepEqual(
+      interpolate(
+        1,
+        Curve.Linear,
+        0,
+        1,
+        {
+          a: [0, 10],
+          b: '0%',
+        },
+        {
+          a: [1, 11],
+          b: '100%',
+        },
+      ),
+      {
+        a: [1, 11],
+        b: '100%',
+      },
+    );
+    test.end();
+  });
+
+  suite.end();
+});


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Solves [We should auto-tween strings that look like percents](https://app.asana.com/0/792819786955677/794177021911777/f).

Regressions to look for:

- None.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test for existing and modified functionality
- [x] Updated `changelog/public/latest.json`
