### PR TITLE
fix: restore log view.

### DIFF
--- a/HaikuHelper.js
+++ b/HaikuHelper.js
@@ -32,6 +32,7 @@ function go () {
     haiku.mode = 'creator';
   }
 
+  logger.view = 'master';
   logger.info(`Haiku plumbing ${process.env.HAIKU_RELEASE_VERSION} on ${process.env.NODE_ENV} launching`);
   logger.info('args:', args);
   logger.info('flags:', flags);
@@ -54,31 +55,5 @@ function go () {
     plumbing.launch(haiku, () => {
       logger.info('Haiku plumbing running');
     });
-  });
-}
-
-function startEmUp (plumbing, haiku, cb) {
-  delete haiku.folder;
-  plumbing.launch(haiku, () => {
-    let folder = global.process.env.HAIKU_PROJECT_FOLDER;
-    if (folder) {
-      if (folder[0] !== path.sep) {
-        folder = path.join(global.process.cwd(), folder);
-      }
-
-      plumbing.bootstrapProject(null, {projectPath: folder}, null, null, (err) => {
-        if (err) {
-          throw err;
-        }
-        plumbing.startProject(null, folder, (err) => {
-          if (err) {
-            throw err;
-          }
-          cb(null, folder);
-        });
-      });
-    } else {
-      cb(null);
-    }
   });
 }

--- a/packages/haiku-creator/index.html
+++ b/packages/haiku-creator/index.html
@@ -23,6 +23,7 @@
   </script>
   <script src="../../node_modules/raven-js/dist/raven.js"></script>
   <script>
+    require('../../node_modules/haiku-serialization/src/utils/LoggerInstance').view = 'creator';
     require('./lib/entry')
   </script>
 <script>

--- a/packages/haiku-creator/src/electron.js
+++ b/packages/haiku-creator/src/electron.js
@@ -118,6 +118,7 @@ if (!haiku.plumbing.url) {
 }
 
 function createWindow () {
+  logger.view = 'main';
   mixpanel.haikuTrack('app:initialize');
 
   browserWindow = new BrowserWindow({

--- a/packages/haiku-glass/index.html
+++ b/packages/haiku-glass/index.html
@@ -28,6 +28,7 @@
     <div id="root"></div>
     <script src="../../node_modules/raven-js/dist/raven.js"></script>
     <script>
+      require('../../node_modules/haiku-serialization/src/utils/LoggerInstance').view = 'glass';
       require('./lib/react/index')
     </script>
   </body>

--- a/packages/haiku-serialization/src/utils/Logger.js
+++ b/packages/haiku-serialization/src/utils/Logger.js
@@ -125,7 +125,7 @@ class Logger extends EventEmitter {
       transports
     })
 
-    // Hook to allow Monkey.js to configure the view prefix from which we log
+    // Hook to allow consumers to configure the view prefix from which we log
     this.view = '?'
   }
 

--- a/packages/haiku-timeline/index.html
+++ b/packages/haiku-timeline/index.html
@@ -20,6 +20,7 @@
     </script>
     <script src="../../node_modules/raven-js/dist/raven.js"></script>
     <script>
+      require('../../node_modules/haiku-serialization/src/utils/LoggerInstance').view = 'timeline';
       require('./lib/index')
     </script>
   </body>


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- I'm not sure how this was done originally, but it looks like our last two builds have ripped the originating "view" of log messages out of user log files, which makes it much harder to debug user-reported issues based on logs/carbonite/etc. There may be a more elegant way of doing this, but what's here definitely works fine.

Regressions to look for:

- None expected.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality