### PR TITLE
fix: use the correct logic to conglomerate components

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -18,7 +18,8 @@
       "Fixed an issue where sometimes a published project might show the wrong version.",
       "Fixed a bug causing the Frame Actions Editor to display the wrong title.",
       "Fixed an issue where externally hosted image files were not included in Lottie exports.",
-      "Fixed an issue where adding keyframes on an SVG path property without a tween might result in an empty Lottie export."
+      "Fixed an issue where adding keyframes on an SVG path property without a tween might result in an empty Lottie export.",
+      "Improved the logic to create new components."
     ]
   }
 }

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -564,8 +564,8 @@ class StageTitleBar extends React.Component {
       });
     } else {
       this.props.conglomerateComponent({
-        isBlankComponent: true,
-        skipInstantiateInHost: true,
+        isBlankComponent: proxy.selection.length === 0,
+        skipInstantiateInHost: proxy.selection.length === 0,
       });
     }
   }

--- a/packages/haiku-creator/src/react/components/library/AssetItem.js
+++ b/packages/haiku-creator/src/react/components/library/AssetItem.js
@@ -232,7 +232,12 @@ class AssetItem extends React.Component {
       items.push({
         label: 'Create Component',
         icon: ComponentIconSVG,
-        onClick: this.props.conglomerateComponent,
+        onClick: () => {
+          this.props.conglomerateComponent({
+            isBlankComponent: true,
+            skipInstantiateInHost: true,
+          });
+        },
       });
     }
 

--- a/packages/haiku-creator/src/react/components/library/FileImporter.js
+++ b/packages/haiku-creator/src/react/components/library/FileImporter.js
@@ -72,6 +72,13 @@ class FileImporter extends React.PureComponent {
     }
   }
 
+  conglomerateComponent = () => {
+    this.props.conglomerateComponent({
+      isBlankComponent: true,
+      skipInstantiateInHost: true,
+    });
+  };
+
   get popoverBody () {
     return (
       <div
@@ -93,7 +100,7 @@ class FileImporter extends React.PureComponent {
         <div style={STYLES.popover.item}>
           <div
             style={STYLES.popover.text}
-            onClick={this.props.conglomerateComponent}
+            onClick={this.conglomerateComponent}
           >
             Create Component
           </div>

--- a/packages/haiku-glass/src/react/modals/CreateComponentModal.js
+++ b/packages/haiku-glass/src/react/modals/CreateComponentModal.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Modal, {MODAL_STYLES} from '../Modal';
 
-const DEFAULT_COMPONENT_NAME = 'untitled';
+const DEFAULT_COMPONENT_NAME = 'Name Component';
 const INITIAL_INVALIDITY_REASON = 'Use only lowercase letters and numbers';
 
 export default class CreateComponentModal extends React.Component {
@@ -61,7 +61,7 @@ export default class CreateComponentModal extends React.Component {
         isOpen={this.props.isOpen}>
         <div
           style={MODAL_STYLES.wrapper}>
-          <div style={MODAL_STYLES.title}>Name your component</div>
+          <div style={MODAL_STYLES.title}>{this.props.options.isBlankComponent ? 'Create component' : 'Create Component from selection'}</div>
           <input
             type="text"
             autoFocus={true}


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Intended new logic is:

1. The + button next to the component tabs => _always create a blank component_
2. The context menu in the Library => _always create a blank component_
3. The component "cube" button in the top bar => _if selection : create component from selection; else: create blank component_
4. The RCM on stage => _create component from selection_
5. Right clicking on the 'Components' folder in the library => _create
blank component_

Also, update the component modal according to Taylor suggestions:

![image](https://user-images.githubusercontent.com/4419992/45243972-2e9e5100-b2cc-11e8-9ea4-5f8bb2386d4a.png)


Regressions to look for:

- Not aware of any, but please watch out for all possible ways to create a component

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
