### PR TITLE
Close only focused Dev Tools on ctrl+w (785191228678645)

### DIFF
--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -590,18 +590,15 @@ export class Glass extends React.Component {
     this.addEmitterListener(this.props.websocket, 'relay', (message) => {
       logger.info('relay received', message.name, 'from', message.from);
 
-      // Don't take action if the user is within the dev tools window
-      if (remote.getCurrentWebContents().isDevToolsFocused()) {
-        return;
-      }
-
       switch (message.name) {
         case 'global-menu:open-dev-tools':
           remote.getCurrentWebContents().openDevTools();
           break;
 
         case 'global-menu:close-dev-tools':
-          remote.getCurrentWebContents().closeDevTools();
+          if (remote.getCurrentWebContents().isDevToolsFocused()) {
+            remote.getCurrentWebContents().closeDevTools();
+          }
           break;
 
         case 'global-menu:zoom-in':


### PR DESCRIPTION
OK to merge.

By description https://app.asana.com/0/792819786955677/785191228678645, I understand that only Dev Tools from focused webview should be closed on ctrl+w. (At least for me, it makes easier to close unwanted dev tools)

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality