### PR TITLE
fix: truncate component names using CSS

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -21,7 +21,8 @@
       "Fixed an issue where adding keyframes on an SVG path property without a tween might result in an empty Lottie export.",
       "Improved the logic to create new components.",
       "Improved accuracy of marquee selection in Timeline.",
-      "Fixed crashes during marquee selection in Timeline."
+      "Fixed crashes during marquee selection in Timeline.",
+      "Fixed layout issues with long component names in Timeline."
     ]
   }
 }

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -182,7 +182,7 @@ export default class ComponentHeadingRow extends React.Component {
           <div
             className="component-heading-row-inner no-select"
             style={{
-              width: (this.props.row.isExpanded()) ? propertiesPixelWidth - 200 : propertiesPixelWidth,
+              width: this.props.row.isExpanded() ? (this.props.row.isRootRow() ? propertiesPixelWidth - 160 : propertiesPixelWidth - 200) : propertiesPixelWidth,
               height: 'inherit',
               cursor: 'pointer',
               backgroundColor: 'transparent',

--- a/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRowHeading.js
@@ -117,6 +117,9 @@ export default class ComponentHeadingRowHeading extends React.Component {
             style={{
               display: 'inline-block',
               transform: 'translateY(1px)',
+              textOverflow: 'ellipsis',
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
             }}
           >
             <span
@@ -125,12 +128,12 @@ export default class ComponentHeadingRowHeading extends React.Component {
                 marginLeft: 8,
                 marginRight: 4,
                 display: 'inline-block',
-                transform: 'translateY(4px)',
+                verticalAlign: 'sub',
               }}
             >
               <ComponentIconSVG />
             </span>
-            {trunc(this.state.rowTitle, 12)}
+            {this.state.rowTitle}
           </div>
         ) : (
           <span
@@ -208,14 +211,6 @@ export default class ComponentHeadingRowHeading extends React.Component {
     );
   }
 }
-
-const trunc = (str, len) => {
-  if (str.length <= len) {
-    return str;
-  }
-
-  return `${str.slice(0, len)}…`;
-};
 
 ComponentHeadingRowHeading.propTypes = {
   row: React.PropTypes.object.isRequired,


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Very quick fix for ["Long component names not truncating appropriately on timeline rows"](https://app.asana.com/0/803720498732761/812439579907618)

Regressions to look for:

- Not aware of any

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
