### PR TITLE
fix: hide drag handle for expanded timeline rows

### DIFF
--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -159,12 +159,12 @@ export default class ComponentHeadingRow extends React.Component {
           position: 'sticky',
           top: 0,
           left: 0,
-          paddingLeft: this.props.row.isRootRow() ? (this.props.isExpanded ? 0 : 7) : (this.props.isExpanded ? 10 : 15),
+          paddingLeft: this.props.row.isRootRow() ? (this.props.isExpanded ? 0 : 7) : (this.props.isExpanded ? 35 : 15),
           width: propertiesPixelWidth,
           backgroundColor: this.props.isExpanded ? 'transparent' : Palette.LIGHT_GRAY,
           zIndex: zIndex.headingRow.base,
         }}>
-          {!this.props.row.isRootRow() &&
+          {!this.props.row.isRootRow() && !this.props.isExpanded &&
             <div
               style={{
                 marginTop: 3,


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Transient fix for ["Reordering elements in timeline doesn't work when row is expanded"](https://app.asana.com/0/803720498732761/801712328420397) by disabling the drag handle when the row is expanded.

Details of why we choose this can be found in the task comments, but as a summary:

Dragging expanding rows _works_, but it can become cumbersome if the row has a considerable height because of how our library operates. We explored a couple of escape hatches:

- We can't auto-collapse the row before is dragged because that interaction causes [undesired UX scenarios](https://gfycat.com/gifs/detail/UltimateMediocreHeterodontosaurus)
- We can't auto-collapse the row after is dragged because our library doesn't support changing the dimensions of the dragged elements when the drag has started.
- We can't use the mouse position instead of the center of gravity of the dragged element because our library doesn't support that (for now)

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
