### PR TITLE
Roberto'n'Sasha timeline perf fun

### DIFF
--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -258,6 +258,7 @@ class Timeline extends BaseModel {
 
         if (this.getRepeat()) {
           this.seek(0)
+          this._stopwatch = Date.now()
         } else {
           this.seekAndPause(frameInfo.maxf)
         }

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -258,7 +258,6 @@ class Timeline extends BaseModel {
 
         if (this.getRepeat()) {
           this.seek(0)
-          this.play()
         } else {
           this.seekAndPause(frameInfo.maxf)
         }


### PR DESCRIPTION
OK to merge after @matthewtoast reviews.

Short review.

Summary of changes:

- Removes perf-destroying call to `Timeline#play` on loop in `Timeline#update`. This seemed to significantly contribute to gradual slowdown of timeline scrubbing (and the app overall) while playback was active, because `play()` calls `update()` and `update()` calls `play()`.

Regressions to look for:

- None expected (we tested all over). But want @matthewtoast to review.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality