### PR TITLE
3-DPO

### DIFF
--- a/packages/@haiku/core/src/HaikuContext.ts
+++ b/packages/@haiku/core/src/HaikuContext.ts
@@ -283,21 +283,23 @@ export default class HaikuContext extends HaikuBase implements IHaikuContext {
       if (this.config.position && root.style.position !== this.config.position) {
         root.style.position = this.config.position;
       }
+    }
 
+    if (this.mount) {
       if (this.config.overflow) {
-        root.style.overflow = this.config.overflow;
+        this.mount.style.overflow = this.config.overflow;
       } else {
         if (
           this.config.overflowX &&
-          root.style.overflowX !== this.config.overflowX
+          this.mount.style.overflowX !== this.config.overflowX
         ) {
-          root.style.overflowX = this.config.overflowX;
+          this.mount.style.overflowX = this.config.overflowX;
         }
         if (
           this.config.overflowY &&
-          root.style.overflowY !== this.config.overflowY
+          this.mount.style.overflowY !== this.config.overflowY
         ) {
-          root.style.overflowY = this.config.overflowY;
+          this.mount.style.overflowY = this.config.overflowY;
         }
       }
     }

--- a/packages/@haiku/core/src/Migration.ts
+++ b/packages/@haiku/core/src/Migration.ts
@@ -161,9 +161,7 @@ export const runMigrationsPrePhase = (component: IHaikuComponent, options: Migra
   const referencesToUpdate = {};
 
   if (bytecode.template) {
-    // y-overflow + preserve-3d leads to various rendering bugs, so for now, disable when overflow is available.
-    // #FIXME
-    const autoPreserve3d = component.config.preserve3d === 'auto' && component.config.overflowY !== 'visible';
+    const autoPreserve3d = component.config.preserve3d === 'auto';
 
     visitManaTree(
       '0',

--- a/packages/haiku-serialization/src/bll/Property.js
+++ b/packages/haiku-serialization/src/bll/Property.js
@@ -152,8 +152,6 @@ Property.HUMANIZED_PROP_NAMES = {
   'translation.z': 'Position Z',
   'sizeAbsolute.x': 'Size X',
   'sizeAbsolute.y': 'Size Y',
-  'style.overflowX': 'Overflow X',
-  'style.overflowY': 'Overflow Y',
   'origin.x': 'Origin X',
   'origin.y': 'Origin Y'
 }
@@ -678,8 +676,8 @@ Property.DISPLAY_RULES = {
   'style.display': {jit: [NEVER], add: [NEVER]},
   'style.height': {jit: [NEVER], add: [NEVER]},
   'style.margin': {jit: [ALWAYS], add: [IF_CHANGED_FROM_PREPOPULATED_VALUE]},
-  'style.overflowX': {jit: [ALWAYS], add: [IF_CHANGED_FROM_PREPOPULATED_VALUE]},
-  'style.overflowY': {jit: [ALWAYS], add: [IF_CHANGED_FROM_PREPOPULATED_VALUE]},
+  'style.overflowX': {jit: [NEVER], add: [NEVER]},
+  'style.overflowY': {jit: [NEVER], add: [NEVER]},
   'style.padding': {jit: [ALWAYS], add: [IF_CHANGED_FROM_PREPOPULATED_VALUE]},
   'style.perspective': {jit: [ALWAYS], add: [NEVER]},
   'style.pointerEvents': {jit: [ALWAYS], add: [NEVER]},

--- a/packages/haiku-ui-common/src/helpers/humanizePropertyName.ts
+++ b/packages/haiku-ui-common/src/helpers/humanizePropertyName.ts
@@ -9,8 +9,6 @@ const HUMANIZED_PROP_NAMES = {
   'translation.z': 'Position Z',
   'sizeAbsolute.x': 'Size X',
   'sizeAbsolute.y': 'Size Y',
-  'style.overflowX': 'Overflow X',
-  'style.overflowY': 'Overflow Y',
 };
 
 export default function humanizePropertyName (propertyName: string) {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes [Hoist overflow: hidden from root node to mount](https://app.asana.com/0/803720498732761/776617977997483/f). You can still break auto-3d by messing with `style.overflow` on the root node in bytecode, but I generally hid overflow from JIT menus along with this change (really couldn't think of a good reason we need users to be able to change it, but please correct me if I'm wrong).

Regressions to look for:

- Any unexpected side effects related to `overflow: hidden`.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
