### PR TITLE
feat: allow timeline to handle pasting expressions if a row is selected

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -2,7 +2,7 @@
   "date": "September 17, 2018",
   "sections": {
     "What's new": [
-      "FIRST!"
+      "Now you can paste expressions or values into Timeline properties without having to open/focus the input."
     ],
     "Fixes": [
       "Snap lines now have a consistent thickness regardless of the artboard zoom level."

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -437,7 +437,7 @@ class Timeline extends React.Component {
           } else {
             // Delegate paste only if the user is not editing something here
             if (document.hasFocus()) {
-              if (!this.isTextInputFocused() && !this._isIntercomOpen) {
+              if (!this.isTextInputFocused() && !this._isIntercomOpen && !this.refs.expressionInput.willHandlePasteEvent()) {
                 this.props.websocket.send(relayable);
               }
             } else {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Implements [ux: pasting with property input selected, but not open to expression, should still paste in the clipboard contents.](https://app.asana.com/0/803720498732761/757672931655208), by allowing to paste in an expression the following kind of values:

- Valid values (`number`, `string`, etc)
- 'Single line' expressions, a la `= $user.mouse.x`
- Wrapped 'Multi line' expressions, a la:
```js
function ($user) {
  return $user.mouse.x
}
```
- 'Multi line' expresions, a la:

```js
const a = 1;
const b = 2;
return a + b;
```

There's a known gotcha related to the webviews losing focus: if the cursor is over the stage, this will simply not work, even if there is a row selected (ie. with the pink outline).

*edit*: one more comment, if the value the user is trying to paste is invalid for some reason, we will simply ignore it.

Regressions to look for:

- Copy/Paste is always messy. I think I implemented it in a safe way, but be on the watch.
- Are we properly handling all kind of trash that the user may paste?

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
