### PR TITLE
Do not crash timeline with out of spec bytecode transition

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -9,7 +9,8 @@
       "Snap lines now have a consistent thickness regardless of the artboard zoom level.",
       "Export options are now disabled outside of a project.",
       "User Menu -> Your Profile now points to the correct location.",
-      "Resolved a breaking change in Lottie Android 2.6.0 causing crashes."
+      "Resolved a breaking change in Lottie Android 2.6.0 causing crashes.",
+      "Fixed a crash caused by forking certain projects."
     ]
   }
 }

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -101,9 +101,14 @@ export default class TransitionBody extends React.Component {
       this.teardownKeyframeUpdateReceiver = keyframe.registerUpdateReceiver(this.props.id, (what) => {
         this.handleUpdate(what);
       });
-      this.teardownNextKeyframeUpdateReceiver = keyframe.next().registerUpdateReceiver(this.props.id, (what) => {
-        this.handleUpdate(what);
-      });
+      const nextKeyframe = keyframe.next();
+      if (nextKeyframe) {
+        this.teardownNextKeyframeUpdateReceiver = nextKeyframe.registerUpdateReceiver(this.props.id, (what) => {
+          this.handleUpdate(what);
+        });
+      } else {
+        this.teardownNextKeyframeUpdateReceiver = () => {};
+      }
     }
   }
 


### PR DESCRIPTION
OK to merge.

The attached project ( https://share.haiku.ai/u/taylor/booptroop/fork ) had an out of spec transition:
``` javascript
        "translation.x": {
          "0": { value: 329.5, edited: true },
          "400": { value: 315.5, edited: true, curve: "linear" },
          "933": { value: 390, edited: true, curve: "linear" }
        },
```
When TransitionBody was created for the second transition, it didn't have next keyframe, so it was crashing timeline. I've tested (Hey @roperzh can you do some testing as you know how to achieve timeline edge cases?),  and the user can edit the element transition without crash after this commit. 

Question: Should we warn the user about the non conformant bytecode?


Completed checkin tasks:
- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`
