### PR TITLE
fix: do not bind states that are already bound.

### DIFF
--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -864,9 +864,10 @@ export default class HaikuComponent extends HaikuElement implements IHaikuCompon
         continue;
       }
 
-      this._states[stateSpecName] = stateSpec.value;
-
-      this.defineSettableState(stateSpec, stateSpecName);
+      if (!this._states.hasOwnProperty(stateSpecName) || this.config.states.hasOwnProperty(stateSpecName)) {
+        this._states[stateSpecName] = stateSpec.value;
+        this.defineSettableState(stateSpec, stateSpecName);
+      }
     }
   }
 


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes @taylorpoe blocker Launch blocker: [Haiku's states (instantiated haiku in React) not working after react-app is built. Does work in react dev locally.](https://app.asana.com/0/803720498732761/821764549032368/f).

Regressions to look for:

- I think this is fine, but worth a peek by @matthewtoast. Basically, this change ensures we don't clobber states downstream of `assignConfig` if the state is already defined, unless the state is coming to us _from_ the config.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality