### PR TITLE
POC: direct selection bounding box love.

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -9,7 +9,8 @@
       "Snap lines now have a consistent thickness regardless of the artboard zoom level.",
       "Export options are now disabled outside of a project.",
       "User Menu -> Your Profile now points to the correct location.",
-      "Fixed a crash caused by forking certain projects."
+      "Fixed a crash caused by forking certain projects.",
+      "Shape layers now show the correct bounding box after morphing."
     ]
   }
 }

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -1197,6 +1197,7 @@ class ElementSelectionProxy extends BaseModel {
       this.component.project.getMetadata(),
       () => {
         this.clearAllRelatedCaches()
+        this.reinitializeLayout()
       }
     )
   }


### PR DESCRIPTION
WIP.

**Known issues** (I suspect these are all easy fixes):

 - Scale-snapping (not translation-snapping) goes nuts when the size of the element isn't what it's supposed to be.
 - Multi-select box is no longer correct if an element's size has changed.

Short review.

Summary of changes:

- POC for direct selection bounding box love handled entirely by `Element#getBoundingBoxPoints`. Result from Friday pair programming collaboration between @jonaias and @stristr. 

Regressions to look for:

- I am mostly concerned about perf (note inline TODO).

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`
