### PR TITLE
Improve to code editor save popup

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -9,7 +9,8 @@
       "Snap lines now have a consistent thickness regardless of the artboard zoom level.",
       "Export options are now disabled outside of a project.",
       "User Menu -> Your Profile now points to the correct location.",
-      "Fixed a crash caused by forking certain projects."
+      "Fixed a crash caused by forking certain projects.",
+      "Improve code editor save error popup"
     ]
   }
 }

--- a/packages/haiku-creator/src/react/components/CodeEditor/BytecodeErrorPopup.js
+++ b/packages/haiku-creator/src/react/components/CodeEditor/BytecodeErrorPopup.js
@@ -20,6 +20,13 @@ const STYLES = {
   modalBody: {
     padding: '20px',
   },
+  code: {
+    fontFamily: 'Fira Mono',
+    backgroundColor: Palette.SPECIAL_COAL,
+    overflow: 'auto',
+    fontSize: '13px',
+    padding: '4px',
+  },
 };
 
 class BytecodeErrorPopup extends React.Component {
@@ -30,17 +37,15 @@ class BytecodeErrorPopup extends React.Component {
     }
 
     const message = error.toString();
-    const relevantStack = error.stack.slice(
-      error.stack.indexOf(':') + 1,
-      error.stack.indexOf(message) + message.length,
-    );
-    return relevantStack.split('\n').map((errorLine, index) => {
-      if (index === 0) {
-        return <div key={`bep-${index}`}>Please fix syntax errors on line {errorLine} and try again.</div>;
-      }
-
-      return <pre key={`bep-${index}`}>{errorLine}</pre>;
-    });
+    const res = error.stack.match(/.*?:(.*?)\n([.|\S|\s]*)/);
+    if (res.length === 3 && res[1] && res[2]) {
+      const lineNum = res[1];
+      const errorMessage = res[2].slice(0, res[2].indexOf(message) + message.length);
+      return (<div >
+        <div >Please fix syntax error(s) on line {lineNum} and try again.</div>
+        <pre style={STYLES.code}>{errorMessage}</pre>
+      </div>);
+    }
   }
 
   render () {

--- a/packages/haiku-creator/src/react/components/CodeEditor/BytecodeErrorPopup.js
+++ b/packages/haiku-creator/src/react/components/CodeEditor/BytecodeErrorPopup.js
@@ -36,16 +36,28 @@ class BytecodeErrorPopup extends React.Component {
       return;
     }
 
-    const message = error.toString();
-    const res = error.stack.match(/.*?:(.*?)\n([.|\S|\s]*)/);
-    if (res.length === 3 && res[1] && res[2]) {
-      const lineNum = res[1];
-      const errorMessage = res[2].slice(0, res[2].indexOf(message) + message.length);
-      return (<div >
-        <div >Please fix syntax error(s) on line {lineNum} and try again.</div>
-        <pre style={STYLES.code}>{errorMessage}</pre>
-      </div>);
+    const lineNum = '?';
+    let errorMessage = error.toString();
+    if (error.name === 'ReferenceError') {
+      const res = error.stack.match(/\(.*?:(.*?):.*?\)/);
+      if (res.length === 2 && res[1]) {
+        lineNum = res[1];
+      }
+    } else if (error.name === 'SyntaxError') {
+      // Captures line number and remaining of stack
+      const res = error.stack.match(/.*?:(.*?)\n([.|\S|\s]*)/);
+      if (res.length === 3 && res[1] && res[2]) {
+        lineNum = res[1];
+        // For syntax error, we slice only important part from remaining
+        // of stack, so we can show to the user where the error is
+        errorMessage = res[2].slice(0, res[2].indexOf(errorMessage) + errorMessage.length);
+      }
     }
+
+    return (<div>
+      <div >Please fix error(s) on line <b>{lineNum}</b> and try again.</div>
+      <pre style={STYLES.code}>{errorMessage}</pre>
+    </div>);
   }
 
   render () {


### PR DESCRIPTION
OK to merge.

- "Syntax errors modal in code mode behaves weirdly when we get a var not defined error"
  - Error popup wasn't able to parse ReferenceError. 

- "Cannot save file' modal needs love":
  - I fixed overflow problem and error code font. About the font size/button, they are the same as other popups (the ones without `ModalHeader`), but anyway I sent the screen for Taylor review. Another option would be using popup without ModalHeader
  - I've changed how parsing is done to put all stack in a single <pre> tag to make `overflow: auto` work

Fixing overflow:
![screenshot_20180918_001008](https://user-images.githubusercontent.com/800493/45662270-89f3ee80-bad7-11e8-848d-039c47af64b0.png)
Parsing ReferenceError:
![screenshot_20180918_001032](https://user-images.githubusercontent.com/800493/45662271-89f3ee80-bad7-11e8-9593-7465e6b7179c.png)


Regressions to look for:

- Any logic regarding the change of how parsing is done

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`
