### PR TITLE
Multiline expression fixes

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -10,7 +10,8 @@
       "Export options are now disabled outside of a project.",
       "User Menu -> Your Profile now points to the correct location.",
       "Fixed a crash caused by forking certain projects.",
-      "Improve code editor save error popup"
+      "Improve code editor save error popup",
+      "Minor fixes to the multiline Expressions editor"
     ]
   }
 }

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -865,7 +865,7 @@ export default class ExpressionInput extends React.Component {
       case EDITOR_MODES.MULTI_LINE:
         this.codemirror.setOptions({
           lineNumbers: true,
-          scrollbarStyle: 'native',
+          scrollbarStyle: 'null',
         });
         renderable = getRenderableValueMultiline(this.state.editedValue);
         this.setEditorValue(renderable);

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -153,16 +153,6 @@ export default class ExpressionInput extends React.Component {
     this.codemirror.setValue('');
     this.codemirror.on('change', this.handleEditorChange.bind(this));
     this.codemirror.on('keydown', this.handleEditorKeydown.bind(this));
-    this.codemirror.on('beforeChange', (cm, changeObject) => {
-      // If multiline mode, only allow a change to the function body, not the signature
-      // Simply cancel any change that occurs in either of those places.
-      if (this.state.editingMode === EDITOR_MODES.MULTI_LINE && changeObject.origin !== SET_VALUE_ORIGIN) {
-        const lines = this.state.editedValue.body.split('\n');
-        if (changeObject.from.line === 0 || changeObject.from.line > lines.length) {
-          changeObject.cancel();
-        }
-      }
-    });
 
     this.state = {
       useAutoCompleter: false, // Used to 'comment out' this feature until it's fully baked
@@ -858,6 +848,14 @@ export default class ExpressionInput extends React.Component {
 
   setEditorValue (value) {
     this.codemirror.setValue(value);
+
+    // Mark the first and last lines (function signature and closing bracket)
+    // as non-editable content.
+    if (this.state.editingMode === EDITOR_MODES.MULTI_LINE) {
+      const lastLine = this.codemirror.lastLine();
+      this.codemirror.markText({line: 0, ch: 0}, {line: 1, ch: 0}, {readOnly: true, atomic: true});
+      this.codemirror.markText({line: lastLine, ch: 0}, {line: lastLine, ch: 1}, {readOnly: true, atomic: true});
+    }
   }
 
   recalibrateEditor (cursor) {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

This PR contains two changes:

**fix: disable edition only in first/last lines of multiline expressions**

Instead of preventing any changes as long as the first and last lines
are selected, this marks those lines as non-editable content.

Before: https://gfycat.com/gifs/detail/LateCleanAnhinga
After: https://gfycat.com/gifs/detail/SlightPertinentAntarcticgiantpetrel

**fix: disable native scrollbars in multiline**

They were showing up only if the user has a mouse connected (not with
trackpad) and are not necessary since the multiline box expands
automatically after the first keystroke.


Regressions to look for:

- Multiline expressions behavior

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
