### PR TITLE
fix: call Globals.allKeysUp when Creator is blur

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -14,7 +14,8 @@
       "Minor fixes to the multiline Expressions editor.",
       "Fixed a bug causing Timeline inputs with numbers in exponential format to display 'NaN' instead of the correct value.",
       "Fixed a bug preventing the time/frame indicator of subcomponents to update.",
-      "Fixed a bug causing the Timeline ticker to behave unexpectedly in certain situations."
+      "Fixed a bug causing the Timeline ticker to behave unexpectedly in certain situations.",
+      "Fixed a bug causing the Actions editor to unexpectedly close."
     ]
   }
 }

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -52,6 +52,7 @@ import * as opn from 'opn';
 import {crashReport} from 'haiku-serialization/src/utils/carbonite';
 import ConfirmGroupUngroupPopup from './components/Popups/ConfirmGroupUngroup';
 import {getAccountUrl} from 'haiku-common/lib/environments';
+import Globals from 'haiku-ui-common/lib/Globals';
 
 // Useful debugging originator of calls in shared model code
 process.env.HAIKU_SUBPROCESS = 'creator';
@@ -457,6 +458,10 @@ export default class Creator extends React.Component {
     });
 
     window.addEventListener('dragover', Asset.preventDefaultDrag, false);
+
+    window.addEventListener('blur', () => {
+      Globals.allKeysUp();
+    });
 
     window.addEventListener(
       'drop',


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes [Actions Editor randomly closing on 'Return' key](https://app.asana.com/0/813447917062242/827178890005381). This feels random but it's very easy to repro:

> 1- Keep the `cmd` key pressed
> 2- Press `tab` and switch to another window, but do it slowly, doing it very quickly does not produce a repro.
> 3- Go back to Haiku and observe how actions editor closes on enter because `Globals.isCommandKeyDown` has the wrong value

Regressions to look for:

- I did a mini-slam to check for unexpected behaviors but everything seems to be right. But: shortcuts and behavior involving `cmd` in general.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
