### PR TITLE
GIF, but good

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -10,8 +10,9 @@
       "Export options are now disabled outside of a project.",
       "User Menu -> Your Profile now points to the correct location.",
       "Fixed a crash caused by forking certain projects.",
-      "Improve code editor save error popup",
-      "Minor fixes to the multiline Expressions editor"
+      "Added more detail to error messages resulting from attempting to save with invalid content in code mode.",
+      "Minor fixes to the multiline Expressions editor.",
+      "GIFs and videos now always show the contents of the main component."
     ]
   }
 }

--- a/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/Gif.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/Gif.tsx
@@ -30,7 +30,8 @@ export default class Gif extends React.PureComponent<GifProps> {
   get gifUrl () {
     // Hack until we are simply subscribing to Envoy ExporterHandler.
     const maybeLocalFile = join(this.props.folder, 'animation.gif');
-    return existsSync(maybeLocalFile) ? maybeLocalFile : this.props.urls.gif;
+    // If serving a local file, we append ?<current timestamp> to cache-bust.
+    return existsSync(maybeLocalFile) ? `${maybeLocalFile}?${Date.now()}` : this.props.urls.gif;
   }
 
   render () {

--- a/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/Video.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/Video.tsx
@@ -30,7 +30,7 @@ export default class Video extends React.PureComponent<VideoProps> {
   get videoUrl () {
     // Hack until we are simply subscribing to Envoy ExporterHandler.
     const maybeLocalFile = join(this.props.folder, 'animation.mp4');
-    return existsSync(maybeLocalFile) ? maybeLocalFile : this.props.urls.video;
+    return existsSync(maybeLocalFile) ? `${maybeLocalFile}?${Date.now()}` : this.props.urls.video;
   }
 
   render () {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes [If you publish from an active sub-component tab, it shows a gif of that sub-component as the meta-image for the entire-project's sharepage link.](https://app.asana.com/0/813447917062242/823106226020461/f)
- I have a hunch this _might_ also fix [Broken GIF-baker](https://app.asana.com/0/813447917062242/802131431144539/f).

Regressions to look for:

- None.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`
