### PR TITLE
 Focus code editor when switching to code mode

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -12,11 +12,12 @@
       "Fixed a crash caused by forking certain projects.",
       "Added more detail to error messages resulting from attempting to save with invalid content in code mode.",
       "Minor fixes to the multiline Expressions editor.",
-      "GIFs and videos now always show the contents of the main component."
+      "GIFs and videos now always show the contents of the main component.",
       "Fixed a bug causing Timeline inputs with numbers in exponential format to display 'NaN' instead of the correct value.",
       "Fixed a bug preventing the time/frame indicator of subcomponents to update.",
       "Fixed a bug causing the Timeline ticker to behave unexpectedly in certain situations.",
-      "Fixed a bug causing the Actions editor to unexpectedly close."
+      "Fixed a bug causing the Actions editor to unexpectedly close.",
+      "Focus code editor when switching to code mode"
     ]
   }
 }

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1083,7 +1083,12 @@ export default class Creator extends React.Component {
       this.safelyHideEventHandlersEditor();
     }
 
-    this.setState({interactionMode}, this.openPreviewDevTools);
+    this.setState({interactionMode}, () => {
+      this.openPreviewDevTools();
+      if (interactionMode === InteractionMode.CODE_EDITOR) {
+        this.refs.stage.focusCodeEditor();
+      }
+    });
   }
 
   setInteractionMode (interactionMode) {
@@ -2171,9 +2176,7 @@ export default class Creator extends React.Component {
                           zIndex: 999999,
                           backgroundColor: Palette.COAL,
                         }}
-                        onClick={() => {
-                          this.setGlassInteractionToEditMode();
-                        }}
+                        onClick={this.setGlassInteractionToEditMode}
                       />
                     )
                   }

--- a/packages/haiku-creator/src/react/components/CodeEditor/CodeEditor.js
+++ b/packages/haiku-creator/src/react/components/CodeEditor/CodeEditor.js
@@ -19,6 +19,7 @@ class CodeEditor extends React.Component {
     this.saveCodeFromEditorToDisk = this.saveCodeFromEditorToDisk.bind(this);
     this.discardFromCodeEditor = this.discardFromCodeEditor.bind(this);
     this.onProjectModelUpdate = this.onProjectModelUpdate.bind(this);
+    this.focusCodeEditor = this.focusCodeEditor.bind(this);
 
     this.hideBytecodeErrorPopup = () => {
       this.setState({
@@ -140,6 +141,10 @@ class CodeEditor extends React.Component {
     });
   }
 
+  focusCodeEditor () {
+    this.refs.monacoeditor.focusCodeEditor();
+  }
+
   discardFromCodeEditor () {
     this.onMonacoEditorChange(this.state.currentComponentCode);
   }
@@ -180,6 +185,7 @@ class CodeEditor extends React.Component {
             closeBytecodeErrorPopup={this.hideBytecodeErrorPopup}
           />}
         <MonacoEditor
+          ref="monacoeditor"
           language="javascript"
           theme="haiku"
           value={this.state.currentEditorContents}

--- a/packages/haiku-creator/src/react/components/CodeEditor/MonacoEditor.js
+++ b/packages/haiku-creator/src/react/components/CodeEditor/MonacoEditor.js
@@ -18,6 +18,7 @@ class MonacoEditor extends React.Component {
     this.currentValue = props.value;
     this.onUpdateDimensions = this.updateDimensions.bind(this);
     this.assignRef = this.assignRef.bind(this);
+    this.focusCodeEditor = this.focusCodeEditor.bind(this);
     this.state = {};
   }
 
@@ -131,6 +132,10 @@ class MonacoEditor extends React.Component {
 
   assignRef (component) {
     this.containerElement = component;
+  }
+
+  focusCodeEditor () {
+    this.editor.focus();
   }
 
   render () {

--- a/packages/haiku-creator/src/react/components/Stage.js
+++ b/packages/haiku-creator/src/react/components/Stage.js
@@ -54,6 +54,7 @@ class Stage extends React.Component {
     this.saveCodeFromEditorToDisk = this.saveCodeFromEditorToDisk.bind(this);
     this.executeActionAfterCodeEditorSavePopup = this.executeActionAfterCodeEditorSavePopup.bind(this);
     this.closeCodeEditorSavePopup = this.closeCodeEditorSavePopup.bind(this);
+    this.focusCodeEditor = this.focusCodeEditor.bind(this);
 
     this.state = {
       nonSavedContentOnCodeEditor: false,
@@ -105,6 +106,10 @@ class Stage extends React.Component {
     } else {
       this.props.setGlassInteractionToPreviewMode();
     }
+  }
+
+  focusCodeEditor () {
+    this.refs.codeeditor.focusCodeEditor();
   }
 
   executeActionAfterCodeEditorSavePopup () {


### PR DESCRIPTION
OK to merge.

Use react refs to allow focusing to monaco editor when changing to code mode.


Completed checkin tasks:
- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`
