### PR TITLE
hack: don't allow timeline draggable elements to be over top controls

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -16,7 +16,8 @@
       "Fixed a bug causing Timeline inputs with numbers in exponential format to display 'NaN' instead of the correct value.",
       "Fixed a bug preventing the time/frame indicator of subcomponents to update.",
       "Fixed a bug causing the Timeline ticker to behave unexpectedly in certain situations.",
-      "Fixed a bug causing the Actions editor to unexpectedly close."
+      "Fixed a bug causing the Actions editor to unexpectedly close.",
+      "Do not allow Timeline rows to be dragged over the controls on the top."
     ]
   }
 }

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1471,6 +1471,13 @@ class Timeline extends React.Component {
                         index={indexOfGroup}
                       >
                         {(providedDraggable) => {
+                          // HACK: Don't allow the draggable element to be positioned above the top bar controls
+                          const {transform, top} = providedDraggable.draggableProps.style;
+                          const transformXRegex = /(\d*)px\)/;
+                          if (transform && top && top - parseInt(transform.match(transformXRegex)[1], 10) <= 35) {
+                            providedDraggable.draggableProps.style.transform = transform.replace(transformXRegex, `${top - 35}px)`);
+                          }
+
                           return (
                             <div>
                               <div


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

> ⚠️ Note: this is a really hacky solution, if you think it's bad I can look for other solutions, or we can backlog this task.

This is a really ugly solution for ["Dragged rows in Timeline overlaps
top bar"](https://app.asana.com/0/813447917062242/813447917062247), I ended up implementing this way because:

- We can't play with `z-index` in order to overlap the dragged row,
simply because of how I refactored the timeline, remember that many
things that look like a single block in reality are two different HTML
elements.
- Our library doesn't allow us to set boundaries (it goes against their
[driving philosophy](https://github.com/atlassian/react-beautiful-dnd#driving-philosophy-physicality))
- I tried to play with `overflow: hidden` on the draggable container,
but this breaks our scrolling behavior.

While this is far from ideal, performance shouldn't be heavily affected
because the calculations are only performed on the row that is being
dragged when its position changes.

Apologies for how fragile the timeline structure is for this kind of
scenarios.

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
