### PR TITLE
Eventual consistency

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -789,24 +789,6 @@ export default class Creator extends React.Component {
       }
     });
 
-    this.props.websocket.on('method', (method, params, message, cb) => {
-      // Harness to enable cross-subview integration testing
-      if (method === 'executeFunctionSpecification') {
-        return Project.executeFunctionSpecification(
-          {creator: this},
-          'creator',
-          lodash.assign(
-            {
-              creator: this,
-              project: this.state.projectModel,
-            },
-            params[0],
-          ),
-          cb,
-        );
-      }
-    });
-
     this.activityMonitor.startWatchers();
 
     this.envoyClient = new EnvoyClient(this.envoyOptions);

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -569,24 +569,6 @@ export class Glass extends React.Component {
       this.performPan(evt.wheelDeltaX * SCROLL_PAN_COEFFICIENT, evt.wheelDeltaY * SCROLL_PAN_COEFFICIENT);
     }, false);
 
-    this.addEmitterListener(this.props.websocket, 'method', (method, params, message, cb) => {
-      // Harness to enable cross-subview integration testing
-      if (method === 'executeFunctionSpecification') {
-        return Project.executeFunctionSpecification(
-          {glass: this},
-          'glass',
-          lodash.assign(
-            {
-              glass: this,
-              project: this.project,
-            },
-            params[0],
-          ),
-          cb,
-        );
-      }
-    });
-
     this.addEmitterListener(this.props.websocket, 'relay', (message) => {
       logger.info('relay received', message.name, 'from', message.from);
 

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -919,7 +919,8 @@ export default class Plumbing extends EventEmitter {
         return this.awaitMasterAndCallMethod(folder, method, params, nextStep);
       }
 
-      return this.sendQueriedClientMethod(lodash.assign({folder}, clientSpec), method, params, nextStep);
+      this.sendQueriedClientMethod(lodash.assign({folder}, clientSpec), method, params, () => {});
+      return nextStep();
     }, (err) => {
       return logAndHandleActionResult(err, cb, method, type, alias);
     });

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -83,24 +83,12 @@ const METHOD_MESSAGES_TO_HANDLE_IMMEDIATELY = {
   unhoverElement: true,
 };
 
-const METHOD_MESSAGES_TIMEOUT = 15000;
-const METHODS_TO_AWAIT_FOREVER = {
-  bootstrapProject: true,
-  setCurrentActiveComponent: true,
-  setInteractionMode: true,
-  startProject: true,
-  initializeFolder: true,
-  saveProject: true,
-  teardownMaster: true,
-};
-
 const Q_GLASS = {alias: 'glass'};
 const Q_TIMELINE = {alias: 'timeline'};
 const Q_CREATOR = {alias: 'creator'};
 const Q_MASTER = {alias: 'master'};
 
 const AWAIT_INTERVAL = 100;
-const WAIT_DELAY = 30 * 1000;
 
 const HAIKU_DEFAULTS = {
   socket: {
@@ -488,59 +476,29 @@ export default class Plumbing extends EventEmitter {
     const nextMethodMessage = this._methodMessages.shift();
 
     if (!nextMethodMessage) {
-      return setTimeout(this.executeMethodMessagesWorker.bind(this), 64);
+      return setTimeout(() => this.executeMethodMessagesWorker(), 64);
     }
 
     const {type, alias, folder, message, cb} = nextMethodMessage;
 
     this.methodMessageBeforeLog(message, alias);
 
-    // If it takes too long for us to get a response for a method, kick start the queue
-    // again so we don't hang when important new messages are being received
-    let timedOut = false;
-    let gotResponse = false;
-
-    if (!METHODS_TO_AWAIT_FOREVER[message.method]) {
-      setTimeout(() => {
-        timedOut = true;
-        if (!gotResponse) {
-          logger.warn(`[plumbing] timed out waiting for ${message.method}; restarting worker`);
-          this.executeMethodMessagesWorker();
-        }
-      }, METHOD_MESSAGES_TIMEOUT);
-    }
-
     // Actions are a special case of methods that end up routed through all of the clients,
     // glass -> timeline -> master before returning. They go through one handler as opposed
     // to the normal 'methods' which plumbing handles on a more a la carte basis
     if (message.type === 'action') {
       return this.handleClientAction(type, alias, folder, message.method, message.params, (err, result) => {
-        if (timedOut) {
-          logger.warn(`[plumbing] received late response from timed out action ${message.method}`);
-        }
 
         this.methodMessageAfterLog(message, err, result, alias);
         cb(err, result);
-
-        if (!timedOut) {
-          gotResponse = true;
-          this.executeMethodMessagesWorker(); // Continue with the next queue entry (if any)
-        }
+        this.executeMethodMessagesWorker();
       });
     }
 
     return this.plumbingMethod(message.method, message.params || [], (err, result) => {
-      if (timedOut) {
-        logger.warn(`[plumbing] received late response from timed out method ${message.method}`);
-      }
-
       this.methodMessageAfterLog(message, err, result, alias);
       cb(err, result);
-
-      if (!timedOut) {
-        gotResponse = true;
-        this.executeMethodMessagesWorker(); // Continue with the next queue entry (if any)
-      }
+      this.executeMethodMessagesWorker();
     });
   }
 
@@ -637,7 +595,7 @@ export default class Plumbing extends EventEmitter {
     }));
   }
 
-  awaitClientWithQuery (query, timeout, cb) {
+  awaitClientWithQuery (query, cb) {
     if (!query) {
       throw new Error('Query is required');
     }
@@ -652,11 +610,6 @@ export default class Plumbing extends EventEmitter {
       }
     }
 
-    if (timeout <= 0) {
-      logger.warn(`[plumbing] timed out waiting for client ${JSON.stringify(fixed)}`);
-      return null;
-    }
-
     const clientMatching = find(
       this.clients,
       {params: fixed},
@@ -667,7 +620,7 @@ export default class Plumbing extends EventEmitter {
     }
 
     return setTimeout(() => {
-      return this.awaitClientWithQuery(query, timeout - AWAIT_INTERVAL, cb);
+      return this.awaitClientWithQuery(query, cb);
     }, AWAIT_INTERVAL);
   }
 
@@ -690,46 +643,23 @@ export default class Plumbing extends EventEmitter {
 
     logger.info(`[plumbing] relaying ${message.name} to ${message.view}`);
 
-    return this.awaitClientWithQuery(clientQuery, WAIT_DELAY, (err, client) => {
-      if (err) {
-        return logger.warn(`[plumbing] timed out awaiting relay client ${JSON.stringify(clientQuery)}`);
-      }
-
+    return this.awaitClientWithQuery(clientQuery, (_, client) => {
       return this.sendClientMessage(client, message);
     });
   }
 
   sendQueriedClientMethod (query = {}, method, params = [], cb) {
-    return this.awaitClientWithQuery(query, WAIT_DELAY, (err, client) => {
+    return this.awaitClientWithQuery(query, (err, client) => {
       if (err) {
         return cb(err);
       }
 
-      // Give a maximum of 10 seconds before forcing a crash if the client doesn't respond.
-      // If the page crashes before sending the result, we might not find out and could lose work.
-      let responseReceived = false;
-      let timedOut = false;
-
-      // In dev, we may use a debugger in which case we don't want to force a timeout
-      setTimeout(() => {
-        timedOut = true;
-
-        if (!responseReceived) {
-          logger.warn(`[plumbing] timed out sending ${method} to client ${JSON.stringify(query)}`);
-        }
-      }, WAIT_DELAY);
-
       return this.sendClientMethod(client, method, params, (error, response) => {
-        responseReceived = true;
-
-        if (!timedOut || METHODS_TO_AWAIT_FOREVER[method]) {
-          if (error) {
-            this.sentryError(method, error, {tags: query});
-            return cb(error);
-          }
-
-          return cb(null, response);
+        if (error) {
+          this.sentryError(method, error, {tags: query});
         }
+
+        return cb(error, response);
       });
     });
   }

--- a/packages/haiku-plumbing/src/Plumbing.js
+++ b/packages/haiku-plumbing/src/Plumbing.js
@@ -362,43 +362,6 @@ export default class Plumbing extends EventEmitter {
   }
 
   /**
-   * @method executeFunction
-   * @param views {Array} List of all views in which to execute the function
-   * @param data {Object} Data object to pass to the function on each execution
-   * @param fn {Function} The function to execute
-   * @param cb {Function} The callback to call when finished
-   * @description Execute an arbitrary function in all of the subviews.
-   * The this-binding of the function will be an instance of Project, if available.
-   */
-  executeFunction (views, data, fn, cb) {
-    const outputs = {};
-    return async.eachSeries(views, (alias, next) => {
-      const finish = (err, result) => {
-        if (err) {
-          return next(err);
-        }
-        outputs[alias] = result;
-        return next();
-      };
-      if (alias === 'plumbing') {
-        return fn.call({plumbing: this}, data, finish);
-      }
-      const rfo = lodash.assign(functionToRFO(fn).__function, data);
-      return this.sendQueriedClientMethod(
-        lodash.assign({alias}, data),
-        'executeFunctionSpecification',
-        [rfo, {from: 'plumbing'}],
-        finish,
-      );
-    }, (err) => {
-      if (err) {
-        return cb(err);
-      }
-      return cb(null, outputs);
-    });
-  }
-
-  /**
    * @method invokeAction
    * @description Convenience wrapper around making a generic action call
    */

--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -10,7 +10,6 @@ const EnvoyLogger = require('haiku-sdk-creator/lib/envoy/EnvoyLogger').default
 const { GLASS_CHANNEL } = require('haiku-sdk-creator/lib/glass')
 const logger = require('./../utils/LoggerInstance')
 const BaseModel = require('./BaseModel')
-const reifyRFO = require('@haiku/core/lib/reflection/reifyRFO').default
 const {InteractionMode} = require('@haiku/core/lib/helpers/interactionModes')
 const toTitleCase = require('./helpers/toTitleCase')
 const Lock = require('./Lock')

--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -26,10 +26,6 @@ const {
   getAngularSelectorName
 } = require('@haiku/sdk-client/lib/ProjectDefinitions')
 
-const ALWAYS_IGNORED_METHODS = {
-  // Handled upstream, by Creator, Glass, Timeline, etc.
-  executeFunctionSpecification: true
-}
 const SILENT_METHODS = {
   hoverElement: true,
   unhoverElement: true
@@ -178,7 +174,6 @@ class Project extends BaseModel {
   }
 
   isIgnoringMethodRequestsForMethod (method) {
-    if (ALWAYS_IGNORED_METHODS[method]) return true
     // HACK: This probably doesn't/shouldn't belong as a part of 'fileOptions'
     // It's a hacky way for MasterProcess to handle certain methods it cares about
     const fileOptions = this.getFileOptions()
@@ -986,13 +981,6 @@ Project.getProjectNameVariations = (folder) => {
     primaryAssetPath,
     defaultIllustratorAssetPath
   }
-}
-
-Project.executeFunctionSpecification = (binding, alias, payload, cb) => {
-  if (process.env.NODE_ENV === 'production') return cb()
-  if (payload.views && payload.views.indexOf(alias) === -1) return cb()
-  const fn = reifyRFO(payload)
-  return fn.call(binding, payload, cb)
 }
 
 const integritiesMismatched = (i1, i2) => {

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -260,24 +260,6 @@ class Timeline extends React.Component {
       resetKeyStates();
     });
 
-    this.addEmitterListener(this.props.websocket, 'method', (method, params, message, cb) => {
-      // Harness to enable cross-subview integration testing
-      if (method === 'executeFunctionSpecification') {
-        return Project.executeFunctionSpecification(
-          {timeline: this},
-          'timeline',
-          lodash.assign(
-            {
-              timeline: this,
-              project: this.state.projectModel,
-            },
-            params[0],
-          ),
-          cb,
-        );
-      }
-    });
-
     this.addEmitterListener(window, 'dragover', Asset.preventDefaultDrag, false);
 
     this.addEmitterListener(


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Essentially, turns every IPC method into `METHODS_TO_AWAIT_FOREVER` and retires the entire concept of timing out waiting for IPC. This probably fixes a litany of unsolved mysteries, including the entire remaining family of integrity crashes, without any obvious downside that I see. Here's my explanation of why:
  - Every "important thing that should matter" is blocked/forced synchronous and ordered by `Lock.request(Lock.LOCKS.ProjectMethodHandler, ...)`. Although we're no longer doing "don't hang when important new messages are being received", the timeouts were already set up so long that realistically, the message we were abandoning to queue up ability to receive the next one was almost certainly important (i.e. integrity-affecting).
   - With respect to data loss, this should actually move the needle in a positive way by creating a system that is _guaranteed eventually consistent_ for a series of long-running tasks, so long as the user doesn't quit the app with Cmd+Q while master is catching up with what is/was on stage, which was already a possibility. This ultimately should cancel a major cause of "strategic crashes when we're worried about data loss". _In particular_, with `Plumbing#handleClientAction` now not blocking method message dispatch to Master when a webview is taking a long time to respond—or not responding at all, which would be the case when the webview has been destroyed by e.g. backing out to the dashboard—it will continue churning through a maybe backed-up method message queue even after `Master#halt` has been called.

Regressions to look for:

- None expected (see above). The worst thing that can happen is the app hangs for a really long time while IPC is catching up. This is already a thing that might happen, but this change should make it ultimately less destructive.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
