### PR TITLE
Avoid capturing mouse position on keyup if mouse was already captured (827578786675323)

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -20,7 +20,8 @@
       "Fixed a bug preventing Timeline marquee selection to start from within collapsed rows.",
       "Added better logic to calculate the size of the Timeline multiline expressions editor on different sizes.",
       "Do not allow Timeline rows to be dragged over the controls on the top.",
-      "Focus code editor when switching to code mode"
+      "Focus code editor when switching to code mode",
+      "Fixed wrong result when pressing ctrl during element mouse scaling"
     ]
   }
 }

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -702,6 +702,8 @@ class ElementSelectionProxy extends BaseModel {
 
   handleMouseUp (mousePosition) {
     ElementSelectionProxy.snaps = []
+    // We set this._lastMouseDownPosition = undefined to imply that there isn't any mouse action in course
+    this._lastMouseDownPosition = undefined
   }
 
   // this is used specifically for the CMD key (though it is not explicitly filtered here.)
@@ -944,7 +946,9 @@ class ElementSelectionProxy extends BaseModel {
     }
 
     // 'mousetrap' for snapping
-    if (this._shouldCaptureMousePosition || this._lastMouseDownPosition === undefined) {
+    // We assume that `this._lastMouseDownPosition === undefined` means that no mouse action is in course,
+    // so we only capture new mouse position if is true
+    if (this._shouldCaptureMousePosition && this._lastMouseDownPosition === undefined) {
       this._lastMouseDownPosition = mouseCoordsCurrent
       this._lastBbox = this.getBoundingClientRect()
       this._lastProxyBox = this.getBoxPointsTransformed()

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -697,7 +697,7 @@ class ElementSelectionProxy extends BaseModel {
   }
 
   handleMouseDown (mousePosition) {
-    this._shouldCaptureMousePosition = true
+    ElementSelectionProxy._shouldCaptureMousePosition = true
   }
 
   handleMouseUp (mousePosition) {
@@ -710,7 +710,7 @@ class ElementSelectionProxy extends BaseModel {
   // if we don't "recapture" mouse position when CMD is released, the element will unexpectedly
   // jolt back to its original position pre-drag.
   handleKeyUp () {
-    this._shouldCaptureMousePosition = true
+    ElementSelectionProxy._shouldCaptureMousePosition = true
   }
 
   // snapDefinitions are the element-side 'snap points' (lines)
@@ -946,9 +946,9 @@ class ElementSelectionProxy extends BaseModel {
     }
 
     // 'mousetrap' for snapping
-    // We assume that `this._lastMouseDownPosition === undefined` means that no mouse action is in course,
-    // so we only capture new mouse position if is true
-    if (this._shouldCaptureMousePosition && this._lastMouseDownPosition === undefined) {
+    // We assume that `ElementSelectionProxy._shouldCaptureMousePosition === undefined` means that no
+    // mouse action is in course, so we only capture new mouse position if is true
+    if (ElementSelectionProxy._shouldCaptureMousePosition && this._lastMouseDownPosition === undefined) {
       this._lastMouseDownPosition = mouseCoordsCurrent
       this._lastBbox = this.getBoundingClientRect()
       this._lastProxyBox = this.getBoxPointsTransformed()
@@ -957,7 +957,7 @@ class ElementSelectionProxy extends BaseModel {
       this._lastOrigins = this.selection.map((elem) => {
         return elem.getOriginTransformed()
       })
-      this._shouldCaptureMousePosition = false
+      ElementSelectionProxy._shouldCaptureMousePosition = false
     }
 
     // track mouse positions, offsets, and original bounding boxes for snapping
@@ -2387,6 +2387,9 @@ const isWithinEpsilon = (v0, v1, override) => {
 
 // Storage for snap lines data
 ElementSelectionProxy.snaps = []
+// Storage to preserve `_shouldCaptureMousePosition` set on handleMouseDown method on former ElementSelectionProxy
+// instance up to `drag` method on newly created ElementSelectionProxy instance
+ElementSelectionProxy._shouldCaptureMousePosition = false
 
 ElementSelectionProxy.fromSelection = (selection, query) => {
   const uid = selection.map((element) => element.getPrimaryKey()).sort().join('+') || 'none'


### PR DESCRIPTION
OK to merge.

I've managed to end up with a simplified version. 


Another ctrl behavior that might be (or not) odd is:
 - ctrl down
 - mouse down, rotate
 - mouse up
 - try to rotate again without ctrl up (instead you can only scale)
(Basically ctrl detection for rotation in done on edge instead level). Anyway, it would be another task.


Regressions to look for:
 - I've done testing but there might be some edge cases, so It's a good idea for someone else to double check against regressions (Especially against direct selection/snapping).

Completed checkin tasks:
- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`
