### PR TITLE
fix: weird rotation issues on Figma

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -22,7 +22,8 @@
       "The code editor is now automatically focused when switching to code mode.",
       "Pressing `Ctrl` during element scaling no longer triggers the context menu.",
       "Fixed disappearing elements when re-publishing very old Haiku.",
-      "Fixed an issue that might cause certain versions of `lottie-android` to crash when parsing Haiku's Lottie export."
+      "Fixed an issue that might cause certain versions of `lottie-android` to crash when parsing Haiku's Lottie export.",
+      "Fixed layout issues when importing Figma shapes that have been rotated around a non-standard origin."
     ]
   }
 }

--- a/packages/haiku-common/src/layout/parseCssTransformString.ts
+++ b/packages/haiku-common/src/layout/parseCssTransformString.ts
@@ -99,6 +99,13 @@ export default function parseCssTransformString (inStr: string) {
       case 'rotate':
         layout.rotate[2] =
           spec.values[0].unit === 'deg' ? degreesToRadians(spec.values[0].value) : spec.values[0].value;
+        if (spec.values.length === 3) {
+          // We are doing rotation about a point, so we have to offset translation….
+          const cosr = Math.cos(layout.rotate[2]);
+          const sinr =  Math.sin(layout.rotate[2]);
+          layout.translate[0] = spec.values[1].value * (1 - cosr) + sinr * spec.values[2].value;
+          layout.translate[1] = spec.values[2].value * (1 - cosr) - sinr * spec.values[1].value;
+        }
         break;
       case 'scale':
         layout.scale[0] = spec.values[0].value;

--- a/packages/haiku-common/test/layout/parseCssTransformString.test.ts
+++ b/packages/haiku-common/test/layout/parseCssTransformString.test.ts
@@ -164,6 +164,14 @@ tape(
           'scale.y': 2.72,
         },
       ],
+      // Test for rotation about a point other than (0, 0)
+      [
+        'rotate(90 10 10)',
+        {
+          'translation.x': 20,
+          'rotation.z': 1.571,
+        },
+      ],
     ];
 
     test.plan(data.length);


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes [user-reported issue](https://haiku-community.slack.com/archives/C62Q4BWJY/p1537810251000100). This Figma file contained SVG directives like `transform="rotate(9.84543 948.026 539.563)"`, which we didn't previously support. `rotate(r, x, y)` means "rotate `r` degrees around the point `<x, y>`".

Regressions to look for:

- None.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test for existing and modified functionality
- [x] Updated `changelog/public/latest.json`
