### PR TITLE
fix: for Layout weirdness when creating nested groups (834345013882114)

### DIFF
--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -4036,6 +4036,7 @@ class ActiveComponent extends BaseModel {
       const timelineName = this.getInstantiationTimelineName()
       const timelineTime = this.getInstantiationTimelineTime()
 
+      const groupComponentId = this.instantiateManaInBytecode(groupMana, bytecode, {}, coords)
       const nodesToRegroup = []
 
       // We only allow grouping of the top level elements, hence iterating children, not visiting
@@ -4078,7 +4079,6 @@ class ActiveComponent extends BaseModel {
         }
       }
 
-      const groupComponentId = this.instantiateManaInBytecode(groupMana, bytecode, {}, coords)
       groupMana.children[0].children = nodesToRegroup
 
       // Place the new group at the top.


### PR DESCRIPTION
OK to merge after health checks pass.

Short review.

Summary of changes:

- Fixes [Layout weirdness when creating nested groups](https://app.asana.com/0/824697491061885/834345013882114/f). The problem was duplicate haiku IDs in the edge case where you do exactly the steps described by @roperzh in his repro! tl;dr, the first "shim" layout div resulting from grouping two elements on an empty artboard will always get the same haiku-id in a project. By splicing out the existing group _before_ instantiating the group mana, we created the possibility of a duplicate ID. By splicing out _after_ instantiation, no collisions are guaranteed.

Regressions to look for:

- (Run group QA checklist against a build with this fix.)

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
