### PR TITLE
Figma naming finesse

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -7,7 +7,8 @@
       "Now the library shows a progress indicator when creating Sketch or Illustrator files within Haiku.",
       "Lottie export now supports SVGs with non-standard viewboxes.",
       "Fixed an edge case causing a crash when changing the zoom of the Timeline from the scroll bar.",
-      "Increase the clickeable area to change the Timeline display mode between frames/seconds."
+      "Increase the clickeable area to change the Timeline display mode between frames/seconds.",
+      "Fixed issues and increased flexibility around Figma import URLs and project names."
     ]
   }
 }

--- a/packages/haiku-serialization/src/bll/Asset.js
+++ b/packages/haiku-serialization/src/bll/Asset.js
@@ -271,7 +271,7 @@ class Asset extends BaseModel {
       figmaID: Figma.findIDFromPath(relpath),
       project,
       relpath,
-      displayName: path.basename(relpath).match(/(\w+)-([\w-]+)\./)[2],
+      displayName: Figma.findDisplayNameFromPath(relpath),
       children: [],
       slicesFolderAsset, // Hacky, but avoids extra 'upsert' logic
       groupsFolderAsset,

--- a/packages/haiku-serialization/src/bll/Figma.js
+++ b/packages/haiku-serialization/src/bll/Figma.js
@@ -14,6 +14,7 @@ const FIGMA_URL = 'https://www.figma.com/'
 const FIGMA_CLIENT_ID = 'tmhDo4V12I3fEiQ9OG8EHh'
 const IS_FIGMA_FILE_RE = /\.figma$/
 const IS_FIGMA_FOLDER_RE = /\.figma\.contents/
+const FIGMA_DEFAULT_FILENAME = 'Untitled'
 
 const VALID_TYPES = {
   SLICE: 'SLICE',
@@ -70,7 +71,6 @@ class Figma {
   importSVG ({url, projectFolder}) {
     const {id} = Figma.parseProjectURL(url)
     let assetBaseFolder
-
 
     logger.info('[figma] about to import document with id ' + id)
     mixpanel.haikuTrack('creator:figma:fileImport:start')
@@ -280,8 +280,7 @@ class Figma {
         return null
       }
 
-      // 'Untitled' is the default name assigned by Figma to unnamed projects
-      return { id, name: name || 'Untitled' }
+      return { id, name: name || FIGMA_DEFAULT_FILENAME }
     } catch (e) {
       return null
     }
@@ -348,12 +347,23 @@ class Figma {
   /**
    * Tries to find an ID from a Figma path
    * @param {string} relpath
-   * @returns {string}
+   * @returns {string|boolean}
    */
   static findIDFromPath (relpath) {
     const basename = path.basename(relpath)
     const match = basename.match(/(\w+)-/)
     return match && match[1]
+  }
+
+  /**
+   * Tries to find the asset name from a Figma path
+   * @param {string} relpath
+   * @returns {string}
+   */
+  static findDisplayNameFromPath (relpath) {
+    const basename = path.basename(relpath)
+    const match = basename.match(/(\w+)-([\w-]+)\./)
+    return match ? match[2] : FIGMA_DEFAULT_FILENAME
   }
 
   static buildFigmaLinkFromPath (relpath) {
@@ -383,4 +393,4 @@ class Figma {
   }
 }
 
-module.exports = {Figma, PHONY_FIGMA_FILE}
+module.exports = {Figma, PHONY_FIGMA_FILE, FIGMA_DEFAULT_FILENAME}


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes ["Figma import error: Cannot read property '2' of null"](https://app.asana.com/0/824697491061885/841922416807739) by:

- *Increasing the flexibility of the URL that the user provides to import projects*: this URL has the general form of `figma.com/<project-id>/<project-name>`, from now on the only required bit will be `<project-id>` since we will infer the name from the Figma API.
- *Making a safer regex test*: we had a cowbow-coding regexp match in `Asset.js` that is now written in a safer way and encapsulated in `Figma.js`

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
