### PR TITLE
Set sync lock when editing deep properties on timeline (803324025609225)

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -8,7 +8,8 @@
       "Lottie export now supports SVGs with non-standard viewboxes.",
       "Fixed an edge case causing a crash when changing the zoom of the Timeline from the scroll bar.",
       "Increase the clickeable area to change the Timeline display mode between frames/seconds.",
-      "Fixed issues and increased flexibility around Figma import URLs and project names."
+      "Fixed issues and increased flexibility around Figma import URLs and project names.",
+      "Disable syncing with external designs when editing element nested properties on timeline"
     ]
   }
 }

--- a/packages/haiku-serialization/src/bll/ActionStack.js
+++ b/packages/haiku-serialization/src/bll/ActionStack.js
@@ -572,7 +572,7 @@ ActionStack.METHOD_INVERTERS = {
       if (oldValue !== undefined) {
         return {
           method: ac.createKeyframe.name,
-          params: [componentId, timelineName, elementName, propertyName, keyframeStartMs, oldValue, oldCurve, null, null]
+          params: [componentId, timelineName, elementName, propertyName, keyframeStartMs, oldValue, oldCurve, null, null, null]
         }
       } else {
         return {

--- a/packages/haiku-serialization/src/bll/Row.js
+++ b/packages/haiku-serialization/src/bll/Row.js
@@ -397,6 +397,13 @@ class Row extends BaseModel {
 
     const curveToAssign = this.getBaselineCurveAtMillisecond(ms)
 
+    // Lock sync on deep SVG attributes change
+    const parentSVG = this.element.getParentSvgElement()
+    let options = {}
+    if (parentSVG && this.element !== parentSVG) {
+      options = {setElementLockStatus: {[parentSVG.getComponentId()]: true}}
+    }
+
     // Update the bytecode directly via ActiveComponent, which updates Timeline UI.
     // Note that createKeyframe handles rehydrating the keyframes with correct indices.
     this.component.createKeyframe(
@@ -409,6 +416,7 @@ class Row extends BaseModel {
       curveToAssign,
       null, // end ms, not used?
       null, // end value, not used?
+      options,
       metadata,
       () => {}
     )

--- a/packages/haiku-serialization/test/bll/02_Project.undo-redo.test.stub.js
+++ b/packages/haiku-serialization/test/bll/02_Project.undo-redo.test.stub.js
@@ -411,6 +411,7 @@ tape('Project.undo-redo[3]', (t) => {
                     'linear',
                     null,
                     null,
+                    {},
                     {from: 'test'},
                     nextN
                   )


### PR DESCRIPTION
OK to merge.

I've used the same idea of `options` parameter to set sync lock status as `updateKeyframes` and `updateKeyframesAndTypes` on `createKeyframe`. 

I choose to not try to add undo/redo lock/unlock sync, just like `updateKeyframes` works (`updateKeyframesAndTypes` has this ability due SNAPSHOTTED_UNDOABLES). To to so, would involve some deeper changes. IMHO the ideal option would be a segregated function specifically to lock sync eg. `ActiveComponent::lockSync` instead interlaced with `updateKeyframes`, `updateKeyframesAndTypes` and `createKeyframe`, but with our current architecture, it would introduce more latency when editing deep SVG attributes. What do you think about this point?

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`
