### PR TITLE
 Added debugger compound launch config for all haiku processes 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,16 @@
         "core-demo-server",
         "core-demo-client"
       ]
+    },
+    {
+        "name": "attach-haiku",
+        "configurations": [
+          "attach-main",
+          "attach-master",
+          "attach-creator",
+          "attach-glass",
+          "attach-timeline"
+        ]
     }
   ],
   "configurations": [

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -282,6 +282,14 @@ function go () {
     case 'everything':
       global.process.env.HAIKU_DEBUG = '1';
       binaryArgs.push('electron', '--inspect=9220', '--remote-debugging-port=9222', '.');
+
+      // Fix drag and drop linux bug on debug build. A Heisenbug according to
+      // https://github.com/electron/electron/issues/12820
+      if (global.process.env.HAIKU_RELEASE_ENVIRONMENT === 'development' && getReleasePlatform() === 'linux') {
+        log.hat('Disable GPU accel as workaround for drag and drop bug');
+        binaryArgs.push('--disable-gpu');
+      }
+
       // On Windows and Linux, custom protocol handler is
       // passed as argument, so here we forward it
       if (haikuURI) {


### PR DESCRIPTION
OK to merge.

I often debug on more then one process (e.g. glass, timeline, creator..) simultaneously. Restarting it tend to be very manual/tedious, so I've added a compound configuration to attach to all processes at the same time. Another good thing is that if you are debugging any process, you don't need to think/change the configuration, just set a breakpoint and "attach-all".

The other commit is a long standing drag and drop Linux exclusive bug. I left it printing to console, so it bothers people using Linux debug build, therefore increasing the chances of fixing it on electron upstream fix.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality

