### PR TITLE
fix: ensure the component title is never offset from the artboard.

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -12,6 +12,7 @@
       "Fixed visual glitches on certain scenarios when dragging items from the Library to the Stage.",
       "Syncing external designs is now automatically disabled after editing nested element properties on the timeline.",
       "Improved Firefox compatibility for Haikus with complex SVGs.",
+      "Fixed an issue causing the component name to sometimes appear offset from the artboard.",
       "Set multi-line expression editor tab width to 2 spaces."
     ]
   }

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -3676,11 +3676,10 @@ export class Glass extends React.Component {
 
           {(!this.isPreviewMode())
             ? <div
-              id="haiku-glass-stage-title-text-container"
               style={{
                 position: 'absolute',
                 zIndex: 10,
-                bottom: container.h - mount.y,
+                bottom: Math.min(container.h, window.innerHeight) - mount.y,
                 left: mount.x + 2,
                 height: 20,
                 width: mount.w,


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes [Project name moves up when scaling the stage](https://app.asana.com/0/833803172975584/842779597043479/f)

Regressions to look for:

- None. #math

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`
