### PR TITLE
fix: avoid errors when creating/renaming projects by not modifying projectsList

### DIFF
--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -131,8 +131,6 @@ class ProjectBrowser extends React.Component {
         this.setState({error});
         return;
       }
-      // newprojectbox is a placeholder for newProject boxorama
-      projectsList.unshift('newprojectbox');
       this.setState({projectsList}, this.updateDimensions);
       this.props.onProjectsList(projectsList);
     });
@@ -405,7 +403,7 @@ class ProjectBrowser extends React.Component {
         }
         }
       >
-        {this.state.projectsList.slice(
+        {['newprojectbox', ...this.state.projectsList].slice(
           this.state.firstDisplayedProject,
           this.state.firstDisplayedProject + this.state.numProjectsPerPage).map((projectObject) => (
           // newprojectbox is a placeholder for newProject boxorama


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes errors when creating/renaming projects product by `unshift`ing a string to `projectsList` instead of an object with the expected format.

I decided to create a new array instead of mutating `projectsList`, but if this has perf considerations we can explore other solutions.

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
