### PR TITLE
Hackathon fixes

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -17,7 +17,8 @@
       "Improve the performance of the Timeline when many rows are open.",
       "Fixed an issue causing the component name to sometimes appear offset from the artboard.",
       "Set multi-line expression editor tab width to 2 spaces.",
-      "Corrected the position of mouse events when the artboard is zoomed."
+      "Corrected the position of mouse events when the artboard is zoomed.",
+      "Fixed issues with missing raster images after duplicating a project."
     ]
   }
 }

--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -2096,7 +2096,9 @@ export default class HaikuComponent extends HaikuElement implements IHaikuCompon
     if (this.layoutAncestryMatrices) {
       const matrix = Layout3D.multiplyArrayOfMatrices(this.layoutAncestryMatrices.reverse());
       const inverse = invert([], matrix);
-      HaikuElement.transformPointInPlace(point, inverse);
+      if (inverse !== null) {
+        HaikuElement.transformPointInPlace(point, inverse);
+      }
     }
 
     return point;

--- a/packages/@haiku/core/src/Migration.ts
+++ b/packages/@haiku/core/src/Migration.ts
@@ -149,7 +149,9 @@ export const runMigrationsPrePhase = (component: IHaikuComponent, options: Migra
     for (const timelineName in bytecode.timelines) {
       for (const selector in bytecode.timelines[timelineName]) {
         for (const property in bytecode.timelines[timelineName][selector]) {
-          if (typeof bytecode.timelines[timelineName][selector][property] !== 'object') {
+          if (!bytecode.timelines[timelineName][selector][property]) {
+            delete bytecode.timelines[timelineName][selector][property];
+          } else if (typeof bytecode.timelines[timelineName][selector][property] !== 'object') {
             bytecode.timelines[timelineName][selector][property] = {
               0: {
                 value: bytecode.timelines[timelineName][selector][property],

--- a/packages/@haiku/core/src/Migration.ts
+++ b/packages/@haiku/core/src/Migration.ts
@@ -149,7 +149,7 @@ export const runMigrationsPrePhase = (component: IHaikuComponent, options: Migra
     for (const timelineName in bytecode.timelines) {
       for (const selector in bytecode.timelines[timelineName]) {
         for (const property in bytecode.timelines[timelineName][selector]) {
-          if (!bytecode.timelines[timelineName][selector][property]) {
+          if (bytecode.timelines[timelineName][selector][property] === null) {
             delete bytecode.timelines[timelineName][selector][property];
           } else if (typeof bytecode.timelines[timelineName][selector][property] !== 'object') {
             bytecode.timelines[timelineName][selector][property] = {

--- a/packages/haiku-common/src/math/geometryUtils.ts
+++ b/packages/haiku-common/src/math/geometryUtils.ts
@@ -157,7 +157,8 @@ export const pointOnPolyLineSegment = (
 
 export const transform2DPoint = (point: Vec2, ancestryMatrices: any[]): Vec2 => {
   const offset = Layout3D.multiplyArrayOfMatrices(ancestryMatrices);
-  const invertedOffset = create(); invert(invertedOffset, offset);
+  const invertedOffset = create();
+  invert(invertedOffset, offset);
   const p = [point.x, point.y, 0, 1];
   return {
     x: invertedOffset[0] * p[0] + invertedOffset[4] * p[1] + invertedOffset[8] * p[2] + invertedOffset[12] * p[3],

--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -1948,7 +1948,7 @@ class Element extends BaseModel {
             {
               elementName: 'defs',
               attributes: {},
-              children: defs.map(lodash.cloneDeep)
+              children: defs.map(Template.reuseHotMana)
             },
             // Note: by resetting IDs here, we willfully destroy any animations that are inside defs. Since this is an atypical
             // construct which can only be achieved by editing bytecode directly today, it's "acceptable".
@@ -1957,7 +1957,7 @@ class Element extends BaseModel {
         )
       }
 
-      node.children.unshift(...extraNodes.map(lodash.cloneDeep))
+      node.children.unshift(...extraNodes.map(Template.reuseHotMana))
       nodes.push(node)
     })
   }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Three unrelated changes from bugs encountered during last week's hackathon with OneGraph.
  - Fixes [null-valued opacity crashes core](https://app.asana.com/0/845286613726317/854040000213904/f).
  - Fixes (paid) user-reported issue related to missing raster images after duplicating a project. The new duplicate is simply copying the directory and removing `.git`. This is a battle-hardened technique I use all the time (project bootstrapping sets up the runtime critical configs correctly, and first publish fixes all the necessary metadata via `writeMetadata`).
  - Fixes obscure bug related to ungrouping something that has a defs node with layout on it.

Regressions to look for:

- None expected.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`
