### PR TITLE
fix: reset the redoable stack when we perform a regular action

### DIFF
--- a/packages/haiku-serialization/src/bll/ActionStack.js
+++ b/packages/haiku-serialization/src/bll/ActionStack.js
@@ -370,9 +370,13 @@ class ActionStack extends BaseModel {
         // Note that we use the cursor mode we snapshotted when the method was initiated
         if (
           // No cursor mode is equivalent to the default cursor mode
-          !metadata.cursor ||
-          metadata.cursor === ActionStack.CURSOR_MODES.undo
+          !metadata.cursor
         ) {
+          did = true
+          this.addUndoable(inverter, ac)
+          // Reset the redo stack.
+          this.redoables.length = 0
+        } else if (metadata.cursor === ActionStack.CURSOR_MODES.undo) {
           did = true
           this.addUndoable(inverter, ac)
         } else if (metadata.cursor === ActionStack.CURSOR_MODES.redo) {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Reset the redoable stack when we perform an action that isn't an undo or redo. This fixes some edge case bugs that seemed to lead to crashes during QA last week.

Regressions to look for:

- None.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
