### PR TITLE
fix: check if a property row should be updated based on its pretty value

### DIFF
--- a/packages/haiku-timeline/src/components/PropertyInputField.js
+++ b/packages/haiku-timeline/src/components/PropertyInputField.js
@@ -133,9 +133,10 @@ class PropertyInputFieldValueDisplay extends React.Component {
     }
     if (what === 'timeline-frame') {
       const valueDescriptor = this.props.row.getPropertyValueDescriptor();
-      if (valueDescriptor.computedValue !== this.valueDescriptor.computedValue) {
+      if (valueDescriptor.prettyValue && valueDescriptor.prettyValue.text !== this.valueDescriptor.prettyValue.text) {
         this.valueDescriptor = valueDescriptor;
         this.throttledForceUpdate();
+        this.forceUpdate();
       }
     }
   }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes ["Timeline property input shows wrong (cached) value"](https://app.asana.com/0/856556209422928/864034901419621) by checking if the react component should be updated based on its `prettyValue` instead of its `computedValue`.

Regressions to look for:

- none expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
