### PR TITLE
fix: ensure unique UIDs when forming cached ElementSelectionProxy

### DIFF
--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -575,10 +575,8 @@ class StageTitleBar extends React.Component {
 
   fetchProxyElementForSelection () {
     const component = this.getActiveComponent();
-
     if (component) {
-      const selection = Element.where({component, _isSelected: true});
-      return ElementSelectionProxy.fromSelection(selection, {component});
+      return ElementSelectionProxy.fromSelection(Element.where({component, _isSelected: true}), component);
     }
   }
 

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -2992,8 +2992,8 @@ export class Glass extends React.Component {
   }
 
   fetchProxyElementForSelection () {
-    const selection = Element.where({component: this.getActiveComponent(), _isSelected: true});
-    return ElementSelectionProxy.fromSelection(selection, {component: this.getActiveComponent()});
+    const component = this.getActiveComponent();
+    return ElementSelectionProxy.fromSelection(Element.where({component, _isSelected: true}), component);
   }
 
   renderDirectSelection (element, selectedAnchorIndices, overlays) {

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -1841,12 +1841,19 @@ class ActiveComponent extends BaseModel {
 
                   // We can't go further unless we actually have the reified bytecode
                   return ac.moduleReload('basicReload', () => {
-                    // In order to render correctly, the template.elementName needs to have the full
-                    // bytecode object; note that core should automatically instantiate a HaikuComponent
-                    lodash.assign(nested, ac.getReifiedBytecode())
+                    ac.doesMatchOrHostComponent(this, (_, answer) => {
+                      // First check (and silently skip) if we are a host of this bytecode. This error state
+                      // can be created by e.g. pasting a component instance from its host into itself.
+                      if (!answer) {
+                        // In order to render correctly, the template.elementName needs to have the full
+                        // bytecode object; note that core should automatically instantiate a HaikuComponent
+                        lodash.assign(nested, ac.getReifiedBytecode())
 
-                    haikuIds.push(this.pasteBytecodeImpl(bytecode, pasteable.data, options))
-                    return next()
+                        haikuIds.push(this.pasteBytecodeImpl(bytecode, pasteable.data, options))
+                      }
+
+                      return next()
+                    })
                   })
                 })
               }

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -2391,8 +2391,8 @@ ElementSelectionProxy.snaps = []
 // instance up to `drag` method on newly created ElementSelectionProxy instance
 ElementSelectionProxy._shouldCaptureMousePosition = false
 
-ElementSelectionProxy.fromSelection = (rawSelection, query) => {
-  const uid = rawSelection.map((element) => element.getPrimaryKey()).sort().join('+') || 'none'
+ElementSelectionProxy.fromSelection = (rawSelection, component) => {
+  const uid = `${component && component.getPrimaryKey()}+${rawSelection.map((element) => element.getPrimaryKey()).sort().join('+') || 'none'}`
 
   return ElementSelectionProxy.findById(uid) || ElementSelectionProxy.upsert(
     Object.assign({
@@ -2405,7 +2405,7 @@ ElementSelectionProxy.fromSelection = (rawSelection, query) => {
         return accumulator
       }, [])
     },
-    query
+    {component}
   ))
 }
 


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes [Crash: while testing "I can cut/copy elements on stage using keyboard controls"](https://app.asana.com/0/856556209422928/864277186293763/f). This was actually an old bug, and related to duplicate UIDs causing the system to resolve the wrong `ElementSelectionProxy`.
- Fixes related ability to accidentally paste a component instance into its definition. (Still broken: ability to paste a group containing a component instance into its definition, but this is progress.)

Regressions to look for:

- None.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
