### PR TITLE
Shells rabbit

### DIFF
--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -3664,14 +3664,13 @@ class ActiveComponent extends BaseModel {
 
                 // Not all views necessarily have the same collection of elements
                 if (element) {
+                  element.rehydrateRows()
                   Row.where({ component: this, element }).forEach((row) => {
                     if (experimentIsEnabled(Experiment.ExpandTimelinePropertiesFromStageChanges)) {
                       if (row.property && keyframeUpdates[timelineName][componentId][row.property.name]) {
                         row.expand(metadata)
                       }
                     }
-
-                    row.rehydrate()
                   })
                 }
               }

--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -1058,10 +1058,13 @@ class Element extends BaseModel {
 
     const clusters = {}
 
+    this.hasAddressableProperties = false
+
     this.eachAddressableProperty((
       propertyGroupDescriptor,
       addressableName
     ) => {
+      this.hasAddressableProperties = true
       if (propertyGroupDescriptor.cluster) {
         // Properties that are 'clustered', like rotation.x,y,z
         const clusterId = Row.buildClusterUid(

--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -65,12 +65,6 @@ function getAncestry (ancestors, elementInstance) {
   return ancestors
 }
 
-function anyEditedKeyframesInKeyframesObject (keyframesObject) {
-  if (!keyframesObject) return false
-  const values = Object.values(keyframesObject)
-  return values.filter((object) => { return object && object.edited }).length > 0
-}
-
 const cleanHaikuId = (str) => titlecase(decamelize((str + '').trim()).replace(/[\W_:]/g, ' '))
 
 /**
@@ -104,7 +98,7 @@ class Element extends BaseModel {
 
   afterInitialize () {
     // Make sure we add to the appropriate collections to avoid unexpected state issues
-    this.populateVisiblePropertiesFromKeyframes()
+    if (!this._visibleProperties) this._visibleProperties = {}
   }
 
   oneListener ($el, uid, type, fn) {
@@ -1529,19 +1523,7 @@ class Element extends BaseModel {
   }
 
   getDisplayedAddressableProperties () {
-    const ours = this.getCollatedAddressableProperties().filtered
-    return ours
-  }
-
-  populateVisiblePropertiesFromKeyframes () {
-    if (!this._visibleProperties) this._visibleProperties = {}
-    const completeAddressableProperties = this.getCompleteAddressableProperties()
-    for (const propertyName in completeAddressableProperties) {
-      const keyframesObject = this.getPropertyKeyframesObject(propertyName)
-      if (keyframesObject && anyEditedKeyframesInKeyframesObject(keyframesObject)) {
-        this._visibleProperties[propertyName] = completeAddressableProperties[propertyName]
-      }
-    }
+    return this.getCollatedAddressableProperties().filtered
   }
 
   getExplicitlyVisibleAddressableProperties () {

--- a/packages/haiku-serialization/src/bll/Property.js
+++ b/packages/haiku-serialization/src/bll/Property.js
@@ -500,7 +500,7 @@ const IF_EXPLICIT_OR_DEFINED = (name, element, property, keyframes) => (
 const IF_EXPLICIT = (name, element, property, keyframes) => !!element._visibleProperties[name]
 
 const IF_DEFINED = (name, element, property, keyframes) => (
-  keyframes && Object.keys(keyframes).length > 0
+  keyframes && Object.values(keyframes).some((keyframe) => keyframe.edited)
 )
 
 const IF_CHANGED_FROM_PREPOPULATED_VALUE = (name, element, property, keyframes) => wasChangedFromPrepopValue(name, keyframes)

--- a/packages/haiku-serialization/src/bll/Property.js
+++ b/packages/haiku-serialization/src/bll/Property.js
@@ -500,19 +500,7 @@ const IF_EXPLICIT_OR_DEFINED = (name, element, property, keyframes) => (
 const IF_EXPLICIT = (name, element, property, keyframes) => !!element._visibleProperties[name]
 
 const IF_DEFINED = (name, element, property, keyframes) => (
-  keyframes &&
-  (
-    Object.keys(keyframes).length > 0 ||
-    (keyframes[0] && keyframes[0].edited)
-  )
-)
-
-const IF_NOT_NONE = (name, element, property, keyframes) => (
-  keyframes &&
-  (
-    keyframes.length > 1 ||
-    (keyframes && keyframes[0] && keyframes[0].value !== 'none')
-  )
+  keyframes && Object.keys(keyframes).length > 0
 )
 
 const IF_CHANGED_FROM_PREPOPULATED_VALUE = (name, element, property, keyframes) => wasChangedFromPrepopValue(name, keyframes)
@@ -650,7 +638,7 @@ Property.DISPLAY_RULES = {
   'cx': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT_OR_DEFINED]},
   'cy': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT_OR_DEFINED]},
   'd': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT_OR_DEFINED]},
-  'fill': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT_OR_DEFINED, IF_NOT_NONE]},
+  'fill': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT_OR_DEFINED]},
   'fillOpacity': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT]},
   'fillRule': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT]},
   'fontFamily': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT_OR_DEFINED]},
@@ -667,7 +655,7 @@ Property.DISPLAY_RULES = {
   'rx': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT_OR_DEFINED]},
   'ry': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT_OR_DEFINED]},
   'stopColor': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT]},
-  'stroke': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT_OR_DEFINED, IF_NOT_NONE]},
+  'stroke': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT_OR_DEFINED]},
   'strokeOpacity': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT]},
   'strokeWidth': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT]},
   'textAnchor': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT]},

--- a/packages/haiku-serialization/src/bll/Property.js
+++ b/packages/haiku-serialization/src/bll/Property.js
@@ -504,73 +504,50 @@ const NEVER = () => false
 
 const ALWAYS = () => true
 
-const NON_ROOT_ONLY = (name, element) => {
-  return !element.isRootElement()
-}
+const NON_ROOT_ONLY = (name, element) => !element.isRootElement()
 
-const ROOT_ONLY = (name, element) => {
-  return element.isRootElement()
-}
+const ROOT_ONLY = (name, element) => element.isRootElement()
 
-const NON_COMPONENT_ONLY = (name, element) => {
-  return !element.isComponent()
-}
+const NON_COMPONENT_ONLY = (name, element) => !element.isComponent()
 
-const COMPONENT_ONLY = (name, element) => {
-  return element.isComponent()
-}
+const COMPONENT_ONLY = (name, element) => element.isComponent()
 
-const IF_EXPLICIT_OR_DEFINED = (name, element, property, keyframes) => {
-  return (
-    IF_EXPLICIT(name, element, property, keyframes) ||
-    IF_DEFINED(name, element, property, keyframes)
+const ROOT_CHILD_ONLY = (name, element, property, keyframes) => element.isVisuallySelectable
+
+const IF_EXPLICIT_OR_DEFINED = (name, element, property, keyframes) => (
+  IF_EXPLICIT(name, element, property, keyframes) ||
+  IF_DEFINED(name, element, property, keyframes)
+)
+
+const IF_EXPLICIT = (name, element, property, keyframes) => !!element._visibleProperties[name]
+
+const IF_DEFINED = (name, element, property, keyframes) => (
+  keyframes &&
+  (
+    Object.keys(keyframes).length > 0 ||
+    (keyframes[0] && keyframes[0].edited)
   )
-}
+)
 
-const IF_EXPLICIT = (name, element, property, keyframes) => {
-  return !!element._visibleProperties[name]
-}
+const IF_NOT_NONE = (name, element, property, keyframes) => (
+  keyframes &&
+  (
+    keyframes.length > 1 ||
+    (keyframes && keyframes[0] && keyframes[0].value !== 'none')
+  )
+)
 
-const IF_DEFINED = (name, element, property, keyframes) => {
-  return keyframes && Object.keys(keyframes).length > 0
-}
+const IF_CHANGED_FROM_PREPOPULATED_VALUE = (name, element, property, keyframes) => wasChangedFromPrepopValue(name, keyframes)
 
-const IF_NOT_NONE = (name, element, property, keyframes) => {
-  if (!keyframes) {
-    return false
-  }
+const IF_IN_SCHEMA = (name, element) => hasInSchema(element.getSafeDomFriendlyName(), name)
 
-  if (keyframes.length > 1) {
-    return true
-  }
-
-  const value = keyframes && keyframes[0] && keyframes[0].value
-  return value !== 'none'
-}
-
-const IF_CHANGED_FROM_PREPOPULATED_VALUE = (name, element, property, keyframes) => {
-  return wasChangedFromPrepopValue(name, keyframes)
-}
-
-const IF_IN_SCHEMA = (name, element) => {
-  const elementName = element.getSafeDomFriendlyName()
-  return hasInSchema(elementName, name)
-}
-
-const IF_TEXT_CONTENT_ENABLED = (name, element, property, keyframes) => {
-  if (element.children.length < 1) {
-    return true
-  }
-
+const IF_TEXT_CONTENT_ENABLED = (name, element, property, keyframes) => (
+  element.children.length < 1 ||
   // Sketch-produced SVGs often have <text><tspan>content, but since <text>
   // can also have raw content inside it, we do this check to exclude it if
   // it happens to contain an inner <tspan>
-  if (typeof element.children[0] !== 'string') {
-    return false
-  }
-
-  return true
-}
+  typeof element.children[0] === 'string'
+)
 
 const wasChangedFromPrepopValue = (name, keyframes) => {
   const fallback = Property.PREPOPULATED_VALUES[name]
@@ -587,12 +564,10 @@ const wasChangedFromPrepopValue = (name, keyframes) => {
   )
 }
 
-const hasInSchema = (elementName, propertyName) => {
-  return (
-    Property.BUILTIN_DOM_SCHEMAS[elementName] &&
-    Property.BUILTIN_DOM_SCHEMAS[elementName][propertyName]
-  )
-}
+const hasInSchema = (elementName, propertyName) => (
+  Property.BUILTIN_DOM_SCHEMAS[elementName] &&
+  Property.BUILTIN_DOM_SCHEMAS[elementName][propertyName]
+)
 
 Property.areAnyKeyframesDefined = (elementName, propertyName, keyframesObject) => {
   const mss = Object.keys(keyframesObject)
@@ -632,23 +607,23 @@ Property.DISPLAY_RULES = {
   'haiku-title': {jit: [NEVER], add: [NEVER]},
   'haiku-var': {jit: [NEVER], add: [NEVER]},
   'height': {jit: [NEVER], add: [NEVER]},
-  'offset.x': {jit: [NEVER], add: [IF_EXPLICIT_OR_DEFINED]},
-  'offset.y': {jit: [NEVER], add: [IF_EXPLICIT_OR_DEFINED]},
-  'offset.z': {jit: [NEVER], add: [IF_EXPLICIT_OR_DEFINED]},
+  'offset.x': {jit: [NEVER], add: [NEVER]},
+  'offset.y': {jit: [NEVER], add: [NEVER]},
+  'offset.z': {jit: [NEVER], add: [NEVER]},
   'opacity': {jit: [NEVER], add: [ALWAYS]},
-  'origin.x': {jit: [NON_ROOT_ONLY], add: [NON_ROOT_ONLY]},
-  'origin.y': {jit: [NON_ROOT_ONLY], add: [NON_ROOT_ONLY]},
+  'origin.x': {jit: [ROOT_CHILD_ONLY], add: [ROOT_CHILD_ONLY]},
+  'origin.y': {jit: [ROOT_CHILD_ONLY], add: [ROOT_CHILD_ONLY]},
   'origin.z': {jit: [NEVER], add: [NEVER]},
   'playback': {jit: [NEVER], add: [NON_ROOT_ONLY, COMPONENT_ONLY]},
-  'rotation.x': {jit: [NON_ROOT_ONLY], add: [NON_ROOT_ONLY]},
-  'rotation.y': {jit: [NON_ROOT_ONLY], add: [NON_ROOT_ONLY]},
-  'rotation.z': {jit: [NON_ROOT_ONLY], add: [NON_ROOT_ONLY]},
-  'scale.x': {jit: [NON_ROOT_ONLY], add: [NON_ROOT_ONLY]},
-  'scale.y': {jit: [NON_ROOT_ONLY], add: [NON_ROOT_ONLY]},
-  'scale.z': {jit: [NON_ROOT_ONLY], add: [NON_ROOT_ONLY]},
-  'shear.xy': {jit: [NON_ROOT_ONLY], add: [NEVER]},
-  'shear.xz': {jit: [NON_ROOT_ONLY], add: [NEVER]},
-  'shear.yz': {jit: [NON_ROOT_ONLY], add: [NEVER]},
+  'rotation.x': {jit: [ROOT_CHILD_ONLY], add: [ROOT_CHILD_ONLY]},
+  'rotation.y': {jit: [ROOT_CHILD_ONLY], add: [ROOT_CHILD_ONLY]},
+  'rotation.z': {jit: [ROOT_CHILD_ONLY], add: [ROOT_CHILD_ONLY]},
+  'scale.x': {jit: [ROOT_CHILD_ONLY], add: [ROOT_CHILD_ONLY]},
+  'scale.y': {jit: [ROOT_CHILD_ONLY], add: [ROOT_CHILD_ONLY]},
+  'scale.z': {jit: [NEVER], add: [NEVER]},
+  'shear.xy': {jit: [NEVER], add: [NEVER]},
+  'shear.xz': {jit: [NEVER], add: [NEVER]},
+  'shear.yz': {jit: [NEVER], add: [NEVER]},
   'shown': {jit: [NEVER], add: [NEVER]},
   'sizeAbsolute.x': {jit: [NON_ROOT_ONLY, COMPONENT_ONLY], add: [ROOT_ONLY]},
   'sizeAbsolute.y': {jit: [NON_ROOT_ONLY, COMPONENT_ONLY], add: [ROOT_ONLY]},
@@ -694,9 +669,9 @@ Property.DISPLAY_RULES = {
   'style.zIndex': {jit: [NON_ROOT_ONLY], add: [NON_ROOT_ONLY]},
   'transform': {jit: [NEVER], add: [NEVER]},
   'transformOrigin': {jit: [NEVER], add: [NEVER]},
-  'translation.x': {jit: [NEVER], add: [NON_ROOT_ONLY]},
-  'translation.y': {jit: [NEVER], add: [NON_ROOT_ONLY]},
-  'translation.z': {jit: [NEVER], add: [NON_ROOT_ONLY]},
+  'translation.x': {jit: [NEVER], add: [ROOT_CHILD_ONLY]},
+  'translation.y': {jit: [NEVER], add: [ROOT_CHILD_ONLY]},
+  'translation.z': {jit: [NEVER], add: [NEVER]},
   'width': {jit: [NEVER], add: [NEVER]},
   // Primitives
   'alignmentBaseline': {jit: [IF_IN_SCHEMA], add: [IF_EXPLICIT]},
@@ -745,29 +720,7 @@ Property.includeInAddressables = (name, element, property, keyframes) => {
 // indicate that the property should be displayed for the given element
 Property.includeInDisplay = (type, name, element, property, keyframes) => {
   const rule = Property.DISPLAY_RULES[name]
-  const tests = rule && rule[type]
-
-  if (!tests) {
-    return false
-  }
-
-  let include = true
-
-  for (let i = 0; i < tests.length; i++) {
-    // Early exit if we've found that one of the truth tests returned false
-    if (!include) {
-      break
-    }
-
-    include = tests[i](
-      name,
-      element,
-      property,
-      keyframes
-    )
-  }
-
-  return include
+  return rule && rule[type] && rule[type].every((test) => test(name, element, property, keyframes))
 }
 
 Property.buildFilterObject = (
@@ -800,25 +753,15 @@ Property.buildFilterObject = (
   const hasOneKeyframe = keyframesObject && Object.keys(keyframesObject).length === 1
   const wasZerothKeyframeEdited = keyframesObject && keyframesObject[0] && keyframesObject[0].edited
 
-  // If the property has any keyframes defined (or explicitly edited), then we show it.
-  if (hasManyKeyframes) {
-    filtered[propertyName] = propertyObject
-    return
-  }
-
-  if (hasOneKeyframe && !keyframesObject[0]) {
-    filtered[propertyName] = propertyObject
-    return
-  }
-
-  if (wasZerothKeyframeEdited) {
-    filtered[propertyName] = propertyObject
-    return
-  }
-
-  // Finally, we drop through to custom per-property rules that may depend on the element type,
-  // its location in the tree, or what the value of its property is.
-  if (Property.includeInAddressables(propertyName, hostElement, propertyObject, keyframesObject)) {
+  if (
+    // If the property has any keyframes defined (or explicitly edited), then we show it.
+    hasManyKeyframes ||
+    (hasOneKeyframe && !keyframesObject[0]) ||
+    wasZerothKeyframeEdited ||
+    // Finally, we drop through to custom per-property rules that may depend on the element type,
+    // its location in the tree, or what the value of its property is.
+    Property.includeInAddressables(propertyName, hostElement, propertyObject, keyframesObject)
+  ) {
     filtered[propertyName] = propertyObject
   }
 }

--- a/packages/haiku-serialization/src/bll/Row.js
+++ b/packages/haiku-serialization/src/bll/Row.js
@@ -605,7 +605,9 @@ class Row extends BaseModel {
     let depth = 0
     let parent = this.parent
     while (parent) {
-      depth += 1
+      if (parent.element.hasAddressableProperties) {
+        depth += 1
+      }
       parent = parent.parent
     }
     return depth

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -946,13 +946,13 @@ Timeline.getPropertyValueDescriptor = function getPropertyValueDescriptor (timel
   }
 
   if (prettyValue === undefined) {
-    prettyValue = (typeof computedValue === 'number')
+    const formattedPrettyValue = (typeof computedValue === 'number')
       ? numeral(computedValue || 0).format(options.numFormat || '0,0[.]0')
       : computedValue
 
-    // TODO: remove this check when https://github.com/adamwdraper/Numeral-js/pull/629 is merged
-    if (isNaN(prettyValue)) {
-      prettyValue = computedValue
+    prettyValue = {
+      // TODO: remove this check when https://github.com/adamwdraper/Numeral-js/pull/629 is merged
+      text: isNaN(formattedPrettyValue) ? computedValue : formattedPrettyValue,
     }
   }
 

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -952,7 +952,7 @@ Timeline.getPropertyValueDescriptor = function getPropertyValueDescriptor (timel
 
     prettyValue = {
       // TODO: remove this check when https://github.com/adamwdraper/Numeral-js/pull/629 is merged
-      text: isNaN(formattedPrettyValue) ? computedValue : formattedPrettyValue,
+      text: isNaN(formattedPrettyValue) ? computedValue : formattedPrettyValue
     }
   }
 

--- a/packages/haiku-timeline/src/components/ClusterInputField.js
+++ b/packages/haiku-timeline/src/components/ClusterInputField.js
@@ -91,7 +91,7 @@ function remapPrettyValue (prettyValue) {
   if (prettyValue && prettyValue.render === 'react') {
     return <span style={prettyValue.style}>{safeText(prettyValue.text)}</span>;
   }
-  return safeText(prettyValue);
+  return safeText(prettyValue.text);
 }
 
 function safeText (textOrObj) {

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -192,7 +192,7 @@ export default class ComponentHeadingRow extends React.Component {
               backgroundColor: 'transparent',
               display: 'flex',
               flexDirection: 'column',
-              paddingLeft: 27 * (this.props.row.getDepthAmongRows() - 1),
+              paddingLeft: 27 * (depth - 1),
             }}>
             <div
               className="component-heading-row-inner-r1"

--- a/packages/haiku-timeline/src/components/PropertyInputField.js
+++ b/packages/haiku-timeline/src/components/PropertyInputField.js
@@ -167,7 +167,7 @@ function remapPrettyValue (prettyValue) {
   if (prettyValue && prettyValue.render === 'react') {
     return <span style={prettyValue.style}>{safeText(prettyValue.text)}</span>;
   }
-  return safeText(prettyValue);
+  return safeText(prettyValue.text);
 }
 
 PropertyInputField.propTypes = {

--- a/packages/haiku-timeline/src/components/PropertyManager.js
+++ b/packages/haiku-timeline/src/components/PropertyManager.js
@@ -8,9 +8,14 @@ const STYLE = {
     fontSize: '11px',
     fontFamily: 'inherit',
     cursor: 'pointer',
-    borderRadius: '2px',
-    background: Palette.DARK_GRAY,
-    padding: '2px 10px',
+    borderRadius: 2,
+    background: Palette.COAL,
+    padding: '1px 10px',
+  },
+  plus: {
+    fontSize: 18,
+    lineHeight: 0,
+    verticalAlign: 'middle',
   },
 };
 
@@ -30,21 +35,21 @@ export default class PropertyManager extends React.Component {
   }
 
   render () {
-    const width = 60;
+    const width = 64;
     return (
       <div className="property-manager" style={{
         width,
         textAlign: 'center',
         height: 30,
-        paddingTop: 4,
-        marginLeft: this.props.timelinePropertiesWidth - width - 5,
+        paddingTop: 6,
+        marginLeft: this.props.timelinePropertiesWidth - width - 9,
       }}>
         <div
           onClick={this.launchMenu}
           style={STYLE.button}
           className="menu-trigger"
           >
-          + ADD
+          <span style={STYLE.plus}>+</span> ADD
         </div>
       </div>
     );

--- a/packages/haiku-timeline/src/components/PropertyRow.js
+++ b/packages/haiku-timeline/src/components/PropertyRow.js
@@ -12,29 +12,15 @@ import zIndex from './styles/zIndex';
 
 const STYLE = {
   helper: {
-    position: 'sticky',
     left: 0,
     clear: 'both',
     width: 300,
-    height: 14,
     zIndex: 10,
-    backgroundColor: Palette.GRAY,
-
     position: 'sticky',
-    left: '0px',
-    clear: 'both',
-    width: '300px',
-    height: '36px',
+    height: 1,
     zIndex: 9,
-    backgroundColor: 'rgb(52, 63, 65)',
-    marginBottom: '0px',
+    marginBottom: 0,
     transform: 'translateY(-8px) scaleY(1.46)',
-  },
-  wrapper: {
-    zIndex: '8',
-    position: 'sticky',
-    left: '0',
-    backgroundColor: Palette.GRAY,
   },
 };
 

--- a/packages/haiku-timeline/src/components/RowManager.js
+++ b/packages/haiku-timeline/src/components/RowManager.js
@@ -24,6 +24,16 @@ class RowManager extends React.PureComponent {
     });
   }
 
+  componentWillUpdate ({group}) {
+    group.rows.forEach((row) => {
+      if (row.isHeading() || row.isClusterHeading()) {
+        // In case we already had a bound listener, remove it.
+        row.removeListener('update', this.handleUpdate);
+        row.on('update', this.handleUpdate);
+      }
+    });
+  }
+
   componentWillUnmount () {
     this.props.group.rows.forEach((row) => {
       if (row.isHeading() || row.isClusterHeading()) {

--- a/packages/haiku-timeline/src/components/ScrollView.js
+++ b/packages/haiku-timeline/src/components/ScrollView.js
@@ -61,7 +61,6 @@ class ScrollView extends React.PureComponent {
       >
         {this.props.children}
         <div style={{
-          background: Palette.GRAY,
           zIndex: zIndex.backgroundHelper.base,
           flex: 1,
           width: this.props.propertiesPixelWidth,


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Small tweak/fix for #862—gives `prettyValue` a normalized structure so that we can always use it like an object.
 - Some minor rabbit/hat work for shells-ui—adds an `IF_ROOT_CHILD` check for property display/row hydration and applies it to layout properties. Also hides some sketchy 2.5D (z-related) properties.

Regressions to look for:

- Please test carefully, but this should simply not populate rows for properties we don't want to display.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality