### PR TITLE
feat: include an ADD button to define JIT properties

### DIFF
--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.js
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.js
@@ -9,7 +9,6 @@ import * as Element from 'haiku-serialization/src/bll/Element';
 import ComponentHeadingRowHeading from './ComponentHeadingRowHeading';
 import CollapsedPropertyTimelineSegments from './CollapsedPropertyTimelineSegments';
 import EventHandlerTriggerer from './EventHandlerTriggerer';
-import PropertyManager from './PropertyManager';
 import zIndex from './styles/zIndex';
 import * as mixpanel from 'haiku-serialization/src/utils/Mixpanel';
 
@@ -275,18 +274,6 @@ export default class ComponentHeadingRow extends React.Component {
                     boltColor={boltColor}
                     onEventHandlerTriggered={this.props.onEventHandlerTriggered}
                     />
-                  : ''}
-              </div>
-              <div
-                title="Add property"
-                className="property-manager-button light-on-hover"
-                style={{
-                  ...STYLES.actionButton,
-                }}>
-                {(this.props.isExpanded)
-                  ? <PropertyManager
-                    element={this.props.row.element}
-                  />
                   : ''}
               </div>
             </div>

--- a/packages/haiku-timeline/src/components/PropertyManager.js
+++ b/packages/haiku-timeline/src/components/PropertyManager.js
@@ -1,17 +1,23 @@
 import * as React from 'react';
-import CirclePlusSVG from 'haiku-ui-common/lib/react/icons/CirclePlusSVG';
 import Palette from 'haiku-ui-common/lib/Palette';
 import PopoverMenu from 'haiku-ui-common/lib/electron/PopoverMenu';
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+
+const STYLE = {
+  button: {
+    color: Palette.PALE_GRAY,
+    fontSize: '11px',
+    fontFamily: 'inherit',
+    cursor: 'pointer',
+    borderRadius: '2px',
+    background: Palette.DARK_GRAY,
+    padding: '2px 10px',
+  },
+};
 
 export default class PropertyManager extends React.Component {
   constructor (props) {
     super(props);
     this.launchMenu = this.launchMenu.bind(this);
-  }
-
-  getIconColor () {
-    return Palette.DARK_ROCK;
   }
 
   launchMenu (event) {
@@ -24,16 +30,21 @@ export default class PropertyManager extends React.Component {
   }
 
   render () {
+    const width = 60;
     return (
-      <div className="property-manager">
+      <div className="property-manager" style={{
+        width,
+        textAlign: 'center',
+        height: 30,
+        paddingTop: 4,
+        marginLeft: this.props.timelinePropertiesWidth - width - 5,
+      }}>
         <div
           onClick={this.launchMenu}
+          style={STYLE.button}
           className="menu-trigger"
-          style={{
-            transform: 'scale(0.75)',
-          }}>
-          <CirclePlusSVG
-            color={this.getIconColor()} />
+          >
+          + ADD
         </div>
       </div>
     );
@@ -42,4 +53,5 @@ export default class PropertyManager extends React.Component {
 
 PropertyManager.propTypes = {
   element: React.PropTypes.object.isRequired,
+  timelinePropertiesWidth: React.PropTypes.number,
 };

--- a/packages/haiku-timeline/src/components/RowManager.js
+++ b/packages/haiku-timeline/src/components/RowManager.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import ClusterRow from './ClusterRow';
 import PropertyRow from './PropertyRow';
 import ComponentHeadingRow from './ComponentHeadingRow';
+import PropertyManager from './PropertyManager';
 class RowManager extends React.PureComponent {
   constructor (props) {
     super(props);
@@ -62,23 +63,26 @@ class RowManager extends React.PureComponent {
     }
 
     if (row.isHeading()) {
-      return (
-        <ComponentHeadingRow
-          key={row.getUniqueKey()}
-          rowHeight={this.props.rowHeight}
-          timeline={activeComponent.getCurrentTimeline()}
-          component={activeComponent}
-          row={row}
-          onEventHandlerTriggered={this.props.showEventHandlersEditor}
-          isExpanded={row.isExpanded()}
-          isHidden={row.isHidden()}
-          isSelected={row.isSelected()}
-          hasAttachedActions={row.element.getVisibleEvents().length > 0}
-          dragHandleProps={this.props.dragHandleProps}
-          setEditingRowTitleStatus={this.props.setEditingRowTitleStatus}
-          timelinePropertiesWidth={this.props.timelinePropertiesWidth}
-        />
-      );
+      return [
+        (
+          <ComponentHeadingRow
+            key={row.getUniqueKey()}
+            rowHeight={this.props.rowHeight}
+            timeline={activeComponent.getCurrentTimeline()}
+            component={activeComponent}
+            row={row}
+            onEventHandlerTriggered={this.props.showEventHandlersEditor}
+            isExpanded={row.isExpanded()}
+            isHidden={row.isHidden()}
+            isSelected={row.isSelected()}
+            hasAttachedActions={row.element.getVisibleEvents().length > 0}
+            dragHandleProps={this.props.dragHandleProps}
+            setEditingRowTitleStatus={this.props.setEditingRowTitleStatus}
+            timelinePropertiesWidth={this.props.timelinePropertiesWidth}
+          />
+        ),
+        (row.isExpanded() && <PropertyManager key={`wereree-${row.getUniqueKey()}`} element={row.element} timelinePropertiesWidth={this.props.timelinePropertiesWidth}/>),
+      ];
     }
 
     // If we got here, display nothing since we don't know what to render


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- As the title says, this add a button on top of every element group to add properties, this makes sense in the context of #866 as we want to better expose the ability to add properties.

Regressions to look for:

- none expected, but please take a look

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
