### PR TITLE
Fix mergeDesigns-related integrity crash

### DIFF
--- a/packages/haiku-serialization/src/bll/Template.js
+++ b/packages/haiku-serialization/src/bll/Template.js
@@ -155,7 +155,7 @@ Template.mirrorHaikuUids = (fromNode, toNode) => {
   }
 }
 
-Template.manaWithOnlyMinimalProps = (mana, referenceSerializer) => {
+Template.manaWithOnlyMinimalProps = (mana, referenceSerializer, includeChildren = true) => {
   if (mana && typeof mana === 'object') {
     const out = {}
 
@@ -187,14 +187,15 @@ Template.manaWithOnlyMinimalProps = (mana, referenceSerializer) => {
     }
 
     // Don't include the children if this node is a component, since those aren't in scope
-    if (typeof mana.elementName !== 'object' && mana.children) {
+    if (includeChildren && typeof mana.elementName !== 'object' && mana.children) {
       out.children = mana.children.filter((child) => {
         // Exclude any empty or content-string elements.
         // This sidesteps the problem where one process shows e.g. children:["BLAH"]
         // but another process shows children:[], which results in unstable hashes
         return child && typeof child !== 'string'
       }).map((child) => {
-        return Template.manaWithOnlyMinimalProps(child, referenceSerializer)
+        // Skip children of children. This should prevent mergeDesigns-related integrity crashes.
+        return Template.manaWithOnlyMinimalProps(child, referenceSerializer, false)
       })
     } else {
       out.children = []

--- a/packages/haiku-serialization/test/bll/01_ActiveComponent.z.test.js
+++ b/packages/haiku-serialization/test/bll/01_ActiveComponent.z.test.js
@@ -29,13 +29,13 @@ tape('ActiveComponent.prototype.instantiateComponent-with-z', (t) => {
         (cb) => { return ac0.instantiateComponent('designs/Circle.svg', {}, {from: 'test'}, cb) },
         (cb) => { t.deepEqual(ac0.getRawStackingInfo('Default', 0), [ { zIndex: 1, haikuId: 'Circle-c6c7407a1b09588e' } ]); return cb() },
         (cb) => { return ac0.instantiateComponent('designs/Circle.svg', {}, {from: 'test'}, cb) },
-        (cb) => { t.deepEqual(ac0.getRawStackingInfo('Default', 0), [ { zIndex: 1, haikuId: 'Circle-c6c7407a1b09588e' }, { zIndex: 2, haikuId: 'Circle-efe81609c3126d58' } ]); return cb() },
+        (cb) => { t.deepEqual(ac0.getRawStackingInfo('Default', 0), [ { zIndex: 1, haikuId: 'Circle-c6c7407a1b09588e' }, { zIndex: 2, haikuId: 'Circle-21d1ab9f688d6255' } ]); return cb() },
         (cb) => { return ac0.instantiateComponent('designs/Circle.svg', {}, {from: 'test'}, cb) },
-        (cb) => { t.deepEqual(ac0.getRawStackingInfo('Default', 0), [ { zIndex: 1, haikuId: 'Circle-c6c7407a1b09588e' }, { zIndex: 2, haikuId: 'Circle-efe81609c3126d58' }, { zIndex: 3, haikuId: 'Circle-2c5057e77fe0398a' } ]); return cb() },
+        (cb) => { t.deepEqual(ac0.getRawStackingInfo('Default', 0), [ { zIndex: 1, haikuId: 'Circle-c6c7407a1b09588e' }, { zIndex: 2, haikuId: 'Circle-21d1ab9f688d6255' }, { zIndex: 3, haikuId: 'Circle-d6c581ca76e44f6f' } ]); return cb() },
         (cb) => { return ac0.instantiateComponent('designs/Circle.svg', {}, {from: 'test'}, cb) },
-        (cb) => { t.deepEqual(ac0.getRawStackingInfo('Default', 0), [ { zIndex: 1, haikuId: 'Circle-c6c7407a1b09588e' }, { zIndex: 2, haikuId: 'Circle-efe81609c3126d58' }, { zIndex: 3, haikuId: 'Circle-2c5057e77fe0398a' }, { zIndex: 4, haikuId: 'Circle-c650035be072d924' } ]); return cb() },
+        (cb) => { t.deepEqual(ac0.getRawStackingInfo('Default', 0), [ { zIndex: 1, haikuId: 'Circle-c6c7407a1b09588e' }, { zIndex: 2, haikuId: 'Circle-21d1ab9f688d6255' }, { zIndex: 3, haikuId: 'Circle-d6c581ca76e44f6f' }, { zIndex: 4, haikuId: 'Circle-e176f05781147ca7' } ]); return cb() },
         (cb) => { return ac0.zMoveBackward('a1ace0824b5d', 'Default', 0, {from: 'test'}, cb) },
-        (cb) => { t.deepEqual(ac0.getRawStackingInfo('Default', 0), [ { zIndex: 1, haikuId: 'Circle-c6c7407a1b09588e' }, { zIndex: 2, haikuId: 'Circle-efe81609c3126d58' }, { zIndex: 3, haikuId: 'Circle-2c5057e77fe0398a' }, { zIndex: 4, haikuId: 'Circle-c650035be072d924' } ]); return cb() },
+        (cb) => { t.deepEqual(ac0.getRawStackingInfo('Default', 0), [ { zIndex: 1, haikuId: 'Circle-c6c7407a1b09588e' }, { zIndex: 2, haikuId: 'Circle-21d1ab9f688d6255' }, { zIndex: 3, haikuId: 'Circle-d6c581ca76e44f6f' }, { zIndex: 4, haikuId: 'Circle-e176f05781147ca7' } ]); return cb() },
       ], (err) => {
         if (err) throw err
         fse.removeSync(folder)


### PR DESCRIPTION
OK to merge after sanity check. Discussing with @zackbrown now.

Short review.

Summary of changes:

- Revise integrity hash to be grandchild-agnostic. A longstanding integrity crash we've been seeing is related to the simple fact that sometimes, `mergeDesigns` will change the internal structure of existing template nodes that are instantiated in the template—but in a way that is ultimately irrelevant to what I understand to be the primary purpose of the integrity hash, which is to async generate the same IDs when instantiating children in Haiku.

Regressions to look for:

- We should just SLAM this after getting tests to pass—too many hidden corners to accurately anticipate possible issues.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
