### PR TITLE
The "trivial" JIT

### DIFF
--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const logger = require('./../utils/LoggerInstance')
 const BaseModel = require('./BaseModel')
-const {rounded, transformFourVectorByMatrix} = require('./MathUtils')
+const {rounded, transformFourVectorByMatrix, basicallyEquals} = require('./MathUtils')
 const TransformCache = require('./TransformCache')
 const {default: Layout3D} = require('@haiku/core/lib/Layout3D')
 const {default: HaikuElement} = require('@haiku/core/lib/HaikuElement')
@@ -2363,6 +2363,11 @@ ElementSelectionProxy.accumulateKeyframeUpdates = (
 
   for (const propertyName in propertyGroup) {
     if (!out[timelineName][componentId][propertyName]) {
+      if (basicallyEquals(Property.PREPOPULATED_VALUES[propertyName], propertyGroup[propertyName].value)) {
+        // Are we setting a layout property to the default value for the first time? If yes, just skip it.
+        // Because of rounding errors, we should allow a reasonable margin of error.
+        continue
+      }
       out[timelineName][componentId][propertyName] = {}
     }
 

--- a/packages/haiku-serialization/src/bll/MathUtils.js
+++ b/packages/haiku-serialization/src/bll/MathUtils.js
@@ -9,7 +9,7 @@ const rounded = (n, d = 3) => {
   return Math.round(n * powerOfTen) / powerOfTen
 }
 
-const basicallyEquals = (n, m) => Math.abs(n - m) < 1e-4
+const basicallyEquals = (n, m) => typeof n === 'number' && typeof m === 'number' && Math.abs(n - m) < 1e-3
 
 const isCoordInsideBoxPoints = (px, py, boxPoints) => pointInPolygon(
   [px, py], [

--- a/packages/haiku-serialization/src/bll/Property.js
+++ b/packages/haiku-serialization/src/bll/Property.js
@@ -523,7 +523,27 @@ const wasChangedFromPrepopValue = (name, keyframes) => {
     return true
   }
 
-  return keyframes && Object.values(keyframes).some((keyframe) => keyframe.value !== Property.PREPOPULATED_VALUES[name])
+  if (!keyframes) {
+    return false
+  }
+
+  const keys = Object.keys(keyframes)
+
+  // Consider the prepolated value effectively changed…
+  return (
+    // If there is more than one key…
+    keys.length > 1 ||
+    (
+      // …or if there is exactly one key…
+      keys.length === 1 &&
+      (
+        // …which is either nonzero (this should never happen)…
+        keys[0] !== 0 ||
+        // …or different from the prepopulated value.
+        keyframes[0].value !== Property.PREPOPULATED_VALUES[name]
+      )
+    )
+  )
 }
 
 const hasInSchema = (elementName, propertyName) => (
@@ -582,10 +602,10 @@ Property.DISPLAY_RULES = {
   'rotation.z': {jit: [ROOT_CHILD_ONLY], add: [ROOT_CHILD_ONLY, IF_CHANGED_FROM_PREPOPULATED_VALUE]},
   'scale.x': {jit: [ROOT_CHILD_ONLY], add: [ROOT_CHILD_ONLY, IF_CHANGED_FROM_PREPOPULATED_VALUE]},
   'scale.y': {jit: [ROOT_CHILD_ONLY], add: [ROOT_CHILD_ONLY, IF_CHANGED_FROM_PREPOPULATED_VALUE]},
-  'scale.z': {jit: [NEVER], add: [NEVER]},
-  'shear.xy': {jit: [NEVER], add: [NEVER]},
-  'shear.xz': {jit: [NEVER], add: [NEVER]},
-  'shear.yz': {jit: [NEVER], add: [NEVER]},
+  'scale.z': {jit: [NEVER], add: [ROOT_CHILD_ONLY, IF_CHANGED_FROM_PREPOPULATED_VALUE]},
+  'shear.xy': {jit: [NEVER], add: [ROOT_CHILD_ONLY, IF_CHANGED_FROM_PREPOPULATED_VALUE]},
+  'shear.xz': {jit: [NEVER], add: [ROOT_CHILD_ONLY, IF_CHANGED_FROM_PREPOPULATED_VALUE]},
+  'shear.yz': {jit: [NEVER], add: [ROOT_CHILD_ONLY, IF_CHANGED_FROM_PREPOPULATED_VALUE]},
   'shown': {jit: [NEVER], add: [NEVER]},
   'sizeAbsolute.x': {jit: [NON_ROOT_ONLY, COMPONENT_ONLY], add: [ROOT_ONLY]},
   'sizeAbsolute.y': {jit: [NON_ROOT_ONLY, COMPONENT_ONLY], add: [ROOT_ONLY]},


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Loosen the rules of what is allowed to display timeline rows, so that if we do have multiple keyframes for an `IF_CHANGED_FROM_PREPOPULATED_VALUE` property, they will always display.
- Meanwhile, greatly decrease the likelihood we will "accidentally" have multiple keyframes for an `IF_CHANGED_FROM_PREPOPULATED_VALUE` property, which (I think) is almost always a side effect of my laziness when implementing on-stage transforms. What we were doing before is creating all these verbose properties whenever a user scales—rotation was a little bit tamer, but the most basic scaling operation will create "trivial" JIT keyframes for the three `shear` properties, `translation.z`, the three `rotation` properties, and so on—despite the fact that a lot of the time, you're only updating `scale.x/y` and `translation.x/y`. This change was actually very simple and addresses the main culprit of the problem that led me to want stricter rules in the first place. Sadly, it does nothing for existing projects, which are going to be thrashed with ugly and extra keyframes. On the bright side, I'm pretty sure these were already there, so they're not necessarily making it worse.

Regressions to look for:

- None, but we'll SLAM! and find them if they're there.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
