### PR TITLE
fix: safely check if a path exists before trying to read its properties

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -4,7 +4,7 @@
       "FIRST!"
     ],
     "Fixes": [
-      "FIRST!"
+      "Fixes crashes related to direct selection on specific SVG assets."
     ]
   }
 }

--- a/packages/haiku-common/src/math/geometryUtils.ts
+++ b/packages/haiku-common/src/math/geometryUtils.ts
@@ -15,6 +15,8 @@ export const DEFAULT_LINE_SELECTION_THRESHOLD = 5;
 // Number of segments to create when approximating a cubic bezier segment
 export const CUBIC_BEZIER_APPROXIMATION_RESOLUTION = 80;
 
+export const isClosedPath = (maybePath: CurveSpec|null) => maybePath && maybePath.closed;
+
 export const bezierCubic = (a: Vec2, h1: Vec2, h2: Vec2, b: Vec2, t: number): Vec2 => {
   const t2 = t * t;
   const t3 = t2 * t;
@@ -56,7 +58,7 @@ export const buildPathLUT = (
     }
   }
 
-  return [out, points[points.length - 1].closed || points[points.length - 2].closed];
+  return [out, isClosedPath(points[points.length - 1]) || isClosedPath(points[points.length - 2])];
 };
 
 export const pointInsideRect = (pt: Vec2, corner1: Vec2, corner2: Vec2): boolean => {

--- a/packages/haiku-common/src/math/geometryUtils.ts
+++ b/packages/haiku-common/src/math/geometryUtils.ts
@@ -34,10 +34,10 @@ export const buildPathLUT = (
   segmentResolution: number = CUBIC_BEZIER_APPROXIMATION_RESOLUTION,
 ): [Vec2[], boolean] => {
   const out = [];
-  for (let i = 0; i < points.length; i++) {
+  for (let i = 1; i < points.length; i++) {
     if (points[i].moveTo) {
       continue;
-    } // TODO: Assert that points[0] is moveTo?
+    }
     if (points[i].curve) {
       for (let t = 0; t < 1; t += 1 / segmentResolution) {
         out.push(bezierCubic(


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Safely check if a path exists before trying to read its properties (fixes ["Direct selection bug: TypeError: Cannot read property 'closed' of undefined"](https://app.asana.com/0/856556209422928/875178733925060)). To me this seems like a classic JS mistake and the proposed solution is enough, but if you suspect this is the symptom of something deeper please disregard this PR 🐎 

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
