### PR TITLE
fix: do not always delete state values before modifying them

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -4,7 +4,8 @@
       "FIRST!"
     ],
     "Fixes": [
-      "Fixes crashes related to direct selection on specific SVG assets."
+      "Fixes crashes related to direct selection on specific SVG assets.",
+      "Fixes crashes in certain circumstances when creating states and undoing."
     ]
   }
 }

--- a/packages/haiku-creator/src/react/components/StateInspector/StateRow.js
+++ b/packages/haiku-creator/src/react/components/StateInspector/StateRow.js
@@ -214,24 +214,18 @@ class StateRow extends React.Component {
   }
 
   submitChanges () {
-    const didValueChange = this.state.desc.value !== this.state.valuePreEdit;
     const didNameChange = this.state.name !== this.props.stateName;
 
-    if (didNameChange && didValueChange) {
+    // If the name has changed and this is not a newly created state, instead of changing
+    // the name of the current state, we delete the state and create a new state with the
+    // new name and the old value.
+    if (didNameChange && !this.props.isNew) {
       return this.props.deleteStateValue(this.props.stateName, () => {
         return this.props.upsertStateValue(this.state.name, this.state.desc, this.props.requestBlur);
       });
     }
 
-    if (didNameChange) {
-      return this.props.deleteStateValue(this.props.stateName, () => {
-        return this.props.upsertStateValue(this.state.name, this.state.desc, this.props.requestBlur);
-      });
-    }
-
-    if (didValueChange) {
-      return this.props.upsertStateValue(this.state.name, this.state.desc, this.props.requestBlur);
-    }
+    return this.props.upsertStateValue(this.state.name, this.state.desc, this.props.requestBlur);
   }
 
   handleClickOutside () {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes ["Undo/Redo + States bug: TypeError: Cannot set property 'edited' of undefined"](https://app.asana.com/0/856556209422928/876867697507733) by avoiding to delete state values when creating a new value.

**Why this fixes the issue?** 

The logic to update the name of a state is a bit weird, instead of updating the name of the state, we are:

1- Deleting the state with the old name
2- Creating a new state with the new name and the old value

This logic was also used to create new states, causing step `1` to add an invalid inversion method in the undo stack.

With this change, we are just doing `1` and `2` if the state name has changed AND we are not dealing with a new state

Regressions to look for:

- None expected, but a quick look at states CRUD will be helpful.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
