### PR TITLE
fix: prevent crashes when choosing monaco snippets with mouse

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -4,7 +4,8 @@
       "FIRST!"
     ],
     "Fixes": [
-      "Fixes crashes related to direct selection on specific SVG assets."
+      "Fixes crashes related to direct selection on specific SVG assets.",
+      "Fixes crashes when selecting autocompletion items with the mouse."
     ]
   }
 }

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/Snippets.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/Snippets.js
@@ -161,18 +161,28 @@ class Snippets extends React.PureComponent {
     this.props.editor.pushUndoStop();
   }
 
+  setPlusRef = (element) => {
+    this._plus = element
+  }
+
+  setRightGradientDivRef = (element) => {
+    this._rightGradientDiv = element
+  }
+
+  launchPopoverMenu = (event) => {
+    PopoverMenu.launch({event, items: this.snippetOptions});
+  }
+
   render () {
     return (
       <div>
-        <div style={STYLES.wrapper} ref={(element) => (this._plus = element)}
-          onClick={(event) => {
-            PopoverMenu.launch({event, items: this.snippetOptions});
-          }}>
+        <div style={STYLES.wrapper} ref={this.setPlusRef}
+          onClick={this.launchPopoverMenu}>
           <div style={STYLES.button}>
             +
           </div>
         </div>
-        <div style={STYLES.rightGradientDiv} ref={(element) => (this._rightGradientDiv = element)} />
+        <div style={STYLES.rightGradientDiv} ref={this.setRightGradientDivRef} />
       </div>
     );
   }

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
@@ -126,6 +126,21 @@ class EventHandlerEditor extends React.PureComponent {
 
   // Define our own autocompletion items
     this.completionDisposer = monaco.languages.registerCompletionItemProvider('javascript', {
+      // FIXME: ugly hack to prevent crashes in monaco, this is [officially fixed in vscode][1]
+      // but we have to wait until [monaco is released again][2].
+      //
+      // [1]: https://github.com/Microsoft/vscode/pull/57617
+      // [2]: https://github.com/Microsoft/monaco-editor/issues/1139
+      resolveCompletionItem (item, token) {
+        for (const element of document.querySelectorAll('.monaco-list-row .contents')) {
+          element.addEventListener('mousedown', (mouseDownEvent) => {
+            mouseDownEvent.preventDefault();
+            mouseDownEvent.stopImmediatePropagation();
+          });
+        }
+
+        return item;
+      },
       provideCompletionItems (model, position) {
 
         // Get text from whole line until autocomplete position


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes crash: [Monaco bug: Error: Invalid start index: 2 ](https://app.asana.com/0/856556209422928/878402025353143)

There's an issue ([now fixed](https://github.com/Microsoft/vscode/pull/57617)) in vscode which causes the editor to crash when selecting autocompletion items with the mouse.

`monaco` is built from the `vscode` source as a separate package from time to time, but that fix is not released yet, so for the moment I'm disabling the ability to select autocompletion items with the mouse.

I created an [issue](https://github.com/Microsoft/monaco-editor/issues/1139) in the `monaco` repo asking for a new  release, but I don't expect that to occur any time soon.

Regressions to look for:

- Autocompletion in Actions Editor.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
