### PR TITLE
fix: force actions editor to close in preview mode

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -6,7 +6,8 @@
     "Fixes": [
       "Fixes crashes related to direct selection on specific SVG assets.",
       "Fixes crashes in certain circumstances when creating states and undoing.",
-      "Fixes crashes when selecting autocompletion items with the mouse."
+      "Fixes crashes when selecting autocompletion items with the mouse.",
+      "Fixes crashes when switching to Preview Mode with the Actions Editor open."
     ]
   }
 }

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1043,7 +1043,7 @@ export default class Creator extends React.Component {
     // - Pressing design button: go to desing and restore left panel
     // - Pressing code button: go to code editor and open state inspector on left panel
     if (interactionMode === InteractionMode.GLASS_PREVIEW) {
-      this.forceHideEventHandlersEditor();
+      this.forceHideEventHandlersEditor({trySave: true});
     } else if (this.state.interactionMode === InteractionMode.GLASS_PREVIEW && interactionMode === InteractionMode.GLASS_EDIT) {
       this.setState({activeNav: this.lastWidgetState.activeNav});
     } else if (interactionMode === InteractionMode.GLASS_EDIT) {
@@ -1907,7 +1907,11 @@ export default class Creator extends React.Component {
     this.getActiveComponent().batchUpsertEventHandlers(selectorName, serializedEvents, {from: 'creator'}, () => {});
   }
 
-  forceHideEventHandlersEditor () {
+  forceHideEventHandlersEditor ({trySave} = {trySave: false}) {
+    if (trySave && this.editor && !this.editor.canBeClosedExternally()) {
+      this.editor.doSave();
+    }
+
     this.setState({
       targetElement: null,
       showEventHandlerEditor: false,

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1043,7 +1043,7 @@ export default class Creator extends React.Component {
     // - Pressing design button: go to desing and restore left panel
     // - Pressing code button: go to code editor and open state inspector on left panel
     if (interactionMode === InteractionMode.GLASS_PREVIEW) {
-      this.safelyHideEventHandlersEditor();
+      this.forceHideEventHandlersEditor();
     } else if (this.state.interactionMode === InteractionMode.GLASS_PREVIEW && interactionMode === InteractionMode.GLASS_EDIT) {
       this.setState({activeNav: this.lastWidgetState.activeNav});
     } else if (interactionMode === InteractionMode.GLASS_EDIT) {
@@ -1055,10 +1055,6 @@ export default class Creator extends React.Component {
     this.lastWidgetState = {interactionMode: this.state.interactionMode, activeNav: this.state.activeNav};
 
     this.mixpanelReportPreviewMode(interactionMode);
-
-    if (interactionMode === InteractionMode.GLASS_PREVIEW) {
-      this.safelyHideEventHandlersEditor();
-    }
 
     this.setState({interactionMode}, () => {
       if (interactionMode === InteractionMode.CODE_EDITOR) {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes crash [TypeError: Cannot read property 'contains' of null](https://app.asana.com/0/856556209422928/880556083108445).

Since we want to close the actions editor no matter what when switching
to preview mode, use `#forceHideEventHandlersEditor` instead of
`#safelyHideEventHandlersEditor`


Regressions to look for:

- None

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
