### PR TITLE
tweak: do not show the Hai loader while booting up the app

### DIFF
--- a/packages/haiku-creator/haiku.html
+++ b/packages/haiku-creator/haiku.html
@@ -26,11 +26,6 @@
     let bytecode, component;
 
     ipcRenderer.on('mount', (_, {bytecodePath, width, height, options}) => {
-      if (component) {
-        ipcRenderer.sendToHost('haiku-webview-ready');
-        return;
-      }
-
       try {
         bytecode = requireFromFile(bytecodePath);
         mount.style.width = width;
@@ -40,9 +35,6 @@
           mount,
           {
             ...options,
-            onComponentDidMount: () => {
-              ipcRenderer.sendToHost('haiku-webview-ready');
-            },
           },
         );
 

--- a/packages/haiku-creator/haiku.html
+++ b/packages/haiku-creator/haiku.html
@@ -26,6 +26,10 @@
     let bytecode, component;
 
     ipcRenderer.on('mount', (_, {bytecodePath, width, height, options}) => {
+      if (component) {
+        return;
+      }
+
       try {
         bytecode = requireFromFile(bytecodePath);
         mount.style.width = width;

--- a/packages/haiku-creator/index.html
+++ b/packages/haiku-creator/index.html
@@ -5,7 +5,6 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Haiku</title>
-  <style>html, body { background-color: #D4D4D4; }</style>
   <link rel="stylesheet" href="./public/stylesheets/global.css">
   <link rel="stylesheet" href="./public/stylesheets/codemirror.css">
   <link rel="stylesheet" href="./public/stylesheets/codemirror-haiku.css">

--- a/packages/haiku-creator/src/electron.js
+++ b/packages/haiku-creator/src/electron.js
@@ -127,6 +127,7 @@ function createWindow () {
     titleBarStyle: 'hiddenInset',
     minWidth: 700,
     minHeight: 650,
+    backgroundColor: '#343f41',
   });
 
   const topmenu = new TopMenu(browserWindow.webContents);

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -132,6 +132,7 @@ export default class Creator extends React.Component {
       projectModel: null, // Instance of the Project model
       dashboardVisible: !this.props.folder,
       readyForAuth: false,
+      hasLoadedOnce: false,
       isUserAuthenticated: false,
       username: null,
       isAdmin: false,
@@ -686,10 +687,7 @@ export default class Creator extends React.Component {
           organizationName: organization.Name,
         });
 
-        // Delay so the default startup screen doesn't just flash then go away
-        setTimeout(() => {
-          this.setState({isUserAuthenticated: true});
-        }, this.state.readyForAuth ? 0 : 2500);
+        this.setState({isUserAuthenticated: true});
       });
 
       this.user.checkOfflinePrivileges().then((allowOffline) => {
@@ -700,46 +698,43 @@ export default class Creator extends React.Component {
     });
 
     this.user.load().then(({user, organization}) => {
-      // Delay so the default startup screen doesn't just flash then go away
-      setTimeout(() => {
-        this.setState({
-          readyForAuth: true,
-          isUserAuthenticated: user && organization,
-        }, () => {
-          if (this.state.isUserAuthenticated && typeof this._postAuthCallback === 'function') {
-            this._postAuthCallback();
-            delete this._postAuthCallback;
-          } else if (this.props.folder) {
-            // Launch folder directly - i.e. allow a 'subl' like experience without having to go
-            // through the projects index
-            const handleFailure = (launchError) => {
-              if (launchError) {
-                logger.error(launchError);
-                this.setState({folderLoadingError: launchError});
-                return this.createNotice({
-                  type: 'error',
-                  title: 'Oh no!',
-                  message: 'We were unable to open the folder. 😢 Please close and reopen the application and try again. If you still see this message, contact Haiku for support.',
-                  closeText: 'Okay',
-                  lightScheme: true,
-                });
-              }
-            };
+      this.setState({
+        readyForAuth: true,
+        isUserAuthenticated: user && organization,
+      }, () => {
+        if (this.state.isUserAuthenticated && typeof this._postAuthCallback === 'function') {
+          this._postAuthCallback();
+          delete this._postAuthCallback;
+        } else if (this.props.folder) {
+          // Launch folder directly - i.e. allow a 'subl' like experience without having to go
+          // through the projects index
+          const handleFailure = (launchError) => {
+            if (launchError) {
+              logger.error(launchError);
+              this.setState({folderLoadingError: launchError});
+              return this.createNotice({
+                type: 'error',
+                title: 'Oh no!',
+                message: 'We were unable to open the folder. 😢 Please close and reopen the application and try again. If you still see this message, contact Haiku for support.',
+                closeText: 'Okay',
+                lightScheme: true,
+              });
+            }
+          };
 
-            this.launchFolder(
-              // Load up the necessary metadata in Plumbing to launch normally.
-              {
-                projectPath: this.props.folder,
-                authorName: 'user@haiku.ai',
-                organizationName: 'Haiku',
-                projectName: path.basename(this.props.folder),
-                branchName: 'master',
-              },
-              handleFailure,
-            );
-          }
-        });
-      }, this.props.folder ? 0 : 2500);
+          this.launchFolder(
+            // Load up the necessary metadata in Plumbing to launch normally.
+            {
+              projectPath: this.props.folder,
+              authorName: 'user@haiku.ai',
+              organizationName: 'Haiku',
+              projectName: path.basename(this.props.folder),
+              branchName: 'master',
+            },
+            handleFailure,
+          );
+        }
+      });
     });
 
     this.user.getConfig(UserSettings.LastViewedChangelog).then((changelogVersion) => {
@@ -1145,7 +1140,8 @@ export default class Creator extends React.Component {
     // If "silent", do not show the loading state.
     this.setState(silent ? {} : {areProjectsLoading: true}, () => {
       this.envoyProject.getProjectsList().then((projectsList) => {
-        this.setState({areProjectsLoading: false, projectsList});
+        console.log('got projects');
+        this.setState({areProjectsLoading: false, hasLoadedOnce: true, projectsList});
         ipcRenderer.send('topmenu:update', {projectsList, isProjectOpen: false});
         return cb(null, projectsList);
       }).catch((error) => {
@@ -2007,7 +2003,7 @@ export default class Creator extends React.Component {
   }
 
   get showGenericLoader () {
-    return !this.state.isUserAuthenticated || !this.state.username || this.state.areProjectsLoading;
+    return this.state.areProjectsLoading && this.state.hasLoadedOnce;
   }
 
   render () {

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1140,7 +1140,6 @@ export default class Creator extends React.Component {
     // If "silent", do not show the loading state.
     this.setState(silent ? {} : {areProjectsLoading: true}, () => {
       this.envoyProject.getProjectsList().then((projectsList) => {
-        console.log('got projects');
         this.setState({areProjectsLoading: false, hasLoadedOnce: true, projectsList});
         ipcRenderer.send('topmenu:update', {projectsList, isProjectOpen: false});
         return cb(null, projectsList);

--- a/packages/haiku-creator/src/react/components/ProjectLoader.js
+++ b/packages/haiku-creator/src/react/components/ProjectLoader.js
@@ -27,7 +27,6 @@ const STYLES = {
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: Palette.COAL,
-    transition: 'opacity 0.5s ease-in-out',
   },
 };
 
@@ -44,12 +43,7 @@ const mountArguments = {
 };
 
 class ProjectLoader extends React.PureComponent {
-  state = {
-    ready: false,
-  };
-
   destroyMountChildren () {
-    this.setState({ready: false});
     while (this.mount.firstChild) {
       this.mount.removeChild(this.mount.firstChild);
     }
@@ -63,14 +57,6 @@ class ProjectLoader extends React.PureComponent {
     this.webview.style.height = '100%';
     this.webview.addEventListener('dom-ready', () => {
       this.webview.send('mount', mountArguments);
-    });
-
-    this.webview.addEventListener('ipc-message', ({channel}) => {
-      if (channel === 'haiku-webview-ready') {
-        requestAnimationFrame((() => {
-          this.setState({ready: true});
-        }));
-      }
     });
 
     this.destroyMountChildren();
@@ -107,11 +93,7 @@ class ProjectLoader extends React.PureComponent {
         id="js-helper-project-loader"
       >
         <div
-          style={{
-            ...STYLES.loadingScreen,
-            opacity: this.state.ready ? 1 : 0,
-            transition: 'opacity 1s linear',
-          }}
+          style={STYLES.loadingScreen}
           ref={this.persistMount}
         />
         {this.props.children}


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- [Rip out loader splash & artificial 2.5s delay](https://app.asana.com/0/856556209422928/876772081245272/f)

Regressions to look for:

- None. Note that when you `Cmd+R` to refresh, you won't actually get the same experience as booting up the app for the first time (during refresh, Electron lightens the entire browser window, but the system-managed background color is actually the same as the project browser).

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality