### PR TITLE
fix: better and safer checks for caching cluster values

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -7,7 +7,8 @@
       "Fixes crashes related to direct selection on specific SVG assets.",
       "Fixes crashes in certain circumstances when creating states and undoing.",
       "Fixes crashes when selecting autocompletion items with the mouse.",
-      "Fixes crashes when switching to Preview Mode with the Actions Editor open."
+      "Fixes crashes when switching to Preview Mode with the Actions Editor open.",
+      "Fixes crashes on certain cirscumstances when editing cluster properties from Code Mode."
     ]
   }
 }

--- a/packages/haiku-timeline/src/components/ClusterInputField.js
+++ b/packages/haiku-timeline/src/components/ClusterInputField.js
@@ -52,8 +52,11 @@ class ClusterInputFieldValueDisplay extends React.Component {
     this.props.timeline.on('update', this.handleUpdate);
   }
 
-  areClusterValuesEqual (originalValues, newValues) {
-    return originalValues.every((value, index) => value.computedValue === newValues[index].computedValue);
+  areClusterValuesEqual (newValues, originalValues) {
+    return (
+      newValues.length !== originalValues.length ||
+      newValues.every((value, index) => value.computedValue === originalValues[index].computedValue)
+    );
   }
 
   handleUpdate (what) {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes: [TypeError: Cannot read property 'computedValue' of undefined](https://app.asana.com/0/856556209422928/881738104033627) by checking first if the length of the cluster values array has changed before digging into individual properties.

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`