### PR TITLE
Undo/redo create component

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -1,7 +1,8 @@
 {
   "sections": {
     "What's new": [
-      "Newly created keyframes are now automatically tweened."
+      "Newly created keyframes are now automatically tweened.",
+      "You can now undo and redo component creation."
     ],
     "Fixes": [
       "Fixes crashes related to direct selection on specific SVG assets.",

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1311,6 +1311,10 @@ export default class Creator extends React.Component {
               // console.info(`[creator] local update ${what}, args:`,args)
 
               switch (what) {
+                case 'updateMenu':
+                  this.updateMenu();
+                  break;
+
                 case 'setCurrentActiveComponent':
                   this.handleActiveComponentReady();
                   break;
@@ -1358,12 +1362,14 @@ export default class Creator extends React.Component {
     this.getActiveComponent().removeAllListeners('sustained-check:start');
   }
 
-  handleActiveComponentReady () {
-    this.mountHaikuComponent();
-
+  updateMenu () {
     ipcRenderer.send('topmenu:update', {
       subComponents: this.state.projectModel.describeSubComponents(),
     });
+  }
+
+  handleActiveComponentReady () {
+    this.mountHaikuComponent();
 
     // Reset not found identifiers in case we are switching current active component
     this.identifiersNotFound = [];

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -283,9 +283,10 @@ export class Glass extends React.Component {
         return;
       }
 
-      // logger.info(`[glass] local update ${what}`)
-
       switch (what) {
+        case 'updateMenu':
+          this.updateMenu();
+          break;
         case 'setCurrentActiveComponent':
           this.handleActiveComponentReady();
           break;
@@ -306,9 +307,10 @@ export class Glass extends React.Component {
     });
 
     this.addEmitterListenerIfNotAlreadyRegistered(this.project, 'remote-update', (what, ...args) => {
-      // logger.info(`[glass] remote update ${what}`)
-
       switch (what) {
+        case 'updateMenu':
+          this.updateMenu();
+          break;
         case 'setCurrentActiveComponent':
           this.handleActiveComponentReady();
           break;
@@ -345,15 +347,18 @@ export class Glass extends React.Component {
     }
   }
 
+  updateMenu () {
+    ipcRenderer.send('topmenu:update', {
+      subComponents: this.project.describeSubComponents(),
+    });
+  }
+
   handleActiveComponentReady () {
     // Reset direct selection before mounting new component
     Element.directlySelected = null;
 
     this.mountHaikuComponent();
-
-    ipcRenderer.send('topmenu:update', {
-      subComponents: this.project.describeSubComponents(),
-    });
+    this.updateMenu();
   }
 
   mountHaikuComponent () {

--- a/packages/haiku-plumbing/src/Master.js
+++ b/packages/haiku-plumbing/src/Master.js
@@ -506,25 +506,10 @@ export default class Master extends EventEmitter {
 
   handleFileRemove (abspath) {
     const relpath = path.relative(this.folder, abspath);
-    const extname = path.extname(relpath);
-
     delete this._knownLibraryAssets[relpath];
 
     return this.waitForSaveToComplete(() => {
-      return this._git.commitFileIfChanged(relpath, this.normalizeCommitMessage(`Removed ${relpath}`), () => {
-        if (!isFileSignificant(relpath)) {
-          return;
-        }
-
-        if (extname === '.js') {
-          return File.expelOne(this.folder, relpath, (err) => {
-            if (err) {
-              return logger.info(err);
-            }
-            logger.info('[master] file expelled:', abspath);
-          });
-        }
-      });
+      return this._git.commitFileIfChanged(relpath, this.normalizeCommitMessage(`Removed ${relpath}`), () => undefined);
     });
   }
 

--- a/packages/haiku-plumbing/src/Master.js
+++ b/packages/haiku-plumbing/src/Master.js
@@ -506,7 +506,10 @@ export default class Master extends EventEmitter {
 
   handleFileRemove (abspath) {
     const relpath = path.relative(this.folder, abspath);
-    delete this._knownLibraryAssets[relpath];
+    if (this._knownLibraryAssets[relpath]) {
+      delete this._knownLibraryAssets[relpath];
+      this.debouncedEmitAssetsChanged(this._knownLibraryAssets);
+    }
 
     return this.waitForSaveToComplete(() => {
       return this._git.commitFileIfChanged(relpath, this.normalizeCommitMessage(`Removed ${relpath}`), () => undefined);

--- a/packages/haiku-serialization/src/bll/ActionStack.js
+++ b/packages/haiku-serialization/src/bll/ActionStack.js
@@ -498,6 +498,20 @@ BaseModel.extend(ActionStack)
  * in the ActiveComponent object prior to the data mutation.
  */
 ActionStack.METHOD_INVERTERS = {
+  conglomerateComponent: {
+    before: (ac, [componentIds, name, size, translation, coords, propertiesSerial, options]) => ({
+      method: ac.unconglomerateComponent.name,
+      params: [componentIds, name, size, translation, coords, propertiesSerial, options]
+    })
+  },
+
+  unconglomerateComponent: {
+    before: (ac, [componentIds, name, size, translation, coords, propertiesSerial, options]) => ({
+      method: ac.conglomerateComponent.name,
+      params: [componentIds, name, size, translation, coords, propertiesSerial, options]
+    })
+  },
+
   updateKeyframes: {
     before: (ac, [keyframeUpdates]) => {
       const previousUpdates = ac.snapshotKeyframeUpdates(keyframeUpdates)

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -979,6 +979,48 @@ class ActiveComponent extends BaseModel {
   }
 
   /**
+   * @method unconglomerateComponent
+   */
+  unconglomerateComponent (
+    componentIds,
+    name,
+    size,
+    translation,
+    coords,
+    propertiesSerial,
+    options = {},
+    metadata,
+    cb
+  ) {
+    Lock.request(Lock.LOCKS.ActiveComponentWork, false, (release) => this.project.updateHook(
+      'unconglomerateComponent',
+      this.getRelpath(),
+      // Note that we only actually need the name of the component we're unconglomerating to do the unconglomeration.
+      // The reason for all these params is so we can also REDO.
+      componentIds,
+      name,
+      size,
+      translation,
+      coords,
+      propertiesSerial,
+      options,
+      metadata,
+      (fire) => {
+        this.fetchActiveBytecodeFile().updateInMemoryHotModule(
+          this.snapshots.pop(),
+          () => {
+            release()
+            this.moduleSync(() => {
+              fire()
+              cb()
+            })
+          }
+        )
+      })
+    )
+  }
+
+  /**
    * @method conglomerateComponent
    * @description Given a list of existing component ids on stage, create a component
    * from them and place the result on the stage
@@ -999,7 +1041,7 @@ class ActiveComponent extends BaseModel {
     })
 
     return Lock.request(Lock.LOCKS.ActiveComponentWork, false, (release) => {
-      return this.project.updateHook(
+      return this.pushBytecodeSnapshot(() => this.project.updateHook(
         'conglomerateComponent',
         this.getRelpath(),
         componentIds,
@@ -1042,7 +1084,7 @@ class ActiveComponent extends BaseModel {
             finish
           )
         }
-      )
+      ))
     })
   }
 

--- a/packages/haiku-serialization/src/bll/File.js
+++ b/packages/haiku-serialization/src/bll/File.js
@@ -74,6 +74,18 @@ class File extends BaseModel {
     // Important: Please see afterInitialize for assigned properties
   }
 
+  destroy (cleanup = false) {
+    this.mod.destroy()
+    this.ast.destroy()
+
+    if (cleanup && this.options.doWriteToDisk) {
+      // Dangerous! Actually removes contents from disk.
+      fse.removeSync(this.getFolder())
+    }
+
+    super.destroy()
+  }
+
   // Hook called automatically by BaseModel during construction or upsert
   afterInitialize () {
     // Track how many times we've updated our in-memory content.
@@ -322,15 +334,6 @@ File.read = (folder, relpath, cb) => {
 
 File.isPathCode = (relpath) => {
   return _isFileCode(relpath)
-}
-
-File.expelOne = (folder, relpath, cb) => {
-  // TODO
-  const file = File.findById(path.join(folder, relpath))
-  if (file) {
-    file.destroy()
-  }
-  cb()
 }
 
 File.buildManaCacheKey = (folder, relpath) => {

--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -274,6 +274,13 @@ class Project extends BaseModel {
     this._multiComponentTabs.push({ scenename, active })
   }
 
+  removeActiveComponentFromMultiComponentTabs (scenename) {
+    const index = this._multiComponentTabs.findIndex((tab) => tab.scenename === scenename)
+    if (index !== -1) {
+      this._multiComponentTabs.splice(index, 1)
+    }
+  }
+
   describeSubComponents () {
     return this._multiComponentTabs.map(({scenename, active}) => {
       return {
@@ -637,6 +644,37 @@ class Project extends BaseModel {
     this.ensurePlatformHaikuRegistry() // Make sure we have this.platform.haiku; race condition
     this.platform.haiku.registry[activeComponentKey] = activeComponent
     this.addActiveComponentToMultiComponentTabs(activeComponent.getSceneName(), false)
+  }
+
+  removeActiveComponentFromRegistry (activeComponent) {
+    const activeComponentKey = path.join(
+      this.getFolder(),
+      activeComponent.getRelpath()
+    )
+    this.ensurePlatformHaikuRegistry() // Make sure we have this.platform.haiku; race condition
+    delete this.platform.haiku.registry[activeComponentKey]
+    this.removeActiveComponentFromMultiComponentTabs(activeComponent.getSceneName())
+  }
+
+  deleteSceneByName (scenename, cb) {
+    // Note: this is a VERY ROUGH implementation of subcomponent destruction that is only meant to be used to undo
+    // subcomponent creation in its current form. If planning to use this for proper subcomponent deletion in any context,
+    // we would also need to find/destroy any subcomponent instances that would have require(...) broken by these actions.
+    const ac = this.findActiveComponentBySceneName(scenename)
+
+    if (!ac) {
+      // Bail if no ActiveComponent.
+      return cb()
+    }
+
+    // First unregister it from the UI.
+    this.removeActiveComponentFromRegistry(ac)
+    this.emit('update', 'updateMenu')
+
+    // Next actually destroy the corresponding BLL entities.
+    ac.destroy(true)
+
+    return cb()
   }
 
   upsertSceneByName (scenename, cb) {

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -304,9 +304,10 @@ class Timeline extends React.Component {
     });
 
     this.addEmitterListenerIfNotAlreadyRegistered(this.project, 'update', (what, arg) => {
-      // logger.info(`[timeline] local update ${what}`)
-
       switch (what) {
+        case 'updateMenu':
+          this.updateMenu();
+          break;
         case 'setCurrentActiveComponent':
           this.handleActiveComponentReady();
           break;
@@ -319,9 +320,10 @@ class Timeline extends React.Component {
     });
 
     this.addEmitterListenerIfNotAlreadyRegistered(this.project, 'remote-update', (what, ...args) => {
-      // logger.info(`[timeline] remote update ${what}`)
-
       switch (what) {
+        case 'updateMenu':
+          this.updateMenu();
+          break;
         case 'setCurrentActiveComponent':
           this.handleActiveComponentReady();
           break;
@@ -552,13 +554,17 @@ class Timeline extends React.Component {
     }
   }
 
+  updateMenu () {
+    ipcRenderer.send('topmenu:update', {
+      subComponents: this.project.describeSubComponents(),
+    });
+  }
+
   handleActiveComponentReady () {
     const timeline = this.getActiveComponent().getCurrentTimeline();
     this.mountHaikuComponent();
 
-    ipcRenderer.send('topmenu:update', {
-      subComponents: this.project.describeSubComponents(),
-    });
+    this.updateMenu();
 
     this.loadUserSettings();
     this.trackExportProgress();


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Adds the ability to undo/redo component creation, including on-disk cleanup.

Regressions to look for:

- None expected, many potentially possible.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`
