### PR TITLE
Unduly strict

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -8,7 +8,8 @@
       "Fixes crashes related to direct selection on specific SVG assets.",
       "Fixes crashes in certain circumstances when creating states and undoing.",
       "Fixes crashes when selecting autocompletion items with the mouse.",
-      "Fixes crashes when switching to Preview Mode with the Actions Editor open."
+      "Fixes crashes when switching to Preview Mode with the Actions Editor open.",
+      "The Edit menu now only exposes options to undo/redo if there is actually something to undo or redo."
     ]
   }
 }

--- a/packages/haiku-common/src/electron/TopMenu.ts
+++ b/packages/haiku-common/src/electron/TopMenu.ts
@@ -7,11 +7,9 @@ import {TourUtils} from '../types/enums';
 
 app.setName('Haiku');
 
-export interface TopMenuOptions {
-  isProjectOpen: boolean;
-  isSaving: boolean;
-  projectsList: PlumbingProject[];
-  subComponents: SubComponent[];
+export interface UndoState {
+  canUndo: boolean;
+  canRedo: boolean;
 }
 
 export interface SubComponent {
@@ -22,6 +20,14 @@ export interface SubComponent {
 
 export interface TopMenuEventSender {
   send: (eventName: string, ...args: any[]) => void;
+}
+
+export interface TopMenuOptions {
+  isProjectOpen: boolean;
+  isSaving: boolean;
+  projectsList: PlumbingProject[];
+  subComponents: SubComponent[];
+  undoState: UndoState;
 }
 
 export default class TopMenu {
@@ -288,6 +294,7 @@ export default class TopMenu {
     editSubmenu.push({
       label: 'Undo',
       accelerator: 'CmdOrCtrl+Z',
+      enabled: this.options.undoState.canUndo,
       click: () => {
         this.sendActionToFirstReponderAndEmit('undo');
       },
@@ -296,6 +303,7 @@ export default class TopMenu {
     editSubmenu.push({
       label: 'Redo',
       accelerator: 'CmdOrCtrl+Shift+Z',
+      enabled: this.options.undoState.canRedo,
       click: () => {
         this.sendActionToFirstReponderAndEmit('redo');
       },

--- a/packages/haiku-creator/src/electron.js
+++ b/packages/haiku-creator/src/electron.js
@@ -137,6 +137,7 @@ function createWindow () {
     isSaving: false,
     isProjectOpen: false,
     subComponents: [],
+    undoState: {canUndo: false, canRedo: false},
   };
 
   topmenu.create(topmenuOptions);

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1363,9 +1363,7 @@ export default class Creator extends React.Component {
   }
 
   updateMenu () {
-    ipcRenderer.send('topmenu:update', {
-      subComponents: this.state.projectModel.describeSubComponents(),
-    });
+    ipcRenderer.send('topmenu:update', this.state.projectModel.describeTopMenu());
   }
 
   handleActiveComponentReady () {
@@ -1605,7 +1603,7 @@ export default class Creator extends React.Component {
         isUserAuthenticated: user && organization,
       });
       this.teardownMaster({shouldFinishTour: true});
-      ipcRenderer.send('topmenu:update', {subComponents: [], isProjectOpen: false});
+      ipcRenderer.send('topmenu:update', {subComponents: [], undoState: {canUndo: false, canRedo: false}, isProjectOpen: false});
     });
   }
 

--- a/packages/haiku-creator/src/react/components/StageTitleBar.js
+++ b/packages/haiku-creator/src/react/components/StageTitleBar.js
@@ -251,7 +251,7 @@ class StageTitleBar extends React.Component {
           ipcRenderer.send('topmenu:update', {
             isProjectOpen: !!masterState.folder,
             isSaving: !!masterState.isSaving,
-            subComponents: this.props.projectModel.describeSubComponents(),
+            ...this.props.projectModel.describeTopMenu(),
           });
         });
       }

--- a/packages/haiku-glass/src/electron.js
+++ b/packages/haiku-glass/src/electron.js
@@ -52,6 +52,7 @@ function createWindow () {
     isSaving: false,
     isProjectOpen: true,
     subComponents: [],
+    undoState: {canUndo: false, canRedo: false},
   });
 
   ipcMain.on('topmenu:update', (ipcEvent, nextTopmenuOptions) => {

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -348,9 +348,7 @@ export class Glass extends React.Component {
   }
 
   updateMenu () {
-    ipcRenderer.send('topmenu:update', {
-      subComponents: this.project.describeSubComponents(),
-    });
+    ipcRenderer.send('topmenu:update', this.project.describeTopMenu());
   }
 
   handleActiveComponentReady () {

--- a/packages/haiku-serialization/src/bll/ActionStack.js
+++ b/packages/haiku-serialization/src/bll/ActionStack.js
@@ -218,6 +218,8 @@ class ActionStack extends BaseModel {
     if (stack.length > MAX_UNDOABLES_LEN) {
       stack.shift()
     }
+
+    this.project.emit('update', 'updateMenu')
   }
 
   addUndoable (undoable, ac) {
@@ -373,9 +375,9 @@ class ActionStack extends BaseModel {
           !metadata.cursor
         ) {
           did = true
-          this.addUndoable(inverter, ac)
           // Reset the redo stack.
           this.redoables.length = 0
+          this.addUndoable(inverter, ac)
         } else if (metadata.cursor === ActionStack.CURSOR_MODES.undo) {
           did = true
           this.addUndoable(inverter, ac)

--- a/packages/haiku-serialization/src/bll/Project.js
+++ b/packages/haiku-serialization/src/bll/Project.js
@@ -291,6 +291,22 @@ class Project extends BaseModel {
     })
   }
 
+  describeUndoState () {
+    const ac = this.getCurrentActiveComponent()
+    const filter = (doable) => !doable.ac || doable.ac === ac
+    return {
+      canUndo: this.actionStack.getUndoables().filter(filter).length > 0,
+      canRedo: this.actionStack.getRedoables().filter(filter).length > 0
+    }
+  }
+
+  describeTopMenu () {
+    return {
+      subComponents: this.describeSubComponents(),
+      undoState: this.describeUndoState()
+    }
+  }
+
   getExistingComponentNames () {
     const names = {
       'main': true // Never allow 'main'

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -555,9 +555,7 @@ class Timeline extends React.Component {
   }
 
   updateMenu () {
-    ipcRenderer.send('topmenu:update', {
-      subComponents: this.project.describeSubComponents(),
-    });
+    ipcRenderer.send('topmenu:update', this.project.describeTopMenu());
   }
 
   handleActiveComponentReady () {

--- a/packages/haiku-timeline/src/electron.js
+++ b/packages/haiku-timeline/src/electron.js
@@ -63,6 +63,7 @@ function createWindow () {
     isSaving: false,
     isProjectOpen: true,
     subComponents: [],
+    undoState: {canUndo: false, canRedo: false},
   });
 
   ipcMain.on('topmenu:update', (ipcEvent, nextTopmenuOptions) => {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- AS SEEN IN DEMO DAY™! Fix for another rough edge of undo/redo—where we expose menu options for Undo/Redo even when there's nothing to undo/redo.

Regressions to look for:

- None are expected. There is some trailing-edge latency you'll see in the standalone run modes (`yarn start glass` and `yarn start timeline`), but they shouldn't actually affect anything, and this latency shouldn't be noticeable in full app mode (due to `master:heartbeat`).

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`
