### PR TITLE
feat: add default curves to new keyframes if they have keyframes next

### DIFF
--- a/packages/haiku-serialization/src/bll/Bytecode.js
+++ b/packages/haiku-serialization/src/bll/Bytecode.js
@@ -1224,24 +1224,42 @@ Bytecode.addDefaultCurveIfNecessary = (
   const property = bytecode.timelines[timelineName][selector][propertyName]
 
   if (property) {
-    const lastKeyframe = Object.keys(property)
-      .map(Number)
+    const orderedKeyframes = Object.keys(property)
+    .map(Number)
+    .sort((a, b) => a - b)
+
+    const lastKeyframe = orderedKeyframes
       .filter((time) => time < newKeyframeTime)
-      .sort((a, b) => a - b)
       .pop()
-    if (lastKeyframe !== undefined) {
-      if (property[lastKeyframe].curve === undefined) {
-        Bytecode.joinKeyframes(
-          bytecode,
-          componentId,
-          timelineName,
-          elementName,
-          propertyName,
-          lastKeyframe,
-          newKeyframeTime,
-          DEFAULT_CURVE
-        )
-      }
+
+    const nextKeyframe = orderedKeyframes
+      .filter((time) => time > newKeyframeTime)
+      .pop()
+
+    if (lastKeyframe !== undefined && property[lastKeyframe].curve === undefined) {
+      Bytecode.joinKeyframes(
+        bytecode,
+        componentId,
+        timelineName,
+        elementName,
+        propertyName,
+        lastKeyframe,
+        newKeyframeTime,
+        DEFAULT_CURVE
+      )
+    }
+
+    if (nextKeyframe) {
+      Bytecode.joinKeyframes(
+        bytecode,
+        componentId,
+        timelineName,
+        elementName,
+        propertyName,
+        newKeyframeTime,
+        nextKeyframe,
+        DEFAULT_CURVE
+      )
     }
   }
 }

--- a/packages/haiku-serialization/src/bll/Bytecode.js
+++ b/packages/haiku-serialization/src/bll/Bytecode.js
@@ -1234,7 +1234,7 @@ Bytecode.addDefaultCurveIfNecessary = (
 
     const nextKeyframe = orderedKeyframes
       .filter((time) => time > newKeyframeTime)
-      .pop()
+      .shift()
 
     if (lastKeyframe !== undefined && property[lastKeyframe].curve === undefined) {
       Bytecode.joinKeyframes(


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

[We should also create a default curve on the keyframe we're creating, if there is a keyframe in front of it](https://app.asana.com/0/856556209422928/883122512587004)

@stristr this code looks a bit clunky and repetitive, but I'm following the premise of "just make it work ™", if you think there's a better way to do this, please shout!

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
