### PR TITLE
tweak: ameliorate inadvertent panel resizings on ticker t0 drag attempts

### DIFF
--- a/packages/haiku-timeline/src/components/PropertiesPanelResizer.jsx
+++ b/packages/haiku-timeline/src/components/PropertiesPanelResizer.jsx
@@ -26,10 +26,10 @@ class PropertiesPanelResizer extends React.PureComponent {
         <span id="properties-panel-resizer" style={{
           display: 'inline-block',
           position: 'fixed',
-          height: 'calc(100% - 45px)',
+          height: 'calc(100% - 80px)',
           width: 11,
           zIndex: zIndex.scrollShadow.base,
-          top: 0,
+          top: 35,
           borderRight: invisibleBorder,
           borderLeft: invisibleBorder,
           cursor: 'col-resize',


### PR DESCRIPTION
I found myself accidentally resizing the timeline property panel quite often when attempting to scrub the ticker from a t0 position. I changed the size of the panel resizer to not overlap with the gauge to solve this misbehavior.

![](https://duaw26jehqd4r.cloudfront.net/items/3m3u1e1X3R2H2z213l05/Screen%20Recording%202018-10-29%20at%2001.56%20PM.gif?v=b8e56599)