### PR TITLE
tweak: do not auto-curve when the value is unchanged.

### DIFF
--- a/packages/haiku-serialization/src/bll/Bytecode.js
+++ b/packages/haiku-serialization/src/bll/Bytecode.js
@@ -1236,7 +1236,7 @@ Bytecode.addDefaultCurveIfNecessary = (
       .filter((time) => time > newKeyframeTime)
       .shift()
 
-    if (lastKeyframe !== undefined && property[lastKeyframe].curve === undefined) {
+    if (lastKeyframe !== undefined && property[lastKeyframe].curve === undefined && property[lastKeyframe].value !== property[newKeyframeTime].value) {
       Bytecode.joinKeyframes(
         bytecode,
         componentId,
@@ -1249,7 +1249,7 @@ Bytecode.addDefaultCurveIfNecessary = (
       )
     }
 
-    if (nextKeyframe) {
+    if (nextKeyframe && property[nextKeyframe].value !== property[newKeyframeTime].value) {
       Bytecode.joinKeyframes(
         bytecode,
         componentId,

--- a/packages/haiku-serialization/test/bll/05_Keyframe.test.js
+++ b/packages/haiku-serialization/test/bll/05_Keyframe.test.js
@@ -243,6 +243,7 @@ tape('Keyframe.06', (t) => {
     t.notOk(Keyframe.groupIsSingleTween([kfs[0]]), 'returns false if only one keyframe is selected')
     t.notOk(Keyframe.groupIsSingleTween([kfs[0], kfs[1], kfs[2]]), 'returns false if more than two keyframes are selected')
     t.notOk(Keyframe.groupIsSingleTween([kfs[0], kfs[3]]), 'returns false if the keyframes are not next to each other')
+    selection[0].curve = 'linear'
     t.ok(Keyframe.groupIsSingleTween(selection), 'returns true if there is a tween between the two provided keyframes')
 
     selection[0].curve = null


### PR DESCRIPTION
OK to merge if @roperzh and @taylorpoe agree.

Short review.

Summary of changes:

- Do not auto-curve when the value is unchanged ahead of/behind the curve in question. We will still auto curve if/when the value is changed. This fixes a workflow I frequently use when building an animation that I want to start at some frame > 0—e.g., creating a keyframe at t=0, then an identical keyframe at t=30 when I actually want the animation to start.

Regressions to look for:

- None expected—this seems to work nicely.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality