### PR TITLE
tweak: do not automatically switch into a newly created component.

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -2,7 +2,8 @@
   "sections": {
     "What's new": [
       "Newly created keyframes are now automatically tweened.",
-      "You can now undo and redo component creation."
+      "You can now undo and redo subcomponent creation.",
+      "Creating a subcomponent no longer automatically switches to the subcomponent tab."
     ],
     "Fixes": [
       "Fixed crashes related to direct selection on specific SVG assets.",

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -1144,8 +1144,6 @@ export class Glass extends React.Component {
           logger.error(err);
           return;
         }
-
-        this.editComponent(`./${nc.getRelpath()}`);
       },
     );
   }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- As title suggests: when creating a subcomponent, do not automatically switch into its tab. This ameliorates UX pain related to undo.

Regressions to look for:

- None expected.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`