### PR TITLE
fix: do not try to handle 'direct-selection-anchor' if there is not an Element.directlySelected

### DIFF
--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -1361,6 +1361,10 @@ export class Glass extends React.Component {
         // NOTE: meta used to determine if anchor or handle for <path> (see directSelectionMana.js)
         const meta = mousedownEvent.nativeEvent.target.getAttribute('data-meta') && mousedownEvent.nativeEvent.target.getAttribute('data-meta').length ? parseInt(mousedownEvent.nativeEvent.target.getAttribute('data-meta'), 10) : null;
 
+        if (!Element.directlySelected) {
+          break;
+        }
+
         // NOTE: go select the previous vertex when a RHS handle is selected
 
         // Convert between corners and curves


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Very small change that fixes [TypeError: Cannot read property 'type' of null](https://app.asana.com/0/856556209422928/885913453927439), but I wanted to make a PR just in case I'm just sweeping a deeper problem (`Element.directlySelected` being `null`) under the rug.

However, we are doing very similar checks in other parts of Glass.js, so this seems ok.

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
