### PR TITLE
fix: only allow pasting expressions on property rows

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -4,7 +4,7 @@
       "FIRST!"
     ],
     "Fixes": [
-      "FIRST!"
+      "Fixed a crash related to pasting stuff while having selected a nested timeline row."
     ]
   }
 }

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -661,7 +661,7 @@ export default class ExpressionInput extends React.Component {
     const selectedRow = this.props.component.getSelectedRow();
     const text = clipboard.readText();
 
-    if (!selectedRow || !text) {
+    if (!selectedRow || !selectedRow.isProperty() || !text) {
       return false;
     }
 


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes [TypeError: Cannot read property 'fallback' of null](https://app.asana.com/0/856556209422928/880699689069281)  by not allowing to paste expressions on rows that are not property rows.

Steps to repro:

- Have a nested tree in the timeline
- Click on a nested heading element of the timeline
- Paste something

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
