### PR TITLE
fix: fully decycle subcomponents when cleaning mana

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -1,10 +1,8 @@
 {
   "sections": {
-    "What's new": [
-      "FIRST!"
-    ],
     "Fixes": [
-      "Fixed a crash related to pasting stuff while having selected a nested timeline row."
+      "Fixed a crash related to pasting with a nested timeline row selected.",
+      "Fixed occasional empty thumbnails on the share page for projects with subcomponents."
     ]
   }
 }

--- a/packages/haiku-serialization/src/bll/Template.js
+++ b/packages/haiku-serialization/src/bll/Template.js
@@ -898,14 +898,25 @@ Template.cleanMana = (mana, {resetIds = false, suppressSubcomponents = true} = {
   const out = {}
   if (!mana) return null
   if (typeof mana === 'string') return mana
-  out.elementName = mana.elementName
 
   // cleanMana is used when producing a decycled (wire-ready) bytecode object during editing.
   // If the bytecode has any subcomponents, which are designated using the .elementName
   // in the same way the React designates components by the .type, then treat the
-  // node as a simple <div>. TODO: We may actually want to decycle the subcomponent here.
-  if (suppressSubcomponents && out.elementName && typeof out.elementName === 'object') {
-    out.elementName = 'div'
+  // node as a simple <div>.
+  if (mana.elementName && typeof mana.elementName === 'object' && mana.elementName !== null) {
+    if (suppressSubcomponents) {
+      out.elementName = 'div'
+    } else {
+      out.elementName = Bytecode.decycle(
+        mana.elementName,
+        {
+          cleanManaOptions: {resetIds, suppressSubcomponents},
+          doCleanMana: true
+        }
+      )
+    }
+  } else {
+    out.elementName = mana.elementName
   }
 
   out.attributes = mana.attributes
@@ -996,3 +1007,4 @@ module.exports = Template
 
 // Down here to avoid Node circular dependency stub objects. #FIXME
 const Element = require('./Element')
+const Bytecode = require('./Bytecode')


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes last known case of blank `static.json` files breaking thumbnails on share page. Repro _was_:
  - New project.
  - Instantiate slice.
  - Create component.
  - Nav back to main.
  - Publish.

Regressions to look for:

- None are expected.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Updated `changelog/public/latest.json`
