### PR TITLE
Task 886134127364494

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -2,7 +2,8 @@
   "sections": {
     "Fixes": [
       "Fixed a crash related to pasting with a nested timeline row selected.",
-      "Fixed occasional empty thumbnails on the share page for projects with subcomponents."
+      "Fixed occasional empty thumbnails on the share page for projects with subcomponents.",
+      "Fixed a crash related to using invalid 'd' attributes for a path."
     ]
   }
 }

--- a/packages/@haiku/core/src/helpers/PathUtils.ts
+++ b/packages/@haiku/core/src/helpers/PathUtils.ts
@@ -336,13 +336,15 @@ export const synchronizePathStructure = (...paths: CurveSpec[][]) => {
   }
 
   const maxVerts = Math.max(...paths.map((path) => path.length));
-  paths.forEach((path) => {
+  const validPaths = paths.filter((path) => path.length);
+
+  validPaths.forEach((path) => {
     ensurePathClockwise(path);
     distributeTotalVertices(path, maxVerts);
     normalizePointCurves(path);
   });
 
-  for (let i = 0; i < paths.length - 1; i++) {
-    rotatePathForSmallestDistance(paths[i], paths[i + 1]);
+  for (let i = 0; i < validPaths.length - 1; i++) {
+    rotatePathForSmallestDistance(validPaths[i], validPaths[i + 1]);
   }
 };


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Band-aid for [TypeError: Cannot read property 'splits' of undefined](https://app.asana.com/0/856556209422928/886134127364494) by omitting paths with an empty `d` set via the timeline.

I tried to include a test but I don't know how to tell TS that I want to send a parameter that does not have a valid type (in this case: `null[][]`)

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
