### PR TITLE
fix: check if there's a next kf before rendering a transition segment

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -3,7 +3,8 @@
     "Fixes": [
       "Fixed a crash related to pasting with a nested timeline row selected.",
       "Fixed occasional empty thumbnails on the share page for projects with subcomponents.",
-      "Fixed a crash related to using invalid 'd' attributes for a path."
+      "Fixed a crash related to using invalid 'd' attributes for a path.",
+      "Fixed a bug causing the Timeline to display non-existent keyframes."
     ]
   }
 }

--- a/packages/haiku-timeline/src/components/RowSegments.js
+++ b/packages/haiku-timeline/src/components/RowSegments.js
@@ -72,7 +72,7 @@ export default class RowSegments extends React.Component {
           // The use of this.props.scope as part of the id/key is necessary so that
           // model updates are routed properly; if you remove it, things will break.
 
-          if (keyframe.isTransitionSegment()) {
+          if (keyframe.isTransitionSegment() && keyframe.next()) {
             segmentPieces.push(
               <TransitionBody
                 id={`keyframe-${keyframe.getUniqueKey()}-${this.props.scope}-transition-body`}


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes a [bug reported by @taylorpoe on Slack](https://the-haiku-team.slack.com/archives/C20K3HVEE/p1540856219029900):

> Marquee is selecting wrong keyframes. for me.
> ![screen recording 2018-10-29 at 04 36 pm](https://user-images.githubusercontent.com/4419992/47929307-662e1180-dea7-11e8-8879-07b9c0958f98.gif)

Steps to repro are:

- Instantiate a slice
- Move the scrubber to t=t<sub>1</sub>
- Perform a mutating operation on the slice to create keyframes at t<sub>1</sub>
- Move the scrubber further in time to t=t<sub>2</sub>
- Perform a mutating operation on the slice to create keyframes at t<sub>2</sub>
- Undo

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
