### PR TITLE
Fixes nov5

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -5,7 +5,9 @@
       "Fixed occasional empty thumbnails on the share page for projects with subcomponents.",
       "Fixed a crash related to using invalid 'd' attributes for a path.",
       "Disabled the creation of keyframes for Size properties on the Main component.",
-      "Fixed a bug causing the Timeline to display non-existent keyframes."
+      "Fixed a bug causing the Timeline to display non-existent keyframes.",
+      "Fixed crashes with direct selection under certain SVG elements.",
+      "Fixed crashes on marquee selection on the Timeline on specific scenarios."
     ]
   }
 }

--- a/packages/haiku-common/src/math/geometryUtils.ts
+++ b/packages/haiku-common/src/math/geometryUtils.ts
@@ -240,6 +240,9 @@ export const isPointInsidePrimitive = (element: HaikuElement, point: Vec2): bool
   if (element.type === 'use') {
     // tslint:disable-next-line:no-parameter-reassignment
     element = element.getTranscludedElement();
+    if (!element) {
+      return false;
+    }
   }
 
   const correctedPoint = transform2DPoint(point, original.layoutAncestryMatrices.reverse());

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -918,7 +918,7 @@ Keyframe.findIntersectingWithArea = ({
 
       const freshBounds = viewCoordinatesProvider(keyframe)
 
-      return !(
+      return freshBounds && !(
         freshBounds.top > area.bottom ||
         area.top > freshBounds.bottom
       )

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -164,7 +164,7 @@ class Timeline extends React.Component {
 
   getKeyframeCoordinates = (keyframe) => {
     const keyframeViewEl = document.getElementById(`keyframe-container-${keyframe.getUniqueKey()}`);
-    return keyframeViewEl.firstChild.getBoundingClientRect();
+    return keyframeViewEl ? keyframeViewEl.firstChild.getBoundingClientRect() : null;
   };
 
   instantiateMarquee () {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

This PR includes fixes for:

- [TypeError: Cannot read property 'firstChild' of null](https://app.asana.com/0/856556209422928/896771693681697) by being aware that some models may not be rendered on the timeline.
- [TypeError: Cannot read property 'type' of undefined](https://app.asana.com/0/856556209422928/891809558900447) by being aware that `Element#getTranscludedElement` can return `null` values.

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [x] Updated `changelog/public/latest.json`
