### PR TITLE
fix: avoid sending subcomponents via websockets to prevent circular structures

### DIFF
--- a/packages/haiku-serialization/src/bll/ActionStack.js
+++ b/packages/haiku-serialization/src/bll/ActionStack.js
@@ -605,7 +605,7 @@ ActionStack.METHOD_INVERTERS = {
 
   deleteKeyframe: {
     before: (ac, [componentId, timelineName, propertyName, keyframeMs]) => {
-      const elementName = ac.getElementNameOfComponentId(componentId)
+      const elementName = ac.getSafeElementNameOfComponentId(componentId)
       const oldValue = ac.getKeyframeValue(componentId, timelineName, keyframeMs, propertyName)
       const oldCurve = ac.getKeyframeCurve(componentId, timelineName, keyframeMs, propertyName)
       return {

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -3122,6 +3122,11 @@ class ActiveComponent extends BaseModel {
     return element && element.elementName
   }
 
+  getSafeElementNameOfComponentId (componentId) {
+    const element = this.findTemplateNodeByComponentId(this.getReifiedBytecode().template, componentId)
+    return element && Element.safeElementName(element)
+  }
+
   getTimelineDescriptor (timelineName) {
     const bytecode = this.getReifiedBytecode()
     return bytecode && bytecode.timelines && bytecode.timelines[timelineName]


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

As the title says, this is intended to fix [TypeError: Converting circular structure to JSON](https://app.asana.com/0/856556209422928/885913453927440), since `elementName` can also be bytecode (why?), use `Element.safeElementName` in `ActionStack` to store the name of the element during `deleteKeyframe`

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
