### PR TITLE
fix: unset _lastSeek when pausing

### DIFF
--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -171,6 +171,7 @@ class Timeline extends BaseModel {
 
   pause () {
     this._playing = false
+    this._lastSeek = null
     if (!this.component.project.getEnvoyClient().isInMockMode()) {
       const channel = this.component.project.getEnvoyChannel('timeline')
       // Don't know why, but this can be undefined in some edge case/race


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes the following bug:

- Play with the ► on the bottom of the timeline
- Pause
- Try to go to frame 0 by clicking on the gauge

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
