### PR TITLE
fix: upgrade monaco to v0.15.5

### DIFF
--- a/packages/haiku-creator/package.json
+++ b/packages/haiku-creator/package.json
@@ -45,7 +45,7 @@
     "lodash.debounce": "4.0.8",
     "marked": "^0.3.17",
     "mixpanel": "0.6.0",
-    "monaco-editor": "^0.14.3",
+    "monaco-editor": "^0.15.5",
     "node-fetch": "^2.0.0-alpha.9",
     "opn": "^5.3.0",
     "qs": "6.4.0",

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/Snippets.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/Snippets.js
@@ -94,9 +94,7 @@ class Snippets extends React.PureComponent {
   componentWillReceiveProps (newProps) {
     if (newProps.editor && !this.props.editor) {
 
-      newProps.editor.domElement
-      .querySelector('.monaco-editor')
-      .appendChild(this._rightGradientDiv);
+      newProps.editor.getDomNode().appendChild(this._rightGradientDiv);
 
       // Start snippet button position at line 0
       const newEditorOffsetTop = newProps.editor.getDomNode().offsetTop;
@@ -143,7 +141,7 @@ class Snippets extends React.PureComponent {
     if (this.hasCursorPosition()) {
       range = new monaco.Range(lineNumber, column, lineNumber, column);
     } else {
-      const allLines = this.props.editor.viewModel.lines.lines.length + 1;
+      const allLines = this.props.editor._modelData.viewModel.lines.lines.length + 1;
       range = new monaco.Range(allLines, 100, allLines, 100);
       // tslint:disable-next-line:no-parameter-reassignment
       injectable = `${injectable}`;

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
@@ -126,21 +126,6 @@ class EventHandlerEditor extends React.PureComponent {
 
   // Define our own autocompletion items
     this.completionDisposer = monaco.languages.registerCompletionItemProvider('javascript', {
-      // FIXME: ugly hack to prevent crashes in monaco, this is [officially fixed in vscode][1]
-      // but we have to wait until [monaco is released again][2].
-      //
-      // [1]: https://github.com/Microsoft/vscode/pull/57617
-      // [2]: https://github.com/Microsoft/monaco-editor/issues/1139
-      resolveCompletionItem (item, token) {
-        for (const element of document.querySelectorAll('.monaco-list-row .contents')) {
-          element.addEventListener('mousedown', (mouseDownEvent) => {
-            mouseDownEvent.preventDefault();
-            mouseDownEvent.stopImmediatePropagation();
-          });
-        }
-
-        return item;
-      },
       provideCompletionItems (model, position) {
 
         // Get text from whole line until autocomplete position
@@ -180,7 +165,7 @@ class EventHandlerEditor extends React.PureComponent {
           completionItems.push(completionEntryWithInsertText);
         }
 
-        return completionItems;
+        return {suggestions: completionItems};
       },
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,13 +630,13 @@
     tslib "^1.8.1"
 
 "@haiku/core@^3.1.32":
-  version "4.3.0"
+  version "4.3.5"
 
 "@haiku/core@^3.2.16":
-  version "4.3.0"
+  version "4.3.5"
 
 "@haiku/core@^3.4.6":
-  version "4.3.0"
+  version "4.3.5"
 
 "@haiku/player@^3.0.4":
   version "3.0.4"
@@ -6299,9 +6299,9 @@ moment@2.18.1:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
-monaco-editor@^0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.14.3.tgz#7cc4a4096a3821f52fea9b10489b527ef3034e22"
+monaco-editor@^0.15.5:
+  version "0.15.5"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.15.5.tgz#78e8bc2c41c08e75a9ac58b075a87d4db00ee7e7"
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Since our request, the `monaco` team has released a new version! 🙌, this PR updates the`monaco` version to `v0.15.5` and:

- Removes ugly hacks to workaround `monaco` bugs fixed in this new version.
- Upgrades sections of the code to satisfy API changes.
- Hopefully fixes some internal `monaco` bugs causing crashes. 

Regressions to look for:

- Actions & Code editor in general

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
