### PR TITLE
fix: check if the descriptor exists before trying to access values

### DIFF
--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -1833,12 +1833,14 @@ export default class HaikuComponent extends HaikuElement implements IHaikuCompon
 
     for (let i = 0; i < parseeWithKeys.keys.length; i++) {
       const ms = parseeWithKeys.keys[i];
-
-      if (skipStableParsees && parseeWithKeys.parsee[ms] && !parseeWithKeys.parsee[ms].expression) {
-        continue;
-      }
-
       const descriptor = cluster[ms];
+
+    if (
+      (skipStableParsees && parseeWithKeys.parsee[ms] && !parseeWithKeys.parsee[ms].expression) ||
+      descriptor === undefined
+    ) {
+      continue;
+    }
 
       if (isFunction(descriptor.value)) {
         parseeWithKeys.parsee[ms] = {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Band-aid fix for [TypeError: Cannot read property 'value' of undefined](https://app.asana.com/0/856556209422928/918972711452978)

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
