### PR TITLE
fix: disable project interactions while a project is being deleted

### DIFF
--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -125,10 +125,10 @@ class ProjectBrowser extends React.Component {
             });
             break;
         }
-        this.setState({error});
+        this.setState({error, areProjectsLoading: false});
         return;
       }
-      this.setState({projectsList}, this.updateDimensions);
+      this.setState({projectsList, areProjectsLoading: false}, this.updateDimensions);
       this.props.onProjectsList(projectsList);
     });
   }
@@ -171,7 +171,7 @@ class ProjectBrowser extends React.Component {
     const projectsList = this.state.projectsList;
     const projectToDelete = projectsList.find((project) => project.projectName === this.state.projToDelete);
     projectToDelete.isDeleted = true;
-    this.setState({projectsList}, () => {
+    this.setState({projectsList, areProjectsLoading: true}, () => {
       this.requestDeleteProject(projectToDelete, (deleteError) => {
         if (deleteError) {
           this.props.createNotice({
@@ -409,6 +409,7 @@ class ProjectBrowser extends React.Component {
           <ProjectThumbnail
             key={projectObject.projectName}
             allowDelete={this.props.isOnline || projectObject.local}
+            allowInteractions={!this.state.areProjectsLoading}
             organizationName={this.props.organizationName}
             projectName={projectObject.projectName}
             projectExistsLocally={projectObject.projectExistsLocally}

--- a/packages/haiku-creator/src/react/components/ProjectThumbnail.js
+++ b/packages/haiku-creator/src/react/components/ProjectThumbnail.js
@@ -17,6 +17,12 @@ class ProjectThumbnail extends React.Component {
     };
   }
 
+  launchProjectIfAllowed = () => {
+    if (this.props.allowInteractions) {
+      this.props.launchProject()
+    }
+  }
+
   render () {
     return (
       <div
@@ -55,14 +61,18 @@ class ProjectThumbnail extends React.Component {
           ]}
           onClick={() => {
             if (!this.state.isMenuActive) {
-              this.props.launchProject();
+              this.launchProjectIfAllowed()
             }
           }}
           onMouseOver={() => {
-            this.setState({isHovered: true});
+            if (this.props.allowInteractions) {
+              this.setState({isHovered: true});
+            }
           }}
           onMouseLeave={() => {
-            this.setState({isHovered: false});
+            if (this.props.allowInteractions) {
+              this.setState({isHovered: false});
+            }
           }}
         >
           <span
@@ -111,21 +121,23 @@ class ProjectThumbnail extends React.Component {
           </span>}
         </div>
         <div
-            onClick={this.props.launchProject}
+            onClick={this.launchProjectIfAllowed}
             style={DASH_STYLES.titleStrip}
         >
           <span style={DASH_STYLES.title}>
             {this.props.projectName}
           </span>
-          {(this.props.allowDelete || this.props.projectExistsLocally) && <span
+          {(this.props.allowDelete || this.props.projectExistsLocally) && this.props.allowInteractions && <span
             title="Show project options"
             style={[DASH_STYLES.titleOptions, {transform: 'translateY(1px)'}]}
             onClick={(e) => {
               // Prevend launching project, as parent div has onClick handler
               e.stopPropagation();
-              this.setState({
-                isMenuActive: !this.state.isMenuActive,
-              });
+              if (this.props.allowInteractions) {
+                this.setState({
+                  isMenuActive: !this.state.isMenuActive,
+                });
+              }
             }}
           >
             <StackMenuSVG color={Palette.SUNSTONE} width="5px" height="12px" />

--- a/packages/haiku-creator/src/react/styles/dashShared.ts
+++ b/packages/haiku-creator/src/react/styles/dashShared.ts
@@ -133,7 +133,7 @@ export const DASH_STYLES: React.CSSProperties = {
   deleted: {
     transform: 'scale(.00001)',
     flex: '.00001',
-    minWidth: '0',
+    minWidth: 'auto',
     marginLeft: 0,
     marginRight: 0,
   },


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

This fixes the [TypeError: Cannot set property 'isDeleted' of undefined](https://app.asana.com/0/856556209422928/919533583031498) crash, occasioned by deleting multiple projects one after the other in a fast sequence.

This solution as democratically voted by the people of Haiku, disables project interactions while a project is being deleted.

I also modified the CSS to make the card going away to actually perform the intended animation.

Regressions to look for:

- None expected, but could be a good idea to check dashboard interactions

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
