### PR TITLE
fix: check if moveTo is defined before trying to read from it

### DIFF
--- a/packages/@haiku/core/src/vendor/svg-points/toPoints.ts
+++ b/packages/@haiku/core/src/vendor/svg-points/toPoints.ts
@@ -420,7 +420,7 @@ const getPointsFromPath = ({d}: PathSpec): CurveSpec[] => {
       if (upperCaseCommand === 'Z') {
         prevPoint.closed = true;
       }
-      if (prevPoint.x !== moveTo.x || prevPoint.y !== moveTo.y) {
+      if (moveTo !== undefined && (prevPoint.x !== moveTo.x || prevPoint.y !== moveTo.y)) {
         points.push({
           x: moveTo.x,
           y: moveTo.y,


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

As the title says, `moveTo` can be undefined if we reach the `else` branch first, which can be the case for invalid paths.

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
