### PR TITLE
fix: edge case of long, allcaps proj names covering menu btn

### DIFF
--- a/packages/haiku-creator/src/react/styles/dashShared.ts
+++ b/packages/haiku-creator/src/react/styles/dashShared.ts
@@ -233,9 +233,12 @@ export const DASH_STYLES: React.CSSProperties = {
     marginRight: 'auto',
   },
   titleOptions: {
-    paddingLeft: 5,
-    paddingRight: 5,
+    backgroundColor: Palette.COAL,
+    paddingLeft: 8,
+    paddingRight: 12,
     opacity: 0.84,
+    position: 'absolute',
+    right: 0,
     transition: 'opacity 120ms ease',
     ':hover': {
       opacity: 1,


### PR DESCRIPTION
OK to merge.

Fixed edge case where max-character-length, all-caps project names were covering the dashboard project card's options menu. A user encountered this and was not able to delete there project due to it. (Would have been able to if they resized their browser slightly.)

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
