### PR TITLE
fix: do not try to access object properties without the object in #isPointAlongStroke

### DIFF
--- a/packages/haiku-common/src/math/geometryUtils.ts
+++ b/packages/haiku-common/src/math/geometryUtils.ts
@@ -184,7 +184,7 @@ export const isPointAlongStroke = (element: HaikuElement, point: Vec2,
 
   const correctedPoint = transform2DPoint(point, original.layoutAncestryMatrices.reverse());
 
-  switch (element.type) {
+  switch (element && element.type) {
     case 'rect': {
       const p1 = {x: Number(element.attributes.x), y: Number(element.attributes.y)};
       const p2 = {x: Number(element.attributes.x) + element.sizeX, y: Number(element.attributes.y)};


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes crash listed in task [941810135553879](https://app.asana.com/0/922186784503552/941810135553879)

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
