### PR TITLE
docs: add an example for vue single file components in publish ui

### DIFF
--- a/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/VueHaiku.tsx
+++ b/packages/haiku-ui-common/src/react/ShareModal/ShareOptions/VueHaiku.tsx
@@ -23,9 +23,30 @@ export default class VueHaiku extends React.PureComponent<VueHaikuProps> {
             components: {
               ${projectName}
             }
-          })
+          });
           `}
         </CodeBox>
+
+        <br />
+        <i>Or using single file components:</i>
+        <CodeBox>
+          {dedent`
+          <template>
+            <${projectName} :loop="true"></${projectName}>
+          </template>
+
+          <script>
+          import ${projectName} from '@haiku/${organizationName.toLowerCase()}-${projectName.toLowerCase()}/vue';
+
+          export default {
+            components: {
+              ${projectName}
+            }
+          }
+          </script>
+          `}
+        </CodeBox>
+
       </NpmInstallable>
     );
   }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- As stated in ["Update Vue import example to provide instructions for 'single file components' codebases"](https://app.asana.com/0/922186784503552/841648199573478) this adds instructions for single file component codebases.

I tested the instructions in our `account` repo and in a brand new `vue-cli` project and they work fine.

Please note that this illustrates the most basic use case, as there could be more customized codebases (for example `account` uses mixins for components)

Regressions to look for:

-  None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
