### PR TITLE
fix: do not try to access 'this' when we shouldn't

### DIFF
--- a/packages/haiku-serialization/src/utils/fileManipulation.js
+++ b/packages/haiku-serialization/src/utils/fileManipulation.js
@@ -3,13 +3,10 @@ const fs = require('fs');
 const {exec} = require('child_process');
 
 const RESERVED_CHAR_REPLACEMENT = '-';
+const FILENAME_RESERVED_REGEX = /[<>:"\/\\|?*\x00-\x1F]/g;
+const WINDOWS_NAMES_RESERVED_REGEX = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])$/i;
 
 module.exports = {
-  // eslint-disable-next-line
-  filenameReservedRegex: /[<>:"\/\\|?*\x00-\x1F]/g,
-
-  windowsNamesReservedRegex: /^(con|prn|aux|nul|com[0-9]|lpt[0-9])$/i,
-
   download (url, downloadPath, onProgress, shouldCancel) {
     const file = fs.createWriteStream(downloadPath);
 
@@ -61,7 +58,7 @@ module.exports = {
     }
 
     return name
-      .replace(this.filenameReservedRegex, RESERVED_CHAR_REPLACEMENT)
-      .replace(this.windowsNamesReservedRegex, RESERVED_CHAR_REPLACEMENT);
+      .replace(FILENAME_RESERVED_REGEX, RESERVED_CHAR_REPLACEMENT)
+      .replace(WINDOWS_NAMES_RESERVED_REGEX, RESERVED_CHAR_REPLACEMENT);
   },
 };

--- a/packages/haiku-serialization/test/utils/00_fileManipulation.test.js
+++ b/packages/haiku-serialization/test/utils/00_fileManipulation.test.js
@@ -22,6 +22,8 @@ test('fileManipulation#unzip succesfully unzips a file', async (t) => {
   t.end();
 });
 
-function _cleanup () {
-  fs.rmdirSync(FIXTURES_TMP);
-}
+test('fileManipulation#sanitize replaces invalid linux characters with a dash', (t) => {
+  const sanitized = fileManipulation.sanitize('my / file / name')
+  t.equal(sanitized, 'my - file - name', 'dashes should be removed');
+  t.end();
+})


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Fixes [Issues with Figma import](https://app.asana.com/0/922186784503552/943552036162046), by properly sanitizing the file name of imported elements.

Two things to note from this horrible mistake that has been live 5 months in prod:

- Tests are useful, this module was easily testeable.
- I'm very dumb.

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
