### PR TITLE
fix: calcule hashes differently on getInsertionPointInfo

### DIFF
--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -663,7 +663,7 @@ class ActiveComponent extends BaseModel {
 
     const index = (mana && mana.children && mana.children.length) || 0;
 
-    const template = mana && Template.manaWithOnlyMinimalProps(mana, () => ({}));
+    const template = mana && Template.manaWithOnlyStandardProps(mana, () => ({}));
 
     const source = jss(template) + '-' + index + '-' + nonce;
 


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

@stristr this is a _very_ lazy way to solve the problem you described in [Multiple gradients clash when mergeDesigns happens](https://app.asana.com/0/922186784503552/941872991077444), is it good enough?

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
