### PR TITLE
fix: set correct element titles for nested elements

### DIFF
--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/ElementTitle.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/ElementTitle.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {get} from 'lodash';
+import isNumeric from 'haiku-ui-common/lib/helpers/isNumeric';
 import {TrashIconSVG} from 'haiku-ui-common/lib/react/OtherIcons';
 import Palette from 'haiku-ui-common/lib/Palette';
 import truncate from 'haiku-ui-common/lib/helpers/truncate';
@@ -26,22 +26,27 @@ const STYLES = {
 };
 
 class ElementTitle extends React.PureComponent {
-  getElementTitle () {
-    if (this.props.title) {
-      return this.props.title;
+  get elementTitle () {
+    return this.props.element ? truncate(this.props.element.getTitle(), 16) : '(unknown)';
+  }
+
+  get title () {
+    return isNumeric(this.props.currentFrame) ? `Frame ${this.props.currentFrame}` : this.elementTitle;
+  }
+
+  get breadcrumb () {
+    if (!isNumeric(this.props.currentFrame) && this.props.currentEvent) {
+      return '> ' + this.props.currentEvent;
     }
 
-    const element = this.props.element;
-    const node = element && element.getStaticTemplateNode();
-    const title = get(node, 'attributes.haiku-title');
-    return title ? truncate(title, 16) : '(unknown)';
+    return '';
   }
 
   render () {
     return (
       <div style={STYLES.wrapper}>
-        <h3 style={STYLES.title}>{`${this.getElementTitle()} Actions ${this.props.breadcrumb}`}</h3>
-        {this.props.isDeleteable &&
+        <h3 style={STYLES.title}>{`${this.title} Actions ${this.breadcrumb}`}</h3>
+        {!this.props.currentEvent &&
           <button onClick={this.props.onEditorRemoved} style={STYLES.trashIcon}>
             <TrashIconSVG color={STYLES.trashIconColor} />
           </button>
@@ -54,8 +59,8 @@ class ElementTitle extends React.PureComponent {
 ElementTitle.propTypes = {
   element: React.PropTypes.object,
   onEditorRemoved: React.PropTypes.func.isRequired,
-  breadcrumb: React.PropTypes.string,
-  isDeleteable: React.PropTypes.bool,
+  currentFrame: React.PropTypes.number,
+  currentEvent: React.PropTypes.string,
 };
 
 export default ElementTitle;

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/index.js
@@ -6,6 +6,7 @@ import Editor from './Editor';
 import EditorActions from './EditorActions';
 import EventSelector from './EventSelector';
 import HandlerManager from './HandlerManager';
+import isNumeric from 'haiku-ui-common/lib/helpers/isNumeric';
 import {
   ModalWrapper,
   ModalHeader,
@@ -65,10 +66,6 @@ const STYLES = {
     marginBottom: '15px',
   },
 };
-
-function isNumeric (n) {
-  return !isNaN(parseFloat(n)) && isFinite(n);
-}
 
 class EventHandlerEditor extends React.PureComponent {
   constructor (props) {
@@ -326,11 +323,7 @@ class EventHandlerEditor extends React.PureComponent {
             <ElementTitle
               element={this.props.element}
               data-tooltip={true}
-              title={
-                isNumeric(this.props.options.frame)
-                  ? `Frame ${this.props.options.frame}`
-                  : null
-              }
+              currentFrame={this.props.options.frame}
               onEditorRemoved={() => {
                 this.doRemove();
                 if (isNumeric(this.props.options.frame)) {
@@ -339,12 +332,7 @@ class EventHandlerEditor extends React.PureComponent {
                   this.hideEditor();
                 }
               }}
-              breadcrumb={
-                isNumeric(this.props.options.frame) || !this.state.currentEvent
-                  ? ''
-                  : '> ' + this.state.currentEvent
-              }
-              isDeleteable={!!this.state.currentEvent}
+              currentEvent={this.state.currentEvent}
             />
           </ModalHeader>
 

--- a/packages/haiku-creator/src/react/components/ProjectThumbnail.js
+++ b/packages/haiku-creator/src/react/components/ProjectThumbnail.js
@@ -19,9 +19,9 @@ class ProjectThumbnail extends React.Component {
 
   launchProjectIfAllowed = () => {
     if (this.props.allowInteractions) {
-      this.props.launchProject()
+      this.props.launchProject();
     }
-  }
+  };
 
   render () {
     return (
@@ -61,7 +61,7 @@ class ProjectThumbnail extends React.Component {
           ]}
           onClick={() => {
             if (!this.state.isMenuActive) {
-              this.launchProjectIfAllowed()
+              this.launchProjectIfAllowed();
             }
           }}
           onMouseOver={() => {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Fixes a bug causing ["'Undefined' as Actions Editor title when opening the editor on direct selection or in a sub element via the timeline"](https://app.asana.com/0/922186784503552/945126442348446) and also refactors a bit some of my horrible code.

- Add two missing semicolons (cc @taylorpoe)


Regressions to look for:

- None expected, but look out for Actions Editor modal titles

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
