### PR TITLE
fix: prevent crashes when non-menuable event listeners are added to the bytecode

### DIFF
--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/ElementTitle.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/ElementTitle.js
@@ -46,7 +46,7 @@ class ElementTitle extends React.PureComponent {
     return (
       <div style={STYLES.wrapper}>
         <h3 style={STYLES.title}>{`${this.title} Actions ${this.breadcrumb}`}</h3>
-        {!this.props.currentEvent &&
+        {(isNumeric(this.props.currentFrame) || this.props.currentEvent) &&
           <button onClick={this.props.onEditorRemoved} style={STYLES.trashIcon}>
             <TrashIconSVG color={STYLES.trashIconColor} />
           </button>

--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -374,7 +374,7 @@ class Element extends BaseModel {
         // If not, show it only if there is a handler explicitly defined for it.
         if (candidate.menuable || handlers[name]) {
           suboptions.push({
-            label: candidate.human,
+            label: candidate.human || name,
             value: name,
           });
         }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:


Prevent crashes when non-menuable event listeners are added to the bytecode by using the event name as a fallback if no 'human' name is defined.

This fixes the two following crashes which are deeply related:

- [TypeError: Cannot read property '_currentElement' of null](https://app.asana.com/0/922186784503552/945628384314125)
- [TypeError: Cannot read property 'toLowerCase' of undefined](https://app.asana.com/0/922186784503552/945628894229325)

I also sneaked a fix for a regression I introduced in #919 .

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
