### PR TITLE
fix: fixes crash when trying to use Object.keys on non-objects

### DIFF
--- a/packages/@haiku/core/src/helpers/isMutableProperty.ts
+++ b/packages/@haiku/core/src/helpers/isMutableProperty.ts
@@ -6,15 +6,21 @@
  * @method isMutableProperty
  * @description Mechanism to determine if a property is mutated within the timeline.
  */
-export default function isMutableProperty (property, propertyName) {
+export default function isMutableProperty (property, propertyName: string) {
   // For now, we can use a "naive" set of sufficient (but not necessary) conditions for immutability of a property:
   //   1. Has exactly one keyframe.
   //   2. The keyframe is "0".
   //   3. The value at keyframe "0" is not a function (and so it cannot be mutated by changes in the state container).
   // Although there is a more complete definition of immutability, this is enough to identify a property which is
   // "likely mutable".
-  return Object.keys(property).length !== 1
-    || !property.hasOwnProperty('0')
-    || typeof property[0].value === 'function'
-    || /^controlFlow/.test(propertyName);
+  return (
+    typeof property === 'object' &&
+    property !== null &&
+    (
+      Object.keys(property).length !== 1
+      || !property.hasOwnProperty('0')
+      || typeof property[0].value === 'function'
+      || /^controlFlow/.test(propertyName)
+    )
+  );
 }

--- a/packages/@haiku/core/test/unit/isMutableProperty.test.ts
+++ b/packages/@haiku/core/test/unit/isMutableProperty.test.ts
@@ -45,6 +45,18 @@ tape(
       isMutableProperty({0: {value: 'foo'}}, 'blah'),
       'scalar-valued single keyframe => immutable',
     );
+    t.false(
+      isMutableProperty(undefined, 'bad-property'),
+      'undefined passed as property should return false'
+    );
+    t.false(
+      isMutableProperty(null, 'bad-property'),
+      'null passed as property should return false'
+    );
+    t.false(
+      isMutableProperty('bad-property', 'bad-property'),
+      'string passed as property should return false'
+    );
     t.end();
   },
 );


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

In ES5, if the argument to this method is not an object (a primitive),
then it will cause a TypeError.

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
