### PR TITLE
fix: don't crash on null states

### DIFF
--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -766,7 +766,7 @@ export default class HaikuComponent extends HaikuElement implements IHaikuCompon
 
     // Local states get precedence over global summonables, so assign them last
     for (const key in this._states) {
-      let type = this._states[key].type;
+      let type = this._states[key] && this._states[key].type;
       if (!type) {
         type = typeof this._states[key];
       }

--- a/packages/@haiku/core/test/api/01_component._getInjectables.test.ts
+++ b/packages/@haiku/core/test/api/01_component._getInjectables.test.ts
@@ -14,6 +14,9 @@ tape(
         baz: {
           value: 'abc',
         },
+        bull: {
+          value: null,
+        },
       },
       timelines: {
         Default: {
@@ -66,6 +69,9 @@ tape(
         injectables.bux,
         'number',
       );
+
+      t.ok(injectables.bull);
+      t.equal(injectables.bull, 'object')
 
       component.context.clock.GLOBAL_ANIMATION_HARNESS.cancel();
 


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

The title says it all, one small detail could be to set the type to `'null'` instead of `'object'`, let me know if you want to make that change and I'll amend shortly.

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [x] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
