### PR TITLE
Fix Gatsby 2 hung builds

### DIFF
--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -1835,12 +1835,12 @@ export default class HaikuComponent extends HaikuElement implements IHaikuCompon
       const ms = parseeWithKeys.keys[i];
       const descriptor = cluster[ms];
 
-    if (
-      (skipStableParsees && parseeWithKeys.parsee[ms] && !parseeWithKeys.parsee[ms].expression) ||
-      descriptor === undefined
-    ) {
-      continue;
-    }
+      if (
+        (skipStableParsees && parseeWithKeys.parsee[ms] && !parseeWithKeys.parsee[ms].expression) ||
+        descriptor === undefined
+      ) {
+        continue;
+      }
 
       if (isFunction(descriptor.value)) {
         parseeWithKeys.parsee[ms] = {

--- a/packages/@haiku/core/src/vendor/raf/index.ts
+++ b/packages/@haiku/core/src/vendor/raf/index.ts
@@ -1,17 +1,19 @@
+/* tslint:disable */
+
 /**
  * The MIT License
- * 
+ *
  * Copyright (c) 2017 Chris Dickinson
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this
  * software and associated documentation files (the "Software"), to deal in the Software
  * without restriction, including without limitation the rights to use, copy, modify, merge,
  * publish, distribute, sublicense, and/or sell copies of the Software, and to permit
  * persons to whom the Software is furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all copies
  * or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
  * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
  * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
@@ -20,79 +22,87 @@
  * OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* eslint-disable */
-
-import now from '../performance-now';
+import performanceNow from '../performance-now';
 
 const root = typeof window === 'undefined' ? global : window;
 const vendors = ['moz', 'webkit'];
 const suffix = 'AnimationFrame';
-let raf = root['request' + suffix];
-let caf = root['cancel' + suffix] || root['cancelRequest' + suffix];
 
-for (let i = 0; !raf && i < vendors.length; i++) {
-  raf = root[vendors[i] + 'Request' + suffix];
-  caf =
-    root[vendors[i] + 'Cancel' + suffix] ||
-    root[vendors[i] + 'CancelRequest' + suffix];
-}
+let raf: Function;
+let caf: Function;
 
-// Some versions of FF have rAF but not cAF
-if (!raf || !caf) {
-  let last = 0,
-    id = 0,
-    queue = [],
-    frameDuration = 1000 / 60;
+if (typeof window !== 'undefined') {
+  raf = window['request' + suffix];
+  caf = window['cancel' + suffix] || window['cancelRequest' + suffix];
 
-  raf = function (callback) {
-    if (queue.length === 0) {
-      const _now = now(),
-        next = Math.max(0, frameDuration - (_now - last));
-      last = next + _now;
-      setTimeout(function () {
-        const cp = queue.slice(0);
-        // Clear queue here to prevent
-        // callbacks from appending listeners
-        // to the current frame's queue
-        queue.length = 0;
-        for (let i = 0; i < cp.length; i++) {
-          if (!cp[i].cancelled) {
-            try {
-              cp[i].callback(last);
-            } catch (e) {
-              setTimeout(function () {
-                throw e;
-              },         0);
+  for (let i = 0; !raf && i < vendors.length; i++) {
+    raf = window[vendors[i] + 'Request' + suffix];
+    caf =
+      window[vendors[i] + 'Cancel' + suffix] ||
+      window[vendors[i] + 'CancelRequest' + suffix];
+  }
+
+  // Some versions of FF have rAF but not cAF
+  if (!raf || !caf) {
+    let last = 0,
+      id = 0,
+      queue = [],
+      frameDuration = 1000 / 60;
+
+    raf = function (callback) {
+      if (queue.length === 0) {
+        const _now = performanceNow(),
+          next = Math.max(0, frameDuration - (_now - last));
+        last = next + _now;
+        setTimeout(function () {
+          const cp = queue.slice(0);
+          // Clear queue here to prevent
+          // callbacks from appending listeners
+          // to the current frame's queue
+          queue.length = 0;
+          for (let i = 0; i < cp.length; i++) {
+            if (!cp[i].cancelled) {
+              try {
+                cp[i].callback(last);
+              } catch (e) {
+                setTimeout(function () {
+                  throw e;
+                }, 0);
+              }
             }
           }
-        }
-      },         Math.round(next));
-    }
-    queue.push({
-      handle: ++id,
-      callback,
-      cancelled: false,
-    });
-    return id;
-  };
-
-  caf = function (handle) {
-    for (let i = 0; i < queue.length; i++) {
-      if (queue[i].handle === handle) {
-        queue[i].cancelled = true;
+        }, Math.round(next));
       }
-    }
-  };
+      queue.push({
+        handle: ++id,
+        callback,
+        cancelled: false,
+      });
+      return id;
+    };
+
+    caf = function (handle) {
+      for (let i = 0; i < queue.length; i++) {
+        if (queue[i].handle === handle) {
+          queue[i].cancelled = true;
+        }
+      }
+    };
+  }
+} else {
+  // Turn raf and caf into noops outside of the web.
+  // This should help with leaked handles/isomorphic rendering.
+  raf = caf = () => {};
 }
 
-function rafCall(fn) {
+function rafCall (fn) {
   // Wrap in a new function to prevent
   // `cancel` potentially being assigned
   // to the native rAF function
   return raf.call(root, fn);
 }
 
-function cafCall(...args) {
+function cafCall (...args) {
   return caf.apply(root, args);
 }
 

--- a/packages/@haiku/core/test/TestHelpers.ts
+++ b/packages/@haiku/core/test/TestHelpers.ts
@@ -4,12 +4,6 @@ import * as ts from 'typescript';
 
 Error.stackTraceLimit = Infinity;
 
-import HaikuDOMAdapter from '@core/adapters/dom/HaikuDOMAdapter';
-import Config from '@core/Config';
-import HaikuContext from '@core/HaikuContext';
-import HaikuGlobal from '@core/HaikuGlobal';
-import HaikuDOMRenderer from '@core/renderers/dom/HaikuDOMRenderer';
-
 // Tell typescript we have these types on Global
 interface Global {
   window: any;
@@ -17,7 +11,15 @@ interface Global {
   haiku: any;
 }
 
+// Set up global rAF early (prior to imports) to ensure correct behavior in tests.
 declare var global: Global;
+global.window = global;
+
+import HaikuDOMAdapter from '@core/adapters/dom/HaikuDOMAdapter';
+import Config from '@core/Config';
+import HaikuContext from '@core/HaikuContext';
+import HaikuGlobal from '@core/HaikuGlobal';
+import HaikuDOMRenderer from '@core/renderers/dom/HaikuDOMRenderer';
 
 const createDOM = (cb) => {
   const html = '<!doctype html><html><body><div id="mount"></div></body></html>';

--- a/packages/@haiku/core/test/api/01_component._getInjectables.test.ts
+++ b/packages/@haiku/core/test/api/01_component._getInjectables.test.ts
@@ -71,7 +71,7 @@ tape(
       );
 
       t.ok(injectables.bull);
-      t.equal(injectables.bull, 'object')
+      t.equal(injectables.bull, 'object');
 
       component.context.clock.GLOBAL_ANIMATION_HARNESS.cancel();
 


### PR DESCRIPTION
Probably OK to merge; checking if random tests fail and haven't tested with Gatsby 2 yet.

Short review.

Summary of changes:

- Fixes [Gastby 2 leaves hung process during gatsby build when Core is present](https://app.asana.com/0/922186784503552/945173228815929)

Regressions to look for:

- I don't think there should be any side effects from not running a fake rAF loop on the server, but tests should bear this out.

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
