### PR TITLE
feat: add endpoints for coupon validation

### DIFF
--- a/packages/@haiku/sdk-inkstone/src/index.ts
+++ b/packages/@haiku/sdk-inkstone/src/index.ts
@@ -893,6 +893,12 @@ export namespace inkstone {
       Plans: Plan[];
     }
 
+    export interface Coupon {
+      AmountOff: number|null;
+      PercentOff: number|null;
+      Valid: boolean;
+    }
+
     /**
      * @authentication-optional
      * Describes the available products. This endpoint is the source of valid values of PlanID which can be used to
@@ -1033,5 +1039,22 @@ export namespace inkstone {
         .withEndpoint(Endpoints.BillingPlanResource)
         .callWithCallback(cb);
     };
+
+    /**
+     * @authentication-required
+     * Gives information about a coupon via a provided ID
+     *
+     * Error codes:
+     *   E_BILLING_COUPON_NOT_FOUND when an unknown coupon ID is provided to the endpoint.
+     */
+    export const getCoupon = (
+      couponID: string,
+      cb: inkstone.Callback<Coupon>
+    ) => {
+      newGetRequest()
+        .withEndpoint(Endpoints.BillingDescribeCoupon)
+        .withUrlParameters({':coupon_id': couponID})
+        .callWithCallback(cb);
+    }
   }
 }

--- a/packages/@haiku/sdk-inkstone/src/services.ts
+++ b/packages/@haiku/sdk-inkstone/src/services.ts
@@ -35,6 +35,7 @@ export const enum Endpoints {
   BillingSetCardAsDefaultById = '/billing/card/:card_id/is_default',
   BillingDeleteCardById = '/billing/card/:card_id',
   BillingPlanResource = '/billing/plan',
+  BillingDescribeCoupon = '/billing/coupon/:coupon_id',
 }
 
 export interface UriParams {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Adds endpoints for coupon validation to sdk-inkstone, sibling PR: https://github.com/HaikuTeam/inkstone/pull/57

Regressions to look for:

- None

Completed checkin tasks:

- [x] Did manual testing of interrelated functionality
- [ ] Wrote an automated test for existing and modified functionality
- [ ] Added measurement instrumentation (Mixpanel, etc.)
- [ ] Updated `changelog/public/latest.json`
