### PR TITLE
fix: actually solve the issue with ID re-refs during padding

### DIFF
--- a/packages/haiku-serialization/src/bll/Bytecode.js
+++ b/packages/haiku-serialization/src/bll/Bytecode.js
@@ -220,10 +220,9 @@ Bytecode.padIds = (bytecode, padderFunction) => {
     const domId = node.attributes.id;
     if (domId) {
       const fixedDomId = padderFunction(domId);
-      fixedReferences[domId] = fixedDomId;
       fixedReferences[`url(#${domId})`] = `url(#${fixedDomId})`; // filter="url(...)"
       fixedReferences[`#${domId}`] = `#${fixedDomId}`; // xlink:href="#path-3-abc123"
-      node.attributes.id = fixedReferences[domId];
+      node.attributes.id = fixedDomId;
 
       // Sketch outputs layer names as element ids, which are usually human friendly.
       // That human friendly element id is used downstream as a label for display, so


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- [Fixes More ID shuffle madness can result in disappearing elements](https://app.asana.com/0/922186784503552/960107844835150/f). The prior fix in 497ec0fb00aa8248f25f9da397d8dd37f2415d65, reverted to solve gradient problems, didn't work because the remapped ID was re-read for the purpose of reassigning the ID…anyway, this should actually be good now.