### PR TITLE
fix: disable offline access when expiration is before, not after, current date

### DIFF
--- a/packages/haiku-sdk-creator/src/bll/User.ts
+++ b/packages/haiku-sdk-creator/src/bll/User.ts
@@ -80,7 +80,7 @@ export class UserHandler extends EnvoyHandler {
       if (
         this.checkOfflinePrivileges() &&
         this.identity.organization.PlanExpirationDate &&
-        this.identity.organization.PlanExpirationDate > nowDate() / 1e3
+        this.identity.organization.PlanExpirationDate < nowDate() / 1e3
       ) {
         this.identity.organization[OrganizationPrivilege.EnableOfflineFeatures] = false;
         this.setConfigObfuscated<HaikuIdentity>(


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Somehow missed a `>` that should have been a `<` when booting the app and checking offline access. Apparently offline-on-boot has been broken since launch of Pro…fixed here.