### PR TITLE
perf: do not enqueue ticks for serialization work

### DIFF
--- a/packages/@haiku/core/src/HaikuClock.ts
+++ b/packages/@haiku/core/src/HaikuClock.ts
@@ -2,6 +2,7 @@
  * Copyright (c) Haiku 2016-2018. All rights reserved.
  */
 
+import {ClockConfig, IHaikuClock} from './api';
 import HaikuBase from './HaikuBase';
 import HaikuGlobal from './HaikuGlobal';
 import assign from './vendor/assign';
@@ -9,7 +10,7 @@ import raf from './vendor/raf';
 
 const NUMBER = 'number';
 
-const DEFAULT_OPTIONS = {
+const DEFAULT_OPTIONS: ClockConfig = {
   // frameDuration: Number
   // Time to elapse per frame (ms)
   frameDuration: 16.666,
@@ -21,6 +22,10 @@ const DEFAULT_OPTIONS = {
   // marginOfErrorForDelta: Number
   // A bit of grace when calculating whether a new frame should be run
   marginOfErrorForDelta: 1.0,
+
+  // run: Boolean
+  // Whether or not the clock should run by default
+  run: true,
 };
 
 // The global animation harness is a singleton
@@ -58,7 +63,7 @@ if (!HaikuGlobal.HaikuGlobalAnimationHarness) {
 }
 
 // tslint:disable:variable-name
-export default class HaikuClock extends HaikuBase {
+export default class HaikuClock extends HaikuBase implements IHaikuClock {
   private boundRunner: () => void = () => {
     this.run();
   };
@@ -69,11 +74,11 @@ export default class HaikuClock extends HaikuBase {
   _localFramesElapsed;
   _localTimeElapsed;
   _numLoopsRun;
-  options;
+  options: ClockConfig;
   _tickables;
   GLOBAL_ANIMATION_HARNESS;
 
-  constructor (tickables, options) {
+  constructor (tickables, options: ClockConfig) {
     super();
 
     this._tickables = tickables;
@@ -83,8 +88,10 @@ export default class HaikuClock extends HaikuBase {
     this._isRunning = false;
     this.reinitialize();
 
-    // Bind to avoid `this`-detachment when called by raf
-    HaikuGlobal.HaikuGlobalAnimationHarness.queue.push(this.boundRunner);
+    if (this.options.run) {
+      // Bind to avoid `this`-detachment when called by raf
+      HaikuGlobal.HaikuGlobalAnimationHarness.queue.push(this.boundRunner);
+    }
 
     // Tests and others may need this to cancel the rAF loop, to avoid leaked handles
     this.GLOBAL_ANIMATION_HARNESS = HaikuGlobal.HaikuGlobalAnimationHarness;
@@ -104,7 +111,7 @@ export default class HaikuClock extends HaikuBase {
     return this;
   }
 
-  assignOptions (options) {
+  assignOptions (options: ClockConfig) {
     this.options = assign(this.options || {}, DEFAULT_OPTIONS, options || {});
     return this;
   }

--- a/packages/@haiku/core/src/HaikuComponent.ts
+++ b/packages/@haiku/core/src/HaikuComponent.ts
@@ -10,6 +10,7 @@ import {
   BytecodeTimelines,
   Curve,
   HaikuBytecode,
+  IHaikuClock,
   IHaikuComponent,
   IHaikuContext,
   ParsedValueCluster,
@@ -18,7 +19,6 @@ import {
 } from './api';
 import Config from './Config';
 import HaikuBase, {GLOBAL_LISTENER_KEY} from './HaikuBase';
-import HaikuClock from './HaikuClock';
 import HaikuElement from './HaikuElement';
 import HaikuHelpers from './HaikuHelpers';
 import {ascend, cssMatchOne, cssQueryList, manaFlattenTree, visit} from './HaikuNode';
@@ -603,7 +603,7 @@ export default class HaikuComponent extends HaikuElement implements IHaikuCompon
     this.bindStates();
   }
 
-  getClock (): HaikuClock {
+  getClock (): IHaikuClock {
     return this.context.clock;
   }
 

--- a/packages/@haiku/core/src/HaikuContext.ts
+++ b/packages/@haiku/core/src/HaikuContext.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Haiku 2016-2018. All rights reserved.
  */
 
-import {BytecodeOptions, HaikuBytecode, IHaikuContext, IRenderer} from './api';
+import {BytecodeOptions, HaikuBytecode, IHaikuClock, IHaikuContext, IRenderer} from './api';
 import Config from './Config';
 import HaikuBase from './HaikuBase';
 import HaikuClock from './HaikuClock';
@@ -30,7 +30,7 @@ export interface ComponentFactory {
  */
 // tslint:disable:variable-name
 export default class HaikuContext extends HaikuBase implements IHaikuContext {
-  clock: HaikuClock;
+  clock: IHaikuClock;
   component: HaikuComponent;
   config;
   container;
@@ -152,7 +152,7 @@ export default class HaikuContext extends HaikuBase implements IHaikuContext {
    * @method getClock
    * @description Returns the HaikuClock instance associated with this context.
    */
-  getClock (): HaikuClock {
+  getClock (): IHaikuClock {
     return this.clock;
   }
 

--- a/packages/@haiku/core/src/StateTransitionManager.ts
+++ b/packages/@haiku/core/src/StateTransitionManager.ts
@@ -1,5 +1,4 @@
-import {BytecodeStateType, Curve, CurveDefinition, IHaikuComponent} from './api';
-import HaikuClock from './HaikuClock';
+import {BytecodeStateType, Curve, CurveDefinition, IHaikuClock, IHaikuComponent} from './api';
 import {interpolate} from './Interpolate';
 
 export interface StateTransitionParameters {
@@ -25,7 +24,7 @@ export default class StateTransitionManager {
 
   // Store running state transitions
   private transitions: {[key in string]: RunningStateTransition[]} = {};
-  private clock: HaikuClock;
+  private clock: IHaikuClock;
   private states: StateValues;
 
   constructor (private readonly component: IHaikuComponent) {

--- a/packages/@haiku/core/src/api/index.ts
+++ b/packages/@haiku/core/src/api/index.ts
@@ -1,5 +1,4 @@
 import HaikuBase from '../HaikuBase';
-import HaikuClock from '../HaikuClock';
 import {RFO} from '../reflection/functionToRFO';
 
 export interface IHaikuElement extends HaikuBase {
@@ -20,6 +19,17 @@ export interface IHaikuElement extends HaikuBase {
   isHovered: boolean;
 }
 
+export interface IHaikuClock {
+  destroy (): void;
+  getExplicitTime (): number;
+  getFrameDuration (): number;
+  getTime (): number;
+  isRunning (): boolean;
+  run (): void;
+  start (): void;
+  assignOptions (options: ClockConfig): void;
+}
+
 export interface IHaikuComponent extends IHaikuElement {
   bytecode: HaikuBytecode;
   config: BytecodeOptions;
@@ -34,7 +44,7 @@ export interface IHaikuComponent extends IHaikuElement {
   callHook: (hookName: string, ...args: any[]) => void;
   clearCaches: () => void;
   markForFullFlush: () => void;
-  getClock: () => HaikuClock;
+  getClock: () => IHaikuClock;
   emitFromRootComponent: (eventName: string, attachedObject: any) => void;
   routeEventToHandlerAndEmit: (eventSelectorGiven: string, eventNameGiven: string, eventArgs: any) => void;
   routeEventToHandlerAndEmitWithoutBubbling: (
@@ -68,8 +78,8 @@ export interface IHaikuContext {
   // #FIXME: This is not necessarily going to be the renderer.
   renderer: IRenderer;
   config: BytecodeOptions;
-  clock: HaikuClock;
-  getClock: () => HaikuClock;
+  clock: IHaikuClock;
+  getClock: () => IHaikuClock;
   getContainer: (doForceRecalc: boolean) => MountLayout;
   getGlobalUserState: () => any;
   contextMount: () => void;
@@ -288,6 +298,13 @@ export interface BytecodeMetadata {
 
 export type ComponentEventHandler = (component: IHaikuComponent) => void;
 
+export interface ClockConfig {
+  frameDuration?: number;
+  frameDelay?: number;
+  marginOfErrorForDelta?: number;
+  run?: boolean;
+}
+
 /**
  * Bytecode options.
  */
@@ -339,7 +356,7 @@ export interface BytecodeOptions {
 
   // Configuration options that will be passed to the HaikuClock instance.
   // See HaikuClock.js for info.
-  clock?: object;
+  clock?: ClockConfig;
 
   // Configures the sizing mode of the component; may be 'normal',
   // 'stretch', 'contain', or 'cover'. See HaikuComponent.js for info.

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -2532,6 +2532,9 @@ class ActiveComponent extends BaseModel {
       mixpanel: false, // Don't track events in mixpanel while the component is being built
       interactionMode: this.interactionMode,
       hotEditingMode: true, // Don't clone the bytecode/template so we can mutate it in-place
+      clock: {
+        run: false,
+      },
     }, config));
 
     createdHaikuCoreComponent.context.getContainer(true); // Force recalc of container for correct sizing

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -3834,6 +3834,9 @@ class ActiveComponent extends BaseModel {
           },
         }, null, () => {
           fire();
+          // Because the serialization layer runs in non-rAF mode, we need to manually tick
+          // after updating keyframes.
+          this.tick();
           return cb();
         });
       });


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

- Other than adding some missing types, the two things happening are [here](https://github.com/HaikuTeam/mono/compare/cold-perf?expand=1#diff-47ce953ca75eceeeb727f4beece5ac77R91) and [here](https://github.com/HaikuTeam/mono/compare/cold-perf?expand=1#diff-7433d312b35db871f4e4161899095cfeR2535). Point being to not enqueue ticks for components that are effectively running headlessly. This should give us a nice perf gain in all processes where the serialization layer is running without affecting preview mode (since that mounts a new component each time). Although this change seems minor and safe, it's worth confirming nothing is broken in Glass and Timeline.