### PR TITLE
fix: disable TopMenu items that require auth on login screen

### DIFF
--- a/packages/haiku-common/src/electron/TopMenu.ts
+++ b/packages/haiku-common/src/electron/TopMenu.ts
@@ -26,6 +26,7 @@ export interface TopMenuEventSender {
 export interface TopMenuOptions {
   isProjectOpen: boolean;
   isSaving: boolean;
+  isUserAuthenticated: boolean;
   projectsList: PlumbingProject[];
   subComponents: SubComponent[];
   undoState: UndoState;
@@ -226,7 +227,7 @@ export default class TopMenu {
       {
         label: 'New',
         accelerator: 'CmdOrCtrl+N',
-        enabled: !options.isSaving,
+        enabled: !options.isSaving && !!options.isUserAuthenticated,
         click: () => {
           this.sender.send('global-menu:show-new-project-modal');
         },
@@ -478,12 +479,13 @@ export default class TopMenu {
             },
           }, {
             label: 'Take Tour',
-            enabled: !!this.options.projectsList.find((project) => project.projectName === TourUtils.ProjectName),
+            enabled: !!this.options.isUserAuthenticated && !!this.options.projectsList.find((project) => project.projectName === TourUtils.ProjectName),
             click: () => {
               this.sender.send('global-menu:start-tour');
             },
           }, {
             label: 'What\'s New',
+            enabled: !!this.options.isUserAuthenticated,
             click: () => {
               this.sender.send('global-menu:show-changelog');
             },

--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1102,6 +1102,7 @@ export default class Creator extends React.Component {
 
     this.user.authenticate(username, password).then(({user, organization}) => {
       mixpanel.haikuTrack('creator:user-authenticated', {username: user.Username});
+      ipcRenderer.send('topmenu:update', {isUserAuthenticated: true});
     }).catch((error) => {
       cb(error);
     });
@@ -1137,7 +1138,7 @@ export default class Creator extends React.Component {
     this.setState(silent ? {} : {areProjectsLoading: true}, () => {
       this.envoyProject.getProjectsList().then((projectsList) => {
         this.setState({areProjectsLoading: false, hasLoadedOnce: true, projectsList});
-        ipcRenderer.send('topmenu:update', {projectsList, isProjectOpen: false});
+        ipcRenderer.send('topmenu:update', {projectsList, isProjectOpen: false, isUserAuthenticated: this.state.isUserAuthenticated});
         return cb(null, projectsList);
       }).catch((error) => {
         mixpanel.haikuTrack('creator:project-list:unable-to-retrieve', {
@@ -1755,6 +1756,15 @@ export default class Creator extends React.Component {
         this.clearAuth();
         mixpanel.haikuTrack('creator:project-browser:user-menu-option-selected', {
           option: 'logout',
+        });
+
+        ipcRenderer.send('topmenu:update', {
+          projectsList: [],
+          isSaving: false,
+          isProjectOpen: false,
+          isUserAuthenticated: false,
+          subComponents: [],
+          undoState: {canUndo: true, canRedo: true}, // allow undo/redo on login form.
         });
       });
     }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

This issue was identified as part of another familiy of issues, all
related to the tour and the behavior of the app for logged-out users.

As the time of this commit there where three top menu items that require
the user to be logged in in order to work:

- New Project
- Take Tour
- What's New

We introduced a new TopMenu option, `isUserAuthenticated`, which is set
during log in/out and projectList fetch (to aid for
already logged in users).

Asana issue: https://app.asana.com/0/922186784503552/963025133104712

Regressions to look for:

- None expected
