### PR TITLE
fix: don't allow the tour and the loading screen at the same time

### DIFF
--- a/packages/haiku-creator/src/react/components/Tour/Tour.js
+++ b/packages/haiku-creator/src/react/components/Tour/Tour.js
@@ -129,7 +129,7 @@ class Tour extends React.Component {
   }
 
   render () {
-    if (!this.state.component) {
+    if (!this.state.component || !this.props.show) {
       return null;
     }
 
@@ -177,6 +177,7 @@ class Tour extends React.Component {
 
 Tour.propTypes = {
   envoyClient: React.PropTypes.object.isRequired,
+  show: React.PropTypes.bool,
 };
 
 export default Tour;


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

If the user starts the tour from the top menu while a project is open,
we are showing for a brief interval of time both the tour modal and the
loading screen at the same time until the project teardown is completed.

Besides of the weird-looking UX, this scenario could lead to
crashes if the user tries to interact with the tour during this short
period of time.

This commit adds logic to hide the tour modal if the loading screen is
visible for any reason.

Asana task: https://app.asana.com/0/922186784503552/959290176846323

Regressions to look for:

None expected, I checked:

- [x] Brand new user opens the app for the first time, the tour modal is shown
- [x] User takes the tour from the project dashboard via top menu
- [x] User takes the tour from the project detail via top menu
- [x] User tries to take the tour while the loading screen is visible

