### PR TITLE
fix: set Keyframes as TransitionSegments iif they have a supported curve

### DIFF
--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -1,6 +1,7 @@
 const HaikuComponent = require('@haiku/core/lib/HaikuComponent').default;
 const expressionToRO = require('@haiku/core/lib/reflection/expressionToRO').default;
 const BaseModel = require('./BaseModel');
+const SupportedCurves = require('@haiku/core/lib/api/index').Curve;
 
 /**
  * @class Keyframe
@@ -220,7 +221,9 @@ class Keyframe extends BaseModel {
   }
 
   isTransitionSegment () {
-    return !!this.getCurve();
+    // TODO: update this check if/when we support custom curves
+    const curve = this.getCurveCapitalized()
+    return !!(curve && SupportedCurves[curve]);
   }
 
   isConstantSegment () {
@@ -459,7 +462,7 @@ class Keyframe extends BaseModel {
 
   getCurveCapitalized () {
     const curve = this.getCurve();
-    return curve.charAt(0).toUpperCase() + curve.slice(1);
+    return curve && curve.charAt(0).toUpperCase() + curve.slice(1);
   }
 
   isWithinCollapsedElementHeadingRow () {


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Since at the moment we don't support custom curves, our view logic
assumes that a keyframe with a curve value defined [is a supported
curve value][1], causing crashes if the user sets a custom curve in the
bytecode by hand.

We have at least two possible options to aid this:

1- Do a check in the view before trying to render the curve and render a default
if we don't recognize the curve.
2- Don't consider a Keyframe a transition segment if we don't recognize
the curve.

This changeset goes with `2` because it aligns better with what is actually
happening in core: we don't animate between keyframes with unrecognized curves.

Going with `2` also protect us against front-end logic that acts on transition
segments based on [events emitted from TransitionSegment components][2].

[1]: /HaikuTeam/mono/tree/e1e1bef96293f3554bd61a334a972732852fdfce/packages/@haiku/core/src/api/index.ts#L591
[2]: /HaikuTeam/mono/tree/e1e1bef96293f3554bd61a334a972732852fdfce/packages/haiku-timeline/src/components/TransitionBody.js#L196

Regressions to look for:

- Could perf be affected significantly by this?
