### PR TITLE
fix: cmd + shift + left now also changes time internally

### DIFF
--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -958,7 +958,7 @@ class Timeline extends React.Component {
         if (this.isCommandKeyDown) {
           if (this.isShiftKeyDown) {
             this.getActiveComponent().getCurrentTimeline().setVisibleFrameRange(0, this.getActiveComponent().getCurrentTimeline().getRightFrameEndpoint());
-            this.getActiveComponent().getCurrentTimeline().updateCurrentFrame(0);
+            this.getActiveComponent().getCurrentTimeline().seek(0);
           } else {
             this.getActiveComponent().getCurrentTimeline().updateScrubberPositionByDelta(-1);
           }


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

The logic that moves the time when the shortcut is invoked was using
`Timeline.updateCurrentFrame` to set the frame to `0`, but this method only
updates the internal state of the `Timeline` model but not the `Envoy` channel.

Calling `Timeline.seek` does that and is enough to also update the the view.

Asana task: https://app.asana.com/0/922186784503552/967841045402195

Regressions to look for:

- None expected