### PR TITLE
fix: do not auto-tween on keyframe moves

### DIFF
--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -3731,21 +3731,6 @@ class ActiveComponent extends BaseModel {
               propertyName,
               true, // fallbackToInitialKeyframeIfProvided
             );
-
-            if (experimentIsEnabled(Experiment.AutoTweenNewKeyframes)) {
-              const ms = parseInt(Object.keys(keyframeMoves[timelineName][componentId][propertyName])[0], 10);
-              if (Number.isInteger(ms)) {
-                Bytecode.addDefaultCurveIfNecessary(
-                  bytecode,
-                  timelineName,
-                  Template.buildHaikuIdSelector(componentId),
-                  ms,
-                  propertyName,
-                  componentId,
-                  this.getElementNameOfComponentId(componentId),
-                );
-              }
-            }
           }
         }
       }

--- a/packages/haiku-serialization/src/bll/Bytecode.js
+++ b/packages/haiku-serialization/src/bll/Bytecode.js
@@ -1344,7 +1344,11 @@ Bytecode.addDefaultCurveIfNecessary = (
       .filter((time) => time > newKeyframeTime)
       .shift();
 
-    if (lastKeyframe !== undefined && property[lastKeyframe].curve === undefined && property[lastKeyframe].value !== property[newKeyframeTime].value) {
+    if (
+      lastKeyframe !== undefined &&
+      property[lastKeyframe].curve === undefined &&
+      property[lastKeyframe].value !== property[newKeyframeTime].value
+    ) {
       Bytecode.joinKeyframes(
         bytecode,
         componentId,
@@ -1357,7 +1361,12 @@ Bytecode.addDefaultCurveIfNecessary = (
       );
     }
 
-    if (nextKeyframe && property[newKeyframeTime].curve === undefined && property[nextKeyframe].value !== property[newKeyframeTime].value) {
+    // Also create a default curve on the keyframe we're creating, if there is a keyframe in front of it
+    if (
+      nextKeyframe &&
+      property[newKeyframeTime].curve === undefined &&
+      property[nextKeyframe].value !== property[newKeyframeTime].value
+    ) {
       Bytecode.joinKeyframes(
         bytecode,
         componentId,


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

The reason for this logic existing on "keyframe move" was because in
the first implementation we decided to add curves even between keyframes with the
same value, so this aided the special-case of creating a tween when the keyframe
at t=0 was moved.

Since dcaddc7843adffd611e61f7c9c83d3b101ba011d, we are no longer doing that, thus is safe to delete auto-tweening
from the keyframe move logic, which also aids a bug where a tween is created
every time a keyframe next to t=0 is moved.

Asana task: https://app.asana.com/0/922186784503552/967841045402196

Regressions to look for:

@taylorpoe @stristr can you think of a possible scenario that not autotweening on keyframe moves can cause?

