### PR TITLE
fix: prevent empty event handlers from randomly appearing in bytecode

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -1918,7 +1918,7 @@ export default class Creator extends React.Component {
     );
   }
 
-  saveEventHandlers (targetElement, serializedEvents) {
+  saveEventHandlers = (targetElement, serializedEvents) => {
     const selectorName = 'haiku:' + targetElement.getComponentId();
     this.getActiveComponent().batchUpsertEventHandlers(selectorName, serializedEvents, {from: 'creator'}, () => {});
   }
@@ -2176,9 +2176,7 @@ export default class Creator extends React.Component {
                       !isPreviewMode(this.state.interactionMode) && (
                         <EventHandlerEditor
                           element={this.state.targetElement}
-                          save={(targetElement, serializedEvent) => {
-                            this.saveEventHandlers(targetElement, serializedEvent);
-                          }}
+                          save={this.saveEventHandlers}
                           close={this.safelyHideEventHandlersEditor}
                           visible={this.state.showEventHandlerEditor}
                           options={this.state.eventHandlerEditorOptions}

--- a/packages/haiku-serialization/src/bll/Bytecode.js
+++ b/packages/haiku-serialization/src/bll/Bytecode.js
@@ -921,6 +921,10 @@ Bytecode.deleteEventHandler = (bytecode, selectorName, eventName) => {
   if (bytecode.eventHandlers) {
     if (bytecode.eventHandlers[selectorName]) {
       delete bytecode.eventHandlers[selectorName][eventName];
+
+      if (!Object.keys(bytecode.eventHandlers[selectorName]).length) {
+        delete bytecode.eventHandlers[selectorName];
+      }
     }
   }
 

--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -299,13 +299,12 @@ class Element extends BaseModel {
   getReifiedEventHandlers () {
     const bytecode = this.component.getReifiedBytecode();
     const selector = 'haiku:' + this.getComponentId();
+
     if (!bytecode.eventHandlers) {
       bytecode.eventHandlers = {};
     }
-    if (!bytecode.eventHandlers[selector]) {
-      bytecode.eventHandlers[selector] = {};
-    }
-    return bytecode.eventHandlers[selector];
+
+    return bytecode.eventHandlers[selector] || {};
   }
 
   getReifiedEventHandler (eventName) {

--- a/packages/haiku-serialization/src/bll/File.js
+++ b/packages/haiku-serialization/src/bll/File.js
@@ -261,8 +261,6 @@ class File extends BaseModel {
    * and instances present as they would be if it were being executed in memory.
    */
   getReifiedBytecode () {
-    // NOTE: Due to a legacy issue there used to be the assumption that the bytecode file could contain
-    // multiple bytecodes, hence the [0]; that is no longer the case and this should be refactored! #FIXME
     return this.mod.fetchInMemoryExport();
   }
 


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

We have noticed empty event handlers written in the bytecode in the form of:

```js
eventHandlers: {
  "haiku:Main-03757d2ca1026e0a": {}
}
```

There are two "forms" of this bug: one transient and one permanent. Reproing the
transient form is easy: just switch between code/edit mode and watch the
`eventHandlers` key in the in-app editor. I call this the transient
version because the bytecode shown here is the in-memory bytecode of Creator, if you
make an edit to the file and save, you now have permanently saved the empty
event handler on disk.

This is happening because `getReifiedEventHandlers`, which is called many times
with the sole purpose of listing event handlers in objects, fetches and
modifies a reference of the in-memory bytecode, adding the empty object.

Given how our logic works, we still need to modify this reference in some
scenarios, but in order to solve this I introduced a new method,
`getReifiedUnreferencedEventHandlers`, which doesn't modify the in-memory
bytecode and can be used with the sole purpose of reading event handlers.

Asana task: https://app.asana.com/0/922186784503552/968639637587944

Regressions to look for:

- None expected, but watch out for regressions in Actions
