### PR TITLE
fix: prevent tween poles from overflowing of their row

### DIFF
--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -79,6 +79,12 @@ const CURVESVGS = {
 
 const THROTTLE_TIME = 17; // ms
 
+const STYLE = {
+  keyframePole: {
+    transform: 'scale(1.7) translateY(-1.5px)',
+  },
+};
+
 export default class TransitionBody extends React.Component {
   constructor (props) {
     super(props);
@@ -272,8 +278,6 @@ export default class TransitionBody extends React.Component {
               left: -5,
               width: 9,
               height: 24,
-              top: -4,
-              transform: 'scale(1.7)',
               zIndex: 1002,
             }}>
             <span
@@ -284,7 +288,7 @@ export default class TransitionBody extends React.Component {
                 left: 1,
                 cursor: (this.props.keyframe.isWithinCollapsedRow()) ? 'pointer' : 'move',
               }}>
-              <KeyframeSVG color={Palette[this.props.keyframe.getLeftKeyframeColorState()]} />
+              <KeyframeSVG style={STYLE.keyframePole} color={Palette[this.props.keyframe.getLeftKeyframeColorState()]} />
             </span>
           </span>
           <span style={{
@@ -309,8 +313,6 @@ export default class TransitionBody extends React.Component {
               right: -5,
               width: 9,
               height: 24,
-              top: -4,
-              transform: 'scale(1.7)',
               transition: 'opacity 130ms linear',
               zIndex: 1002,
             }}>
@@ -324,7 +326,7 @@ export default class TransitionBody extends React.Component {
                   ? 'pointer'
                   : 'move',
               }}>
-              <KeyframeSVG color={Palette[this.props.keyframe.getRightKeyframeColorState()]} />
+              <KeyframeSVG style={STYLE.keyframePole} color={Palette[this.props.keyframe.getRightKeyframeColorState()]} />
             </span>
           </span>
         </span>

--- a/packages/haiku-ui-common/src/react/icons/KeyframeSVG.tsx
+++ b/packages/haiku-ui-common/src/react/icons/KeyframeSVG.tsx
@@ -1,8 +1,13 @@
 import * as React from 'react';
 import Palette from './../../Palette';
 
-export default ({color = Palette.ROCK}) => (
-  <svg width="7" height="7" viewBox="0 8 7 7">
+export interface KeyframeSVGProps {
+  color?: string;
+  style?: React.CSSProperties;
+}
+
+export default ({color = Palette.ROCK, style}: KeyframeSVGProps) => (
+  <svg width="7" height="7" viewBox="0 8 7 7" style={style}>
     <g fill={color}>
       <path d="M5.331 11c1.245 0 1.543.787.663 1.759l-1.697 1.875a1.052 1.052 0 0 1-1.595 0L1.005 12.76C.126 11.787.424 11 1.668 11h3.663"/>
       <path d="M5.331 12.5c1.245 0 1.543-.787.663-1.759L4.297 8.866a1.052 1.052 0 0 0-1.595 0L1.005 10.74c-.879.972-.581 1.759.663 1.759h3.663"/>


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Due to some CSS being misplaced, the keyframe poles of tweens were overflowing
from their rows, causing the wrong tween to be selected on certain
circumstances.

Asana Task: https://app.asana.com/0/922186784503552/1102067997618469

Regressions to look for:

- None expected
