### PR TITLE
fix: avoid tweens from shrinking on certain drag motions

### DIFF
--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -2077,9 +2077,9 @@ class ActiveComponent extends BaseModel {
     }
   }
 
-  dragStopSelectedKeyframes (dragData) {
+  dragStopSelectedKeyframes () {
     const keyframes = this.getSelectedKeyframes();
-    keyframes.forEach((keyframe) => keyframe.dragStop(dragData));
+    keyframes.forEach((keyframe) => keyframe.dragStop());
 
     // We only update once we're finished dragging because moving keyframes may end up
     // destroying/creating keyframes in the bytecode, and when rehydrate() is called, the

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -799,7 +799,7 @@ class Keyframe extends BaseModel {
     }
 
     this.setDidHandleDragStop();
-    this.component.dragStopSelectedKeyframes(dragData);
+    this.component.dragStopSelectedKeyframes();
   }
 
   clearOtherKeyframes () {

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -83,6 +83,7 @@ export default class TransitionBody extends React.Component {
   constructor (props) {
     super(props);
     this.handleUpdate = this.handleUpdate.bind(this);
+    this.isDragging = false;
     this.handleProps(props);
   }
 
@@ -198,17 +199,18 @@ export default class TransitionBody extends React.Component {
         }}
         onStart={(dragEvent, dragData) => {
           if (!this.props.preventDragging) {
+            this.isDragging = true;
             this.props.component.dragStartSelectedKeyframes(dragData);
           }
         }}
         onStop={(dragEvent, dragData, wasDrag, lastMouseButtonPressed) => {
           if (!this.props.preventDragging) {
+            this.isDragging = false;
             this.props.keyframe.handleDragStop(dragData, {wasDrag, lastMouseButtonPressed, ...Globals}, {isViaKeyframeDraggerView: true});
           }
-          this.props.component.dragStopSelectedKeyframes(dragData);
         }}
         onDrag={lodash.throttle((dragEvent, dragData) => {
-          if (!this.props.preventDragging) {
+          if (!this.props.preventDragging && this.isDragging) {
             this.props.component.dragSelectedKeyframes(frameInfo.pxpf, frameInfo.mspf, dragData, {alias: 'timeline'});
           }
         }, THROTTLE_TIME)}>


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Due to how the drag logic is setup, the `onDrag` method can be called after the
`onStop` method on `TransitionBody`, causing the drag calculation to be
incorrect and shrink the components involved.

This adds a flag to prevent `onDrag` to be called after `onStop` is called.

Note that there's similar logic for other components like
`InvisibleKeyframeDragger` and `Scrubber`, but they shouldn't be affected by
this.

Asana Task: https://app.asana.com/0/922186784503552/1101796002992131

Regressions to look for:

- None expected, but just in case: drag and drop of tweens.
