### PR TITLE
fix: avoid marquee init from starting on TransitionBody keyframe poles

### DIFF
--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -275,6 +275,7 @@ export default class TransitionBody extends React.Component {
               backgroundColor: Color(Palette.SUNSTONE).fade(0.98),
             }} />
           <span
+            className="js-avoid-marquee-init"
             style={{
               position: 'absolute',
               left: -5,
@@ -283,7 +284,7 @@ export default class TransitionBody extends React.Component {
               zIndex: 1002,
             }}>
             <span
-              className="keyframe-diamond"
+              className="keyframe-diamond js-avoid-marquee-init"
               style={{
                 position: 'absolute',
                 top: 5,
@@ -310,6 +311,7 @@ export default class TransitionBody extends React.Component {
             />
           </span>
           <span
+            className="js-avoid-marquee-init"
             style={{
               position: 'absolute',
               right: -5,
@@ -319,7 +321,7 @@ export default class TransitionBody extends React.Component {
               zIndex: 1002,
             }}>
             <span
-              className="keyframe-diamond"
+              className="keyframe-diamond js-avoid-marquee-init"
               style={{
                 position: 'absolute',
                 top: 5,


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

This will prevent issues with marquee selection causing a weird behavior where
marquee is active and some tweens are dragged at the same time.

This is also related to #949 because the overflow of the poles makes this issue
more feasible to happen.

Asana Task: https://app.asana.com/0/922186784503552/814729684196780

Regressions to look for:

- None expected
