### PR TITLE
fix: prevent crashes when the plus button ref is missing

### DIFF
--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/Snippets.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/Snippets.js
@@ -106,7 +106,7 @@ class Snippets extends React.PureComponent {
         const visibleRanges = this.props.editor.getVisibleRanges();
         const cursorIsVisible = visibleRanges.some((range) => range.containsPosition(editorPosition));
 
-        if (cursorIsVisible) {
+        if (cursorIsVisible && Boolean(this._plus)) {
           this._plus.style.visibility = 'visible';
 
           // Snippet button position is monaco editor position + relative cursor scroll position


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

According to the [React docs][1], it's completely normal and expected to get
`null` refs as the component is mounting/unmounting. Since the scroll event of
the Actions Editor can be triggered while the ref is null, this adds a simple
guard to prevent crashes.

Asana Task: https://app.asana.com/0/922186784503552/1104227124130859

[1]: https://reactjs.org/docs/refs-and-the-dom.html#callback-refs


Regressions to look for:

None expected
