### PR TITLE
WIP: expired trial lockouts

### DIFF
--- a/packages/haiku-creator/src/react/Creator.js
+++ b/packages/haiku-creator/src/react/Creator.js
@@ -151,6 +151,7 @@ export default class Creator extends React.Component {
       interactionMode: InteractionMode.GLASS_EDIT,
       artboardDimensions: null,
       showChangelogModal: false,
+      expiredTrialNonPro: true,
       showOfflineExportUpgradeModal: false,
       // This is a sensible default to avoid flashes of offline warnings.
       // (The Envoy server will protect us from any potential abuse.)
@@ -1124,7 +1125,7 @@ export default class Creator extends React.Component {
     setTimeout(() => {
       this.tourChannel.start(true);
     });
-  }
+  };
 
   resendEmailConfirmation (username) {
     return this.props.websocket.request({method: 'resendEmailConfirmation', params: [username]}, () => {});
@@ -2105,6 +2106,7 @@ export default class Creator extends React.Component {
           onShowChangelogModal={this.showChangelogModal}
           privateProjectLimit={this.state.privateProjectLimit}
           showChangelogModal={this.state.showChangelogModal}
+          expiredTrialNonPro={this.state.expiredTrialNonPro}
           username={this.state.username}
           softwareVersion={this.state.softwareVersion}
           organizationName={this.state.organizationName}

--- a/packages/haiku-creator/src/react/components/LockoutModal.js
+++ b/packages/haiku-creator/src/react/components/LockoutModal.js
@@ -1,0 +1,125 @@
+import * as React from 'react';
+import {
+  ModalWrapper,
+  ModalHeader,
+  ModalFooter,
+} from 'haiku-ui-common/lib/react/Modal';
+import {BTN_STYLES} from '../styles/btnShared';
+import {DASH_STYLES} from '../styles/dashShared';
+import ExternalLinkIconSVG from 'haiku-ui-common/lib/react/icons/ExternalLinkIconSVG';
+import Palette from 'haiku-ui-common/lib/Palette';
+
+const STYLES = {
+  modalWrapper: {
+    maxWidth: '540px',
+    zIndex: '9002',
+    position: 'absolute',
+    top: '50%',
+    transform: 'translateY(-50%)',
+  },
+  modalContent: {
+    padding: '20px 40px 60px',
+  },
+  iconStyle: {
+    marginRight: '8px',
+  },
+  button: {
+    ...BTN_STYLES.btnText,
+    ...BTN_STYLES.btnBlack,
+  },
+  version: {
+    fontSize: '30px',
+  },
+  sectionTitle: {
+    textTransform: 'uppercase',
+    fontWeight: 'normal',
+    fontSize: '15px',
+  },
+  list: {
+    paddingLeft: '30px',
+    fontSize: '13px',
+  },
+  inner: {
+    padding: '10px 25px 60px',
+  },
+  upgradeWrap: {
+    color: Palette.SUNSTONE,
+    marginTop: 20,
+    textAlign: 'center',
+  },
+  link: {
+    position: 'absolute',
+    top: 20,
+    right: 20,
+    color: Palette.LIGHT_BLUE,
+    cursor: 'pointer',
+  },
+  btnSecondary: {
+    ...BTN_STYLES.btnText,
+    ...BTN_STYLES.centerBtns,
+    textTransform: 'uppercase',
+    display: 'inline-block',
+    marginTop: 10,
+    backgroundColor: 'transparent',
+    border: '1px solid ' + Palette.LIGHT_BLUE,
+  },
+};
+
+class LockoutModal extends React.PureComponent {
+  constructor (props) {
+    super();
+  }
+
+  render () {
+    return (
+      <div style={DASH_STYLES.overlay} onClick={this.props.onClose}>
+        <ModalWrapper style={STYLES.modalWrapper}>
+          <ModalHeader>
+            <h2>Your Trial Has Expired</h2>
+          </ModalHeader>
+
+          <div style={STYLES.inner}>
+            <div>
+              <p>Your 14 day trial has expired. Go Pro to continue working on your projects!</p>
+              <p>Until upgrading, your existing projects will no longer be editable, but you retain full access to the source files and animation files.</p>
+              <p>Choose 'Reveal in Finder' to access the source files, and use the project share-link for online viewing and instructions on how to embed your work.</p>
+            </div>
+            <div style={STYLES.upgradeWrap}>
+              <span onClick={this.explorePro} style={STYLES.btnSecondary}>Go Pro
+              <span
+                  style={{
+                    width: 11,
+                    height: 11,
+                    display: 'inline-block',
+                    marginLeft: 4,
+                    transform: 'translateY(1px)',
+                  }}
+                >
+                  <ExternalLinkIconSVG color={Palette.LIGHT_BLUE} />
+                </span>
+              </span>
+            </div>
+          </div>
+          <ModalFooter>
+            <div style={{display: 'inline-block'}}>
+              <button
+                key="discard-code"
+                id="discard-code"
+                onClick={this.props.onClose}
+                style={STYLES.button}
+              >
+                <span>Okay</span>
+              </button>
+            </div>
+          </ModalFooter>
+        </ModalWrapper>
+      </div>
+    );
+  }
+}
+
+LockoutModal.propTypes = {
+  onClose: React.PropTypes.func.isRequired,
+};
+
+export default LockoutModal;

--- a/packages/haiku-creator/src/react/components/ProjectThumbnail.js
+++ b/packages/haiku-creator/src/react/components/ProjectThumbnail.js
@@ -60,6 +60,10 @@ class ProjectThumbnail extends React.Component {
             (this.state.isMenuActive || this.state.isHovered) && {opacity: 1},
           ]}
           onClick={() => {
+            if (this.props.expiredTrialNonPro) {
+              // TODO: Open the sharelink
+              return false;
+            }
             if (!this.state.isMenuActive) {
               this.launchProjectIfAllowed();
             }
@@ -84,9 +88,10 @@ class ProjectThumbnail extends React.Component {
               !this.state.isHovered && DASH_STYLES.gone2,
             ]}
           >
-            OPEN
+          {this.props.expiredTrialNonPro ? 'View Online' : 'Open'}
           </span>
-          {this.props.projectExistsLocally && <span
+
+          {(this.props.projectExistsLocally && !this.props.expiredTrialNonPro) && <span
             key="duplicate"
             onClick={this.props.showDuplicateProjectModal}
             style={[

--- a/packages/haiku-creator/src/react/styles/btnShared.js
+++ b/packages/haiku-creator/src/react/styles/btnShared.js
@@ -67,6 +67,13 @@ export const BTN_STYLES = {
   btnPrimaryAlt: {
     backgroundColor: Color(Palette.FATHER_COAL).darken(0.2),
   },
+  btnSecondary: {
+    textTransform: 'uppercase',
+    display: 'inline-block',
+    marginTop: 10,
+    backgroundColor: 'transparent',
+    border: '1px solid ' + Palette.LIGHT_BLUE,
+  },
   btnCancel: {
     letterSpacing: '1.3px',
     marginTop: 4,

--- a/packages/haiku-creator/src/react/styles/dashShared.ts
+++ b/packages/haiku-creator/src/react/styles/dashShared.ts
@@ -1,6 +1,7 @@
 import * as Color from 'color';
 import Palette from 'haiku-ui-common/lib/Palette';
 import * as React from 'react';
+import {BTN_STYLES} from '../styles/btnShared';
 
 export const DASH_STYLES: React.CSSProperties = {
   upcase: {
@@ -36,7 +37,7 @@ export const DASH_STYLES: React.CSSProperties = {
     color: Palette.ROCK,
   },
   bannerNotice: {
-    margin: '0 -7px 0 7px',
+    margin: '0 7px 0 0px',
     border: '1px solid' + Palette.BLUE,
     borderRadius: 3,
     padding: '0 8px',

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,13 +630,13 @@
     tslib "^1.8.1"
 
 "@haiku/core@^3.1.32":
-  version "4.3.9"
+  version "4.3.10"
 
 "@haiku/core@^3.2.16":
-  version "4.3.9"
+  version "4.3.10"
 
 "@haiku/core@^3.4.6":
-  version "4.3.9"
+  version "4.3.10"
 
 "@haiku/player@^3.0.4":
   version "3.0.4"
@@ -8343,6 +8343,13 @@ rxjs@^5.1.1:
 rxjs@^6.1.0:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.2.2.tgz#eb75fa3c186ff5289907d06483a77884586e1cf9"
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.3.3:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
+  integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
WIP: Do not merge

* Adds a lockout modal with upgrade CTA.
* Removes new proj buttons when in lockout state
* Removes ability to duplicate projects when in lockout state
* Switches open project thumbnail clicks to instead open project share links when in lockout state.

Still needed:
* The `expiredTrialNonPro` in `Creator.js` flag wired up to the server
* Server to gift UI project share-links regardless of expired trial distinction
* Wire up proj sharelink for expired and non-expired use. (ping @taylorpoe when available).
