### PR TITLE
fix: early return instead of crashing animating paths w/ different lengths

### DIFF
--- a/packages/@haiku/core/src/helpers/PathUtils.ts
+++ b/packages/@haiku/core/src/helpers/PathUtils.ts
@@ -206,7 +206,7 @@ export const distributeTotalVertices = (path: CurveSpec[], totalVertices: number
 
 export const rotatePathForSmallestDistance = (source: CurveSpec[], dest: CurveSpec[]): void => {
   if (source.length !== dest.length) {
-    throw new Error('Mismatched source and destination length.');
+    return;
   }
 
   let moveToPopped = false;


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Early return instead of crashing animating paths w/ different lengths

Regressions to look for:

- None
