### PR TITLE
feat: double click tweens to edit bezier curves

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -1,7 +1,7 @@
 {
   "sections": {
     "What's new": [
-      "FIRST!"
+      "Double click on curves to open the Bezier Editor."
     ],
     "Fixes": [
       "FIRST!"

--- a/packages/haiku-timeline/src/components/ClusterRow.js
+++ b/packages/haiku-timeline/src/components/ClusterRow.js
@@ -108,6 +108,7 @@ export default class ClusterRow extends React.Component {
             scope="ClusterRow"
             includeDraggables={false}
             preventDragging={true}
+            showBezierEditor={this.props.showBezierEditor}
             row={this.props.row}
             component={this.props.component}
             timeline={this.props.timeline}
@@ -123,4 +124,5 @@ ClusterRow.propTypes = {
   timeline: React.PropTypes.object.isRequired,
   component: React.PropTypes.object.isRequired,
   rowHeight: React.PropTypes.number.isRequired,
+  showBezierEditor: React.PropTypes.func,
 };

--- a/packages/haiku-timeline/src/components/PropertyRow.js
+++ b/packages/haiku-timeline/src/components/PropertyRow.js
@@ -198,6 +198,7 @@ export default class PropertyRow extends React.Component {
             timeline={this.props.timeline}
             rowHeight={this.props.rowHeight}
             row={this.props.row}
+            showBezierEditor={this.props.showBezierEditor}
             preventDragging={this.props.row.element.isLocked()} />
         </div>
       </div>
@@ -214,4 +215,5 @@ PropertyRow.propTypes = {
   timeline: React.PropTypes.object.isRequired,
   component: React.PropTypes.object.isRequired,
   rowHeight: React.PropTypes.number.isRequired,
+  showBezierEditor: React.PropTypes.func,
 };

--- a/packages/haiku-timeline/src/components/PropertyTimelineSegments.js
+++ b/packages/haiku-timeline/src/components/PropertyTimelineSegments.js
@@ -10,6 +10,7 @@ export default class PropertyTimelineSegments extends React.Component {
           scope="PropertyTimelineSegments"
           includeDraggables={true}
           row={this.props.row}
+          showBezierEditor={this.props.showBezierEditor}
           component={this.props.component}
           timeline={this.props.timeline}
           rowHeight={this.props.rowHeight}
@@ -25,4 +26,5 @@ PropertyTimelineSegments.propTypes = {
   timeline: React.PropTypes.object.isRequired,
   rowHeight: React.PropTypes.number.isRequired,
   preventDragging: React.PropTypes.bool.isRequired,
+  showBezierEditor: React.PropTypes.func,
 };

--- a/packages/haiku-timeline/src/components/RowManager.js
+++ b/packages/haiku-timeline/src/components/RowManager.js
@@ -52,6 +52,7 @@ class RowManager extends React.PureComponent {
           rowHeight={this.props.rowHeight}
           timeline={activeComponent.getCurrentTimeline()}
           component={activeComponent}
+          showBezierEditor={this.props.showBezierEditor}
           row={row}
         />
       );
@@ -68,6 +69,7 @@ class RowManager extends React.PureComponent {
           prev={group[index - 1]}
           next={group[index + 1]}
           row={row}
+          showBezierEditor={this.props.showBezierEditor}
         />
       );
     }

--- a/packages/haiku-timeline/src/components/RowSegments.js
+++ b/packages/haiku-timeline/src/components/RowSegments.js
@@ -78,6 +78,7 @@ export default class RowSegments extends React.Component {
                 id={`keyframe-${keyframe.getUniqueKey()}-${this.props.scope}-transition-body`}
                 key={`keyframe-${keyframe.getUniqueKey()}-${this.props.scope}-transition-body`}
                 preventDragging={this.props.preventDragging}
+                showBezierEditor={this.props.showBezierEditor}
                 component={this.props.component}
                 timeline={this.props.timeline}
                 rowHeight={this.props.rowHeight}
@@ -183,4 +184,5 @@ RowSegments.propTypes = {
   rowHeight: React.PropTypes.number.isRequired,
   includeDraggables: React.PropTypes.bool.isRequired,
   preventDragging: React.PropTypes.bool.isRequired,
+  showBezierEditor: React.PropTypes.func,
 };

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -714,11 +714,7 @@ class Timeline extends React.Component {
         type === 'keyframe-transition' &&
         Keyframe.groupHasBezierEditableCurves(selectedKeyframes),
       onClick: () => {
-        this.setState({
-          showBezierEditor: true,
-          bezierEditorCoords: {x: event.clientX, y: event.clientY},
-          currentEditingBezier: selectedKeyframes,
-        });
+        this.showBezierEditor({x: event.clientX, y: event.clientY}, selectedKeyframes)
       },
     });
 
@@ -1266,6 +1262,14 @@ class Timeline extends React.Component {
     this.setState({showBezierEditor: false});
   };
 
+  showBezierEditor = (bezierEditorCoords, currentEditingBezier) => {
+    this.setState({
+      showBezierEditor: true,
+      bezierEditorCoords,
+      currentEditingBezier,
+    });
+  }
+
   onGaugeMouseDown (event) {
     event.persist();
 
@@ -1390,6 +1394,7 @@ class Timeline extends React.Component {
         showEventHandlersEditor={this.showEventHandlersEditor}
         onDoubleClickToMoveGauge={this.moveGaugeOnDoubleClick}
         setEditingRowTitleStatus={this.setEditingRowTitleStatus}
+        showBezierEditor={this.showBezierEditor}
         timelinePropertiesWidth={this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth()}
       />
     );

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -131,6 +131,10 @@ export default class TransitionBody extends React.Component {
     }
   };
 
+  showBezierEditor = (dblClickEvent) => {
+    this.props.showBezierEditor({x: dblClickEvent.clientX, y: dblClickEvent.clientY}, [this.props.keyframe])
+  }
+
   render () {
     const frameInfo = this.props.timeline.getFrameInfo();
 
@@ -213,6 +217,7 @@ export default class TransitionBody extends React.Component {
               this[uniqueKey].style.color = 'transparent';
             }
           }}
+          onDoubleClick={this.showBezierEditor}
           style={{
             position: 'absolute',
             left: pxOffsetLeft + 4,
@@ -305,4 +310,5 @@ TransitionBody.propTypes = {
   timeline: React.PropTypes.object.isRequired,
   component: React.PropTypes.object.isRequired,
   preventDragging: React.PropTypes.bool.isRequired,
+  showBezierEditor: React.PropTypes.func,
 };


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Enable double click on `TransitionBody` components to open the Bezier Curve
editor

![2019-02-07 13-34-47 2019-02-07 13_38_49](https://user-images.githubusercontent.com/4419992/52426955-cacbbe80-2add-11e9-9e85-aca5f0f0cd0a.gif)

Asana task: https://app.asana.com/0/922186784503552/1108611244155108

Regressions to look for:

- None expected, maybe check tween drag/drop behavior?
