### PR TITLE
fix: prevent rows from unexpectedly expanding on certain situations

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -4,7 +4,7 @@
       "Double click on curves to open the Bezier Editor."
     ],
     "Fixes": [
-      "FIRST!"
+      "Prevent nested Timeline rows from expanding unexpectedly."
     ]
   }
 }

--- a/packages/haiku-serialization/src/bll/Element.js
+++ b/packages/haiku-serialization/src/bll/Element.js
@@ -982,7 +982,15 @@ class Element extends BaseModel {
     }
 
     if (headingRow) {
-      headingRow.parent.silentlyExpandSelfAndParents();
+      // TODO: since we are [not displaying][1] <g> elements, we _need_ to set
+      // their `_isExpanded` property to `true`, otherwise the nested element [will
+      // not be shown][2].
+      // Fix for this will be to display <g> elements, but that involves more work
+      // than just showing them.
+      //
+      // [1]: https://github.com/HaikuTeam/mono/blob/5613bab3cc6006a72acc00c99bf42d723c01ed74/packages/haiku-serialization/src/bll/Property.js#L241
+      // [2]: https://github.com/HaikuTeam/mono/blob/65cbfd8e0f2d32ac285c84a45753d741cf2d421b/packages/haiku-timeline/src/components/RowManager.js#L106-L107
+      headingRow.parent.silentlyExpandAllGParents();
       return headingRow;
     }
 

--- a/packages/haiku-serialization/src/bll/Row.js
+++ b/packages/haiku-serialization/src/bll/Row.js
@@ -682,15 +682,17 @@ class Row extends BaseModel {
     return false;
   }
 
-  silentlyExpandSelfAndParents () {
+  silentlyExpandAllGParents () {
     if (this.isRootRow()) {
       return;
     }
 
-    this._isExpanded = true;
+    if (this.element.getNameString() === 'g') {
+      this._isExpanded = true;
+    }
 
     if (this.parent) {
-      this.parent.silentlyExpandSelfAndParents();
+      this.parent.silentlyExpandAllGParents();
     }
   }
 


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

We are setting `_isExpanded` true to all nested heading rows on every render (ugly hack that I'm responsible of)
because otherwise elements under `<g>`s are not displayed due to Timeline internal "politics" causing [weird issues][1].

With that in mind, dragging rows triggers a re-render => that sets `_isExpanded = true` => which in  turn expands nested rows.

This fixes the problem by expanding only `<g>` elements, fixing all sort of weirdness around timeline rows and their expanded state.

![2019-02-07 18 13 35](https://user-images.githubusercontent.com/4419992/52443301-1f823000-2b04-11e9-93b4-e81787cdb6dc.gif)

Asana task: https://app.asana.com/0/922186784503552/1108525011175274

Regressions to look for:

- None expected
