### PR TITLE
fix: filter invalid paths before trying to synchronizePathStructure

### DIFF
--- a/packages/@haiku/core/src/helpers/PathUtils.ts
+++ b/packages/@haiku/core/src/helpers/PathUtils.ts
@@ -336,7 +336,7 @@ export const synchronizePathStructure = (...paths: CurveSpec[][]) => {
   }
 
   const maxVerts = Math.max(...paths.map((path) => path.length));
-  const validPaths = paths.filter((path) => path.length && !path.some(({x, y}) => isNaN(x) || isNaN(y)))
+  const validPaths = paths.filter((path) => path.length && !path.some(({x, y}) => isNaN(x) || isNaN(y)));
 
   validPaths.forEach((path) => {
     ensurePathClockwise(path);

--- a/packages/@haiku/core/src/helpers/PathUtils.ts
+++ b/packages/@haiku/core/src/helpers/PathUtils.ts
@@ -336,7 +336,7 @@ export const synchronizePathStructure = (...paths: CurveSpec[][]) => {
   }
 
   const maxVerts = Math.max(...paths.map((path) => path.length));
-  const validPaths = paths.filter((path) => path.length);
+  const validPaths = paths.filter((path) => path.length && !path.some(({x, y}) => isNaN(x) || isNaN(y)))
 
   validPaths.forEach((path) => {
     ensurePathClockwise(path);


### PR DESCRIPTION
OK to merge.

Short review.

Summary of changes:

Another possible solution for #954, this time the idea is to filter invalid paths before trying to do anything with them. 

If we think that this is a solution worth perusing I can add some tests.

Regressions to look for:

- None expected
