### PR TITLE
hackfix: assign better boilerplate parameters to custom events

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -6,7 +6,8 @@
     ],
     "Fixes": [
       "Prevent Timeline rows from expanding unexpectedly.",
-      "Fix empty `lottie.json` files for certain animations made with path morphing."
+      "Fix empty `lottie.json` files for certain animations made with path morphing.",
+      "Set the correct parameters for custom events in the Actions Editor."
     ]
   }
 }

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/HandlerManager.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/HandlerManager.js
@@ -93,7 +93,8 @@ class HandlerManager {
   }
 
   /**
-   * Maps all the DOM events in memory (ie. not custom) into an array
+   * Returns an Array of all the events that should be displayed for an element, this means
+   * all events that are not frame listeners.
    *
    * @returns {String[]}
    */
@@ -107,6 +108,18 @@ class HandlerManager {
     });
 
     return result;
+  }
+
+  isNewCustomEvent (eventName) {
+    return !this.applicableEventHandlers
+    .reduce((acc, element) => {
+      if (element.label !== "Favorites" && element.label !== "Custom Events") {
+        return acc.concat(element.options.map(o => o.label));
+      } else {
+        return acc;
+      }
+    }, [])
+    .includes(eventName);
   }
 
   /**
@@ -235,11 +248,13 @@ class HandlerManager {
    * @returns {Object}
    */
   _buildEventHandler (event) {
+    const params = this.isNewCustomEvent(event) ? ['component', 'data'] : ['component', 'element', 'target', 'event'];
+
     return {
       event,
       handler: {
         body: ``,
-        params: ['component', 'element', 'target', 'event'],
+        params,
       },
     };
   }

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/HandlerManager.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/HandlerManager.js
@@ -112,13 +112,7 @@ class HandlerManager {
 
   isNewCustomEvent (eventName) {
     return !this.applicableEventHandlers
-    .reduce((acc, element) => {
-      if (element.label !== "Favorites" && element.label !== "Custom Events") {
-        return acc.concat(element.options.map(o => o.label));
-      } else {
-        return acc;
-      }
-    }, [])
+    .reduce((acc, element) => acc.concat(element.options.map(o => o.label)), [])
     .includes(eventName);
   }
 

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/HandlerManager.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/HandlerManager.js
@@ -110,7 +110,7 @@ class HandlerManager {
     return result;
   }
 
-  isNewCustomEvent (eventName) {
+  _isNewCustomEvent (eventName) {
     return !this.applicableEventHandlers
     .reduce((acc, element) => acc.concat(element.options.map(o => o.value)), [])
     .includes(eventName);

--- a/packages/haiku-creator/src/react/components/EventHandlerEditor/HandlerManager.js
+++ b/packages/haiku-creator/src/react/components/EventHandlerEditor/HandlerManager.js
@@ -112,7 +112,7 @@ class HandlerManager {
 
   isNewCustomEvent (eventName) {
     return !this.applicableEventHandlers
-    .reduce((acc, element) => acc.concat(element.options.map(o => o.label)), [])
+    .reduce((acc, element) => acc.concat(element.options.map(o => o.value)), [])
     .includes(eventName);
   }
 
@@ -242,7 +242,7 @@ class HandlerManager {
    * @returns {Object}
    */
   _buildEventHandler (event) {
-    const params = this.isNewCustomEvent(event) ? ['component', 'data'] : ['component', 'element', 'target', 'event'];
+    const params = this._isNewCustomEvent(event) ? ['component', 'data'] : ['component', 'element', 'target', 'event'];
 
     return {
       event,


### PR DESCRIPTION
OK to merge.

Summary of changes:

A hackfix with several disadvantages:

- By looking at the code, seems like the user could send more than one data
parameter via custom events, however this covers the most common use case, which
is a single parameter.
- The way to detect if an event is a custom event is _ugly_, and will not update
the parameters of old custom events, which is good in a sense, since the user can
edit the parameters directly in the bytecode.

While this is not the ideal way to go, nor 100, it's better than showing 'element'
as the second parameter for all custom events.

Asana task: https://app.asana.com/0/922186784503552/1109117416798204

Regressions to look for:

- None expected

Completed checkin tasks:
- [x] Updated `changelog/public/latest.json`.
