### PR TITLE
4.3.12 hotfixes

### DIFF
--- a/packages/haiku-serialization/src/bll/Property.js
+++ b/packages/haiku-serialization/src/bll/Property.js
@@ -725,11 +725,13 @@ Property.hasColorPopup = (propertyName) => {
   return Property.WITH_COLOR_POPUP.has(propertyName);
 };
 
+const ROTATION_PI = Number(Math.PI.toFixed(2))
+
 Property.WITH_RANGE_POPUP = {
   opacity: {max: 1, min: 0, step: 0.1},
-  'rotation.x': {max: Math.PI, min: -Math.PI, step: 0.01},
-  'rotation.y': {max: Math.PI, min: -Math.PI, step: 0.01},
-  'rotation.z': {max: Math.PI, min: -Math.PI, step: 0.01},
+  'rotation.x': {max: ROTATION_PI, min: -ROTATION_PI, step: 0.1},
+  'rotation.y': {max: ROTATION_PI, min: -ROTATION_PI, step: 0.1},
+  'rotation.z': {max: ROTATION_PI, min: -ROTATION_PI, step: 0.1},
 };
 
 Property.hasRangePopup = (propertyName) => {

--- a/packages/haiku-serialization/src/bll/Property.js
+++ b/packages/haiku-serialization/src/bll/Property.js
@@ -725,7 +725,7 @@ Property.hasColorPopup = (propertyName) => {
   return Property.WITH_COLOR_POPUP.has(propertyName);
 };
 
-const ROTATION_PI = Number(Math.PI.toFixed(2))
+const ROTATION_PI = Number(Math.PI.toFixed(2));
 
 Property.WITH_RANGE_POPUP = {
   opacity: {max: 1, min: 0, step: 0.1},

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -1163,7 +1163,17 @@ export default class ExpressionInput extends React.Component {
 
   getDisplayColor (rawValueDescriptor) {
     if (rawValueDescriptor && Property.hasColorPopup(rawValueDescriptor.propertyName)) {
-      return rawValueDescriptor.computedValue;
+      if (rawValueDescriptor.computedValue) {
+        return rawValueDescriptor.computedValue
+      } else {
+        const fallbackValue = '#fff';
+
+        if (!Boolean(this.codemirror.getValue())) {
+          this.setEditorValue(fallbackValue);
+        }
+
+        return fallbackValue;
+      }
     }
 
     return false;

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -1164,7 +1164,7 @@ export default class ExpressionInput extends React.Component {
   getDisplayColor (rawValueDescriptor) {
     if (rawValueDescriptor && Property.hasColorPopup(rawValueDescriptor.propertyName)) {
       if (rawValueDescriptor.computedValue) {
-        return rawValueDescriptor.computedValue
+        return rawValueDescriptor.computedValue;
       } else {
         const fallbackValue = '#fff';
 

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -568,6 +568,7 @@ class Timeline extends React.Component {
 
     this.loadUserSettings();
     this.trackExportProgress();
+    this.hideBezierEditor();
     timeline.setTimelinePixelWidth(document.body.clientWidth - timeline.getPropertiesPixelWidth() + 20);
 
     if (this.mounted) {

--- a/packages/haiku-ui-common/src/react/InspectorPanels/ColorPicker.tsx
+++ b/packages/haiku-ui-common/src/react/InspectorPanels/ColorPicker.tsx
@@ -140,9 +140,13 @@ class HaikuColorPicker extends React.PureComponent<HaikuColorPickerProps> {
   };
 
   onChange = (data: any) => {
-    this.props.onChange({
+    const source = (data.a !== 1 && this.state.valueDisplay === DISPLAY_VALUES.HEX)
+      ? DISPLAY_VALUES.RGB
+      :this.state.valueDisplay
+
+      this.props.onChange({
       ...data,
-      source: this.state.valueDisplay,
+      source,
     });
   };
 

--- a/packages/haiku-ui-common/src/react/InspectorPanels/ColorPicker.tsx
+++ b/packages/haiku-ui-common/src/react/InspectorPanels/ColorPicker.tsx
@@ -143,10 +143,10 @@ class HaikuColorPicker extends React.PureComponent<HaikuColorPickerProps> {
     let source: DISPLAY_VALUES;
 
     if (data.a !== 1 && this.state.valueDisplay === DISPLAY_VALUES.HEX) {
-      source = DISPLAY_VALUES.RGB
+      source = DISPLAY_VALUES.RGB;
       this.setState({valueDisplay: source});
     } else {
-      source = this.state.valueDisplay
+      source = this.state.valueDisplay;
     }
 
     this.props.onChange({

--- a/packages/haiku-ui-common/src/react/InspectorPanels/ColorPicker.tsx
+++ b/packages/haiku-ui-common/src/react/InspectorPanels/ColorPicker.tsx
@@ -140,11 +140,16 @@ class HaikuColorPicker extends React.PureComponent<HaikuColorPickerProps> {
   };
 
   onChange = (data: any) => {
-    const source = (data.a !== 1 && this.state.valueDisplay === DISPLAY_VALUES.HEX)
-      ? DISPLAY_VALUES.RGB
-      :this.state.valueDisplay
+    let source: DISPLAY_VALUES;
 
-      this.props.onChange({
+    if (data.a !== 1 && this.state.valueDisplay === DISPLAY_VALUES.HEX) {
+      source = DISPLAY_VALUES.RGB
+      this.setState({valueDisplay: source});
+    } else {
+      source = this.state.valueDisplay
+    }
+
+    this.props.onChange({
       ...data,
       source,
     });
@@ -184,7 +189,7 @@ class HaikuColorPicker extends React.PureComponent<HaikuColorPickerProps> {
             </div>
             <div>
               <select
-                defaultValue={this.state.valueDisplay.toString()}
+                value={this.state.valueDisplay.toString()}
                 style={STYLES.select}
                 onChange={this.onValueDisplayChange}
               >


### PR DESCRIPTION
OK to merge.

Summary of changes:

- fix: use a value of PI fixed to two digits for ranges
- fix: set a fallback value for color properties
- fix: automagically change to RGBA if alpha is changed
- fix: hide bezier editor when switching components
