### PR TITLE
fix: check if we get a valid color string before trying to infer its model

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -4,7 +4,7 @@
       "FIRST!"
     ],
     "Fixes": [
-      "FIRST!"
+      "Fix a crash when entering invalid color values."
     ]
   }
 }

--- a/packages/haiku-ui-common/src/helpers/uiColorHelpers.ts
+++ b/packages/haiku-ui-common/src/helpers/uiColorHelpers.ts
@@ -8,7 +8,7 @@ export enum DISPLAY_VALUES {
 }
 
 export function derivateDisplayValueFromColorString (colorString: string) {
-  if (typeof colorString !== 'string') {
+  if (typeof colorString !== 'string' || !get(colorString)) {
     return DISPLAY_VALUES.HEX;
   }
 


### PR DESCRIPTION
OK to merge.

Summary of changes:

- This will prevent crashes when an invalid color string is entered in the input
or coded in the bytecode

Asana Task: https://app.asana.com/0/922186784503552/1109531996595639

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
