### PR TITLE
 fix: don't try to open the bezier editor for descomposable curves on double click

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -5,7 +5,7 @@
     ],
     "Fixes": [
       "Fix a crash when entering invalid color values.",
-      "Fix a crash when trying to edit descomposable curves by double clicking on them."
+      "Fix a crash when trying to edit bounce and elastic curves by double clicking on them."
     ]
   }
 }

--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -4,7 +4,8 @@
       "State transitions now accept a callback to be called when the transition is complete."
     ],
     "Fixes": [
-      "Fix a crash when entering invalid color values."
+      "Fix a crash when entering invalid color values.",
+      "Fix a crash when trying to edit descomposable curves by double clicking on them."
     ]
   }
 }

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -132,7 +132,9 @@ export default class TransitionBody extends React.Component {
   };
 
   showBezierEditor = (dblClickEvent) => {
-    this.props.showBezierEditor({x: dblClickEvent.clientX, y: dblClickEvent.clientY}, [this.props.keyframe]);
+    if (!this.props.keyframe.hasDescomposableCurve()) {
+      this.props.showBezierEditor({x: dblClickEvent.clientX, y: dblClickEvent.clientY}, [this.props.keyframe]);
+    }
   };
 
   render () {


### PR DESCRIPTION
OK to merge.

Summary of changes:

As the title says, prevent crashes when double-clicking descomposable bezier curves.

I consider this one a serious issue, but at the same time, as of today, this is the first time we see this crash, so I'm conflicted if we should release a hotfix release, but I lean towards no: this can wait until Tuesday if we don't see it again.

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
