### PR TITLE
chore: Print env.HAIKU_RELEASE_COUNTDOWN on Slack advancement messages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -222,7 +222,7 @@ void notifyAdvancementRequest() {
     slackSend([
         channel: 'engineering-feed',
         color: 'good',
-        message: ":powerup: A build would like to advance\n\n" +
+        message: ":powerup: A build would like to advance | countdown: ${env.HAIKU_RELEASE_COUNTDOWN}\n\n" +
                   "https://ci.haiku.ai/blue/organizations/jenkins/Haiku/detail/Haiku/${env.BUILD_NUMBER}/pipeline"
     ])
 }


### PR DESCRIPTION
Summary of changes:

- Print `env.HAIKU_RELEASE_COUNTDOWN` on Slack advancement messages

Regressions to look for:

- None

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
