### PR TITLE
fix: properly set internal state variables on `Timeline.seekAndPause`

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -5,7 +5,9 @@
     ],
     "Fixes": [
       "Added a notice when trying to edit Bounce/Elastic curves via double-click.",
-      "Prevented property inputs on the Timeline from closing unexpectedly."
+      "Prevented property inputs on the Timeline from closing unexpectedly.",
+      "Fixes a crash when trying to animate invalid paths.",
+      "Fixes issues with the Timeline playback controls."
     ]
   }
 }

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -169,7 +169,7 @@ class Timeline extends BaseModel {
     }
   }
 
-  pause (skipTransmit) {
+  pause (skipTransmit = false) {
     this._playing = false;
     this._lastSeek = null;
     if (!skipTransmit && !this.component.project.getEnvoyClient().isInMockMode()) {
@@ -222,7 +222,7 @@ class Timeline extends BaseModel {
 
   seekAndPause (newFrame) {
     this.seek(newFrame, true);
-    this.pause(true)
+    this.pause(true);
     if (!this.component.project.getEnvoyClient().isInMockMode()) {
       const timelineChannel = this.component.project.getEnvoyChannel('timeline');
       // When ActiveComponent is loaded, it calls setTimelineTimeValue() -> seek(),

--- a/packages/haiku-serialization/src/bll/Timeline.js
+++ b/packages/haiku-serialization/src/bll/Timeline.js
@@ -169,10 +169,10 @@ class Timeline extends BaseModel {
     }
   }
 
-  pause () {
+  pause (skipTransmit) {
     this._playing = false;
     this._lastSeek = null;
-    if (!this.component.project.getEnvoyClient().isInMockMode()) {
+    if (!skipTransmit && !this.component.project.getEnvoyClient().isInMockMode()) {
       const channel = this.component.project.getEnvoyChannel('timeline');
       // Don't know why, but this can be undefined in some edge case/race
       if (channel) {
@@ -221,8 +221,8 @@ class Timeline extends BaseModel {
   }
 
   seekAndPause (newFrame) {
-    this.setCurrentFrame(newFrame);
-    this._playing = false;
+    this.seek(newFrame, true);
+    this.pause(true)
     if (!this.component.project.getEnvoyClient().isInMockMode()) {
       const timelineChannel = this.component.project.getEnvoyChannel('timeline');
       // When ActiveComponent is loaded, it calls setTimelineTimeValue() -> seek(),


### PR DESCRIPTION
Summary of changes:

Before this fix, `Timeline.seekAndPause` was only setting `currentFrame` and
`_isPlaying`, but turns out that `Timeline.seek` and `Timeline.pause` do
much more than that, for example, setting `_lastSeek` to `null`.

This fixes the issue by directly calling these methods instead of trying
to replicate what they are doing, but taking care of providing a parameter
to avoid notifying `Envoy` on every call.

Asana Task: https://app.asana.com/0/922186784503552/1110506015963658

Regressions to look for:

- None expected, but careful review is adviced.

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
