### PR TITLE
fix: hook up a toast when trying to edit Bounce/Elastic curves

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -4,7 +4,7 @@
       "FIRST!"
     ],
     "Fixes": [
-      "FIRST!"
+      "Add a notice when trying to edit Bounce/Elastic curves via double-click."
     ]
   }
 }

--- a/packages/haiku-creator/src/react/components/Timeline.js
+++ b/packages/haiku-creator/src/react/components/Timeline.js
@@ -119,7 +119,6 @@ export default class Timeline extends React.Component {
           display: 'flex',
           alignItems: 'center',
         }}>
-          {/* <TimelineSkeletonState haikuOptions={{loop: true}} /> */}
         </div>
           }
       </div>

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -134,6 +134,8 @@ export default class TransitionBody extends React.Component {
   showBezierEditor = (dblClickEvent) => {
     if (!this.props.keyframe.hasDecomposableCurve()) {
       this.props.showBezierEditor({x: dblClickEvent.clientX, y: dblClickEvent.clientY}, [this.props.keyframe]);
+    } else {
+      console.log('[notice] Bounce/Elastic curves cannot be edited with the curve editor');
     }
   };
 


### PR DESCRIPTION
Summary of changes:

Hook up a toast when trying to edit Bounce/Elastic curves

<img width="308" alt="image" src="https://user-images.githubusercontent.com/4419992/53059962-9241c280-3497-11e9-9250-1407c159d173.png">


Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
