### PR TITLE
 fix: prevent the expression input from closing if the mose event orginated from itself

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -4,7 +4,8 @@
       "FIRST!"
     ],
     "Fixes": [
-      "Add a notice when trying to edit Bounce/Elastic curves via double-click."
+      "Added a notice when trying to edit Bounce/Elastic curves via double-click.",
+      "Prevented property inputs on the Timeline from closing unexpectedly."
     ]
   }
 }

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -143,6 +143,7 @@ export default class ExpressionInput extends React.Component {
     this._injectables = {}; // List of current custom keywords (to be erased/reset)
     this._paramcache = null;
     this._parse = null; // Cache of last parse of the input field
+    this._mouseDownStarted = false;
 
     this.codemirror = CodeMirror(document.createElement('div'), {
       theme: 'haiku',
@@ -1307,6 +1308,22 @@ export default class ExpressionInput extends React.Component {
     }
   }
 
+  doesClickOriginatedFromMouseDown () {
+    return this._mouseDownStarted;
+  }
+
+  cleanMouseDownTracker () {
+    this._mouseDownStarted = false;
+  }
+
+  onMouseUp = () => {
+    this._mouseDownStarted = false;
+  };
+
+  onMouseDown = () => {
+    this._mouseDownStarted = true;
+  };
+
   render () {
     const rawValueDescriptor = this.getValueDescriptorForPopover();
     const rangePopover = this.renderRangePopover(rawValueDescriptor);
@@ -1316,7 +1333,13 @@ export default class ExpressionInput extends React.Component {
     const hasPopover = hasColorPopover || hasRangePopover;
 
     return (
-      <div id="expression-input-holster" style={this.getRootStyle(hasColorPopover)} onClick={this.stopPropagation}>
+      <div
+        id="expression-input-holster"
+        style={this.getRootStyle(hasColorPopover)}
+        onClick={this.stopPropagation}
+        onMouseUp={this.onMouseUp}
+        onMouseDown={this.onMouseDown}
+      >
         <div style={this.getSubWrapperStyle(hasPopover)}>
           <span id="expression-input-tooltip" style={this.getTooltipStyle()}>
             <span id="expression-input-tooltip-tri" style={this.getTooltipTriStyle()} />

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1516,6 +1516,16 @@ class Timeline extends React.Component {
     );
   }
 
+  onTimelineClick = () => {
+    if (this.refs.expressionInput.doesClickOriginatedFromMouseDown()) {
+      this.refs.expressionInput.cleanMouseDownTracker();
+      activeComponent.getRows().forEach((row) => {
+        row.blur({from: 'timeline'});
+        row.deselect({from: 'timeline'}, true);
+      });
+    }
+  };
+
   render () {
     if (!this.getActiveComponent() || !this.getActiveComponent().getCurrentTimeline()) {
       return (
@@ -1543,12 +1553,7 @@ class Timeline extends React.Component {
         ref={this.attachContainerElement}
         id="timeline"
         className="no-select"
-        onClick={(clickEvent) => {
-          activeComponent.getRows().forEach((row) => {
-            row.blur({from: 'timeline'});
-            row.deselect({from: 'timeline'}, true);
-          });
-        }}
+        onClick={this.onTimelineClick}
         style={{
           position: 'absolute',
           backgroundColor: Palette.GRAY,

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -1517,13 +1517,14 @@ class Timeline extends React.Component {
   }
 
   onTimelineClick = () => {
-    if (this.refs.expressionInput.doesClickOriginatedFromMouseDown()) {
-      this.refs.expressionInput.cleanMouseDownTracker();
-      activeComponent.getRows().forEach((row) => {
+    if (!this.refs.expressionInput.doesClickOriginatedFromMouseDown()) {
+      this.getActiveComponent().getRows().forEach((row) => {
         row.blur({from: 'timeline'});
         row.deselect({from: 'timeline'}, true);
       });
     }
+
+    this.refs.expressionInput.cleanMouseDownTracker();
   };
 
   render () {


### PR DESCRIPTION
Summary of changes:

fix: prevent the expression input from closing if the mose event orginated from itself

Regressions to look for:

- None expected, but would be a good idea to double test timeline property inputs.

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
