### PR TITLE
feat: add basic schema declarations for injectables

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -1,7 +1,7 @@
 {
   "sections": {
     "What's new": [
-      "FIRST!"
+      "Better auto-complete items in Expressions."
     ],
     "Fixes": [
       "Added a notice when trying to edit Bounce/Elastic curves via double-click.",

--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -6,8 +6,9 @@
     "Fixes": [
       "Added a notice when trying to edit Bounce/Elastic curves via double-click.",
       "Prevented property inputs on the Timeline from closing unexpectedly.",
-      "Fixes a crash when trying to animate invalid paths.",
-      "Fixes issues with the Timeline playback controls."
+      "Fixed a crash when trying to animate invalid paths.",
+      "Fixed issues with the Timeline playback controls.",
+      "Fixed the value of the `$clock` injectable."
     ]
   }
 }

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -580,6 +580,16 @@ export default class ExpressionInput extends React.Component {
         // Enter when single-line commits the value
         // Meta+Enter when single-line commits the value
         keydownEvent.preventDefault();
+
+        // If something is currently highlighted in the autocompletion menu, select and commit.
+        if (highlightedAutoCompletions.length > 0) {
+          this.chooseHighlightedAutoCompletion();
+          // Note: we have to setImmediate() here to allow the change to bubble down to state.
+          return setImmediate(() => {
+            return this.performCommit(NAVIGATION_DIRECTIONS.NEXT, false);
+          });
+        }
+
         return this.performCommit(NAVIGATION_DIRECTIONS.NEXT, false);
       }
 

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -370,17 +370,7 @@ export default class ExpressionInput extends React.Component {
         }
 
         if (cm.hasFocus()) {
-          const completions = parse.completions.sort((a, b) => {
-            const na = a.name.toLowerCase();
-            const nb = b.name.toLowerCase();
-            if (na < nb) {
-              return -1;
-            }
-            if (na > nb) {
-              return 1;
-            }
-            return 0;
-          }).slice(0, MAX_AUTOCOMPLETION_ENTRIES);
+          const completions = parse.completions.slice(0, MAX_AUTOCOMPLETION_ENTRIES);
 
           // Highlight the initial completion in the list
           if (completions[0]) {

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -468,6 +468,11 @@ export default class ExpressionInput extends React.Component {
         // when presented as the formal final value for this method
         clean = (desiredExpressionSign === EXPR_SIGNS.EQ) ? ensureEq(clean) : ensureRet(clean);
 
+        // Avoid spurious errors due to trailing dots while we're in the middle of typing expressions.
+        if (clean[clean.length - 1] === '.') {
+          clean = clean.substr(0, clean.length - 1);
+        }
+
         return {
           kind: EXPR_KINDS.MACHINE,
           params: [], // To populate later


### PR DESCRIPTION
Summary of changes:

- Add basic schema declarations for injectables, this will enable more rich autocompletion options on expressions:

![2019-02-20 11 19 48](https://user-images.githubusercontent.com/4419992/53098090-a7533b80-3501-11e9-90e4-3387ed81a9fd.gif)

- Fix? `$clock` injectable (see comment, I'm not sure if this was intentional).

Known issues:

Due to how the `ExpressionInput` logic works, parse errors are triggered when you have an incomplete expression, which is the case if the expression ends with a dot (example: `$user.mouse.`). When a parse error is triggered, all autocompletion entries are deleted and fixing this would imply some refactor. Do we want to?

![2019-02-20 11 20 25](https://user-images.githubusercontent.com/4419992/53098198-e41f3280-3501-11e9-8ab2-a069b990561f.gif)


Regressions to look for:

- `@haiku/core` weight, maybe this could live somewhere else?

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
