### PR TITLE
fix: avoid glass marquee controls from being affected by zoom

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -7,7 +7,8 @@
       "Added a notice when trying to edit Bounce/Elastic curves via double-click.",
       "Prevented property inputs on the Timeline from closing unexpectedly.",
       "Fixes a crash when trying to animate invalid paths.",
-      "Fixes issues with the Timeline playback controls."
+      "Fixes issues with the Timeline playback controls.",
+      "Prevented marquee controls on stage from being affected by zoom."
     ]
   }
 }

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -3125,6 +3125,7 @@ export class Glass extends React.Component {
             height,
             stroke: Palette.DARKER_ROCK2,
             'stroke-width': 1,
+            'vector-effect': 'non-scaling-stroke',
             fill: Palette.ROCK,
             'fill-opacity': 0.25,
             rx: 1,


### PR DESCRIPTION
Summary of changes:

- Avoid glass marquee controls from being affected by zoom, h/t 🎩 to @stristr for pointing out the solution in the team meeting.

Regressions to look for:

- None

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
