### PR TITLE
feat: add placeholder support for the Vue adapter.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,8 +9,9 @@
     },
     "typescript.format.enable": false,
     "typescript.tsdk": "node_modules/typescript/lib",
-    "tslint.enable": true,
     "tslint.jsEnable": true,
-    "tslint.autoFixOnSave": true,
-    "tslint.alwaysShowRuleFailuresAsWarnings": true
+    "tslint.alwaysShowRuleFailuresAsWarnings": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.tslint": true
+    }
 }

--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -1,13 +1,13 @@
 {
   "sections": {
     "What's new": [
-      "FIRST!"
+      "Added placeholder support for the Vue adapter."
     ],
     "Fixes": [
       "Added a notice when trying to edit Bounce/Elastic curves via double-click.",
       "Prevented property inputs on the Timeline from closing unexpectedly.",
-      "Fixes a crash when trying to animate invalid paths.",
-      "Fixes issues with the Timeline playback controls.",
+      "Fixed a crash when trying to animate invalid paths.",
+      "Fixed issues with the Timeline playback controls.",
       "Prevented marquee controls on stage from being affected by zoom."
     ]
   }

--- a/packages/@haiku/core/demo/projects/controlflow-placeholder-with-haiku/code/main/micro/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/controlflow-placeholder-with-haiku/code/main/micro/vue-dom.js
@@ -1,0 +1,6 @@
+const HaikuVueAdapter = require('@haiku/core/dom/vue');
+const HaikuVueComponent = HaikuVueAdapter(require('./dom'));
+if (HaikuVueComponent.default) {
+  HaikuVueComponent = HaikuVueComponent.default;
+}
+module.exports = HaikuVueComponent;

--- a/packages/@haiku/core/demo/projects/controlflow-placeholder-with-haiku/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/controlflow-placeholder-with-haiku/code/main/vue-dom.js
@@ -1,4 +1,18 @@
-var HaikuVueAdapter = require('@haiku/core/dom/vue')
-var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
-if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
-module.exports = HaikuVueComponent
+const HaikuVueAdapter = require('@haiku/core/dom/vue');
+const HaikuVueComponent = HaikuVueAdapter(require('./dom'));
+if (HaikuVueComponent.default) {
+  HaikuVueComponent = HaikuVueComponent.default;
+}
+const TestMicro = require('./micro/vue-dom');
+
+module.exports = {
+  template: `
+<container>
+  <test-micro></test-micro>
+</container>
+`,
+  components: {
+    container: HaikuVueComponent,
+    'test-micro': TestMicro,
+  },
+};

--- a/packages/@haiku/core/demo/projects/controlflow-placeholder/code/main/vue-dom.js
+++ b/packages/@haiku/core/demo/projects/controlflow-placeholder/code/main/vue-dom.js
@@ -1,4 +1,26 @@
-var HaikuVueAdapter = require('@haiku/core/dom/vue')
-var HaikuVueComponent = HaikuVueAdapter(require('./dom'))
-if (HaikuVueComponent.default) HaikuVueComponent = HaikuVueComponent.default
-module.exports = HaikuVueComponent
+let HaikuVueAdapter = require('@haiku/core/dom/vue');
+let HaikuVueComponent = HaikuVueAdapter(require('./dom'));
+if (HaikuVueComponent.default) {
+  HaikuVueComponent = HaikuVueComponent.default;
+}
+
+const Thing = {
+  data () {
+    return {foo: 'Vue DOM Stateful Thing Component Was Here'};
+  },
+  template: '<div style="color: green">{{foo}}</div>',
+};
+
+module.exports = {
+  template: `
+<container>
+  <span style="color: blue;">Meow meow</span>
+  <thing></thing>
+  <span style="color: red;">Chirp chirp</span>
+</container>
+`,
+  components: {
+    container: HaikuVueComponent,
+    thing: Thing,
+  },
+};

--- a/packages/@haiku/core/src/adapters/react-dom/HaikuReactDOMAdapter.ts
+++ b/packages/@haiku/core/src/adapters/react-dom/HaikuReactDOMAdapter.ts
@@ -69,7 +69,7 @@ export default function HaikuReactDOMAdapter (haikuComponentFactory, optionalRaw
       let haikuConfig = {
         ref: this.mount,
         vanities: {
-          'controlFlow.placeholder': function _controlFlowPlaceholderReactVanity (
+          'controlFlow.placeholder': (
             element,
             surrogate,
             value,
@@ -77,34 +77,32 @@ export default function HaikuReactDOMAdapter (haikuComponentFactory, optionalRaw
             timeline,
             receiver,
             sender,
-          ) {
-            visit(this.mount, (node) => {
-              const flexId = flexIdIfSame(element, node);
-              if (flexId) {
-                if (element.__memory.placeholder.surrogate !== surrogate) {
-                  if (
-                    typeof surrogate.type === 'string' ||
-                    (typeof surrogate.type === 'function' && surrogate.type.isHaikuAdapter)) {
-                    // What *should happen* in the DOM renderer is:
-                    // this new swapped DOM element will be updated (not replaced!)
-                    // with the attributes of the virtual element at the same position
-                    const div = document.createElement('div');
-                    node.parentNode.replaceChild(div, node);
-                    // tslint:disable-next-line:no-parameter-reassignment
-                    node = div;
-                  }
-                  node.style.visibility = 'hidden';
-                  ReactDOM.render(surrogate, node);
-                  window.requestAnimationFrame(() => {
-                    element.__memory.placeholder.surrogate = surrogate;
-                    node.style.visibility = 'visible';
-                  });
-                  sender.markHorizonElement(element);
-                  sender.markForFullFlush();
+          ) => visit(this.mount, (node) => {
+            const flexId = flexIdIfSame(element, node);
+            if (flexId) {
+              if (element.__memory.placeholder.surrogate !== surrogate) {
+                if (
+                  typeof surrogate.type === 'string' ||
+                  (typeof surrogate.type === 'function' && surrogate.type.isHaikuAdapter)) {
+                  // What *should happen* in the DOM renderer is:
+                  // this new swapped DOM element will be updated (not replaced!)
+                  // with the attributes of the virtual element at the same position
+                  const div = document.createElement('div');
+                  node.parentNode.replaceChild(div, node);
+                  // tslint:disable-next-line:no-parameter-reassignment
+                  node = div;
                 }
+                node.style.visibility = 'hidden';
+                ReactDOM.render(surrogate, node);
+                window.requestAnimationFrame(() => {
+                  element.__memory.placeholder.surrogate = surrogate;
+                  node.style.visibility = 'visible';
+                });
+                sender.markHorizonElement(element);
+                sender.markForFullFlush();
               }
-            });
-          }.bind(this),
+            }
+          }),
         },
       };
 

--- a/packages/@haiku/core/src/adapters/vue-dom/HaikuVueDOMAdapter.ts
+++ b/packages/@haiku/core/src/adapters/vue-dom/HaikuVueDOMAdapter.ts
@@ -1,23 +1,88 @@
+/* tslint:disable:max-line-length */
 /**
  * Copyright (c) Haiku 2016-2018. All rights reserved.
  */
 
+import {BytecodeNode} from '../../api';
+import HaikuComponent from '../../HaikuComponent';
 import getParsedProperty from '../../helpers/getParsedProperty';
 import {randomString} from '../../helpers/StringUtils';
 
-function clearProps (props): Object {
-  let result = {};
+const clearProps = (props): Object => {
+  const result = {};
 
   for (const verboseKeyName in props) {
     if (props[verboseKeyName] === undefined) {
       continue;
     }
 
-    result = {...result, ...getParsedProperty(props, verboseKeyName)};
+    Object.assign(result, getParsedProperty(props, verboseKeyName));
   }
 
   return result;
-}
+};
+
+const allProps = (vueComponent) => {
+  return Object.assign(
+    clearProps(vueComponent.$props),
+    {
+      ref: vueComponent.$el,
+      onHaikuComponentWillInitialize: (component) => {
+        vueComponent.$emit('haikuComponentWillInitialize', component);
+      },
+      onHaikuComponentDidMount: (component) => {
+        vueComponent.$emit('haikuComponentDidMount', component);
+      },
+      onHaikuComponentWillMount: (component) => {
+        vueComponent.$emit('haikuComponentWillMount', component);
+      },
+      onHaikuComponentDidInitialize: (component) => {
+        vueComponent.$emit('haikuComponentDidInitialize', component);
+      },
+      onHaikuComponentWillUnmount: (component) => {
+        vueComponent.$emit('haikuComponentWillUnmount', component);
+      },
+      children: vueComponent.$slots.default
+        ? vueComponent.$slots.default.filter((node: any) => node.tag !== undefined)
+        : [],
+      vanities: {
+        'controlFlow.placeholder': (
+          element: BytecodeNode,
+          surrogate,
+          value,
+          context,
+          timeline,
+          receiver,
+          sender: HaikuComponent,
+        ) => {
+
+          if (element.__memory.placeholder.surrogate === surrogate || !element.__memory.targets) {
+            return;
+          }
+
+          const node = element.__memory.targets[0];
+          if (node) {
+            const vueElement = surrogate.elm;
+            const div = document.createElement('div');
+            node.parentNode.replaceChild(div, node);
+
+            node.style.visibility = 'hidden';
+            if (vueElement) {
+              div.appendChild(vueElement);
+            }
+
+            window.requestAnimationFrame(() => {
+              element.__memory.placeholder.surrogate = surrogate;
+              node.style.visibility = 'visible';
+            });
+            sender.markHorizonElement(element);
+            sender.markForFullFlush();
+          }
+        },
+      },
+    },
+  );
+};
 
 // tslint:disable-next-line:function-name
 export default function HaikuVueDOMAdapter (haikuComponentFactory): {} {
@@ -54,50 +119,21 @@ export default function HaikuVueDOMAdapter (haikuComponentFactory): {} {
       haikuOptions: Object,
     },
     mounted () {
-      const clearedProps = clearProps(this.$props);
-
-      this.haiku = haikuComponentFactory(this.$el, {
-        ...clearedProps,
-        ref: this.$el,
-        onHaikuComponentWillInitialize: (component) => {
-          this.$emit('haikuComponentWillInitialize', component);
-        },
-        onHaikuComponentDidMount: (component) => {
-          this.$emit('haikuComponentDidMount', component);
-        },
-        onHaikuComponentWillMount: (component) => {
-          this.$emit('haikuComponentWillMount', component);
-        },
-        onHaikuComponentDidInitialize: (component) => {
-          this.$emit('haikuComponentDidInitialize', component);
-        },
-        onHaikuComponentWillUnmount: (component) => {
-          this.$emit('haikuComponentWillUnmount', component);
-        },
-      });
+      this.haiku = haikuComponentFactory(this.$el, allProps(this));
     },
     updated () {
-      const clearedProps = clearProps(this.$props);
-      this.haiku.assignConfig(clearedProps);
+      this.haiku.assignConfig(allProps(this));
     },
     destroyed () {
       this.haiku.callUnmount();
     },
-    render (createElement) {
-      return createElement('div', {
-        attrs: {
-          id: 'haiku-vueroot-' + randomString(24),
-        },
-        style: {
-          position: 'relative',
-          margin: 0,
-          padding: 0,
-          border: 0,
-          width: '100%',
-          height: '100%',
-          transform: 'matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)',
-        },
-      });
-    },
+    template: `
+<div
+  id="haiku-vueroot-${randomString(24)}"
+  style="position: relative; margin: 0; padding: 0; border: 0; width: 100%; height: 100%; transform: matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)"
+>
+  <slot></slot>
+</div>
+`,
   };
 }


### PR DESCRIPTION
Summary of changes:

- Placeholder support for Vue (weekend fun project). Like Angular, string selectors aren't supported because that functionality was tailor-made for React.

Regressions to look for:

- None expected. @roperzh, please test the adapter, since I did indeed change some things. You should be able to see everything working in the demo projects I updated (`controlflow-placeholder-with-haiku` and `controlflow-placeholder`).

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
