### PR TITLE
fix: don't show dots on top of expression editor

### DIFF
--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -991,10 +991,6 @@ export default class ExpressionInput extends React.Component {
     return max;
   }
 
-  getEvaluatorText () {
-    return this.state.evaluatorText || '•••';
-  }
-
   getPropertyName () {
     const row = this.props.component.getFocusedRow();
     const name = (row && row.getPropertyName()) || '';
@@ -1346,10 +1342,12 @@ export default class ExpressionInput extends React.Component {
         onMouseDown={this.onMouseDown}
       >
         <div style={this.getSubWrapperStyle(hasPopover)}>
-          <span id="expression-input-tooltip" style={this.getTooltipStyle()}>
-            <span id="expression-input-tooltip-tri" style={this.getTooltipTriStyle()} />
-            {this.getEvaluatorText()}
-          </span>
+          {this.state.evaluatorText &&
+            <span id="expression-input-tooltip" style={this.getTooltipStyle()}>
+              <span id="expression-input-tooltip-tri" style={this.getTooltipTriStyle()} />
+              {this.state.evaluatorText}
+            </span>
+          }
           <div
             id="expression-input-editor-context"
             className={this.getEditorContextClassName()}


### PR DESCRIPTION
Summary of changes:

Don't show dots on top of expression editor, they were meant to show the calculated value of the expression a la Excel, but I have found some problems and according to the task prompt:

> if super easy, show the calculated value in the box — if there are any problems, don't waste cycles: just hide.

Regressions to look for:

- None expected

Completed checkin tasks:

Not worthy of a changelog entry IMO, but let me know if you don't think so.
