### PR TITLE
fix: use pre-compiled templates in Vue adapter

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -4,7 +4,7 @@
       "FIRST!"
     ],
     "Fixes": [
-      "FIRST!"
+      "Modified core Vue adapter for compatibility with production builds."
     ]
   }
 }

--- a/packages/@haiku/core/src/adapters/vue-dom/HaikuVueDOMAdapter.ts
+++ b/packages/@haiku/core/src/adapters/vue-dom/HaikuVueDOMAdapter.ts
@@ -127,13 +127,21 @@ export default function HaikuVueDOMAdapter (haikuComponentFactory): {} {
     destroyed () {
       this.haiku.callUnmount();
     },
-    template: `
-<div
-  id="haiku-vueroot-${randomString(24)}"
-  style="position: relative; margin: 0; padding: 0; border: 0; width: 100%; height: 100%; transform: matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)"
->
-  <slot></slot>
-</div>
-`,
+    render (createElement) {
+      return createElement('div', {
+        attrs: {
+          id: `haiku-vueroot-${randomString(24)}`,
+        },
+        style: {
+          position: 'relative',
+          margin: 0,
+          padding: 0,
+          border: 0,
+          width: '100%',
+          height: '100%',
+          transform: 'matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)',
+        },
+      }, this.$slots.default);
+    },
   };
 }


### PR DESCRIPTION
Summary of changes:

- Fixes Vue adapter when used in the context of runtime-only mode. My bad—fixes breaking change when I deployed account just now.

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
