### PR TITLE
fix: prevent timeline marquee from initiating from the properties panel

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -5,7 +5,8 @@
     ],
     "Fixes": [
       "Modified core Vue adapter for compatibility with production builds.",
-      "Improved undo/redo management in Timeline inputs."
+      "Improved undo/redo management in Timeline inputs.",
+      "Prevented Timeline marquee selection to start from the properties panel."
     ]
   }
 }

--- a/packages/haiku-timeline/src/components/Timeline.js
+++ b/packages/haiku-timeline/src/components/Timeline.js
@@ -180,7 +180,11 @@ class Timeline extends React.Component {
           // This event triggers on `mousedown`, we make the assumption that a
           // mousedown + mouse movement on one of the elements below is a drag,
           // therefore we stop the marquee selection by returning `false`.
-          return !(typeof event.target.className !== 'string' || event.target.className.includes('js-avoid-marquee-init'));
+          return !(
+            event.clientX < this.getActiveComponent().getCurrentTimeline().getPropertiesPixelWidth() ||
+            typeof event.target.className !== 'string' ||
+            event.target.className.includes('js-avoid-marquee-init')
+          );
         },
         onChange: lodash.throttle((finalArea) => {
           if (


### PR DESCRIPTION
Summary of changes:

- Prevent marquee selection from starting on the properties panel by doing a quick check based on mouse position:

![2019-03-08 11-18-55 2019-03-08 11_19_34](https://user-images.githubusercontent.com/4419992/54033862-32843080-4194-11e9-96f6-26c2ec273916.gif)


Regressions to look for:

- None expected.

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
