### PR TITLE
fix: use separate keyboard history for every Timeline input field

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -4,7 +4,8 @@
       "Added Lottie support for line animations."
     ],
     "Fixes": [
-      "Modified core Vue adapter for compatibility with production builds."
+      "Modified core Vue adapter for compatibility with production builds.",
+      "Improved undo/redo management in Timeline inputs."
     ]
   }
 }

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -144,6 +144,7 @@ export default class ExpressionInput extends React.Component {
     this._paramcache = null;
     this._parse = null; // Cache of last parse of the input field
     this._mouseDownStarted = false;
+    this._historyMap = new Map();
 
     this.codemirror = CodeMirror(document.createElement('div'), {
       theme: 'haiku',
@@ -298,6 +299,8 @@ export default class ExpressionInput extends React.Component {
     if (changeObject.origin === SET_VALUE_ORIGIN) {
       return void (0);
     }
+
+    this._historyMap.set(this.props.component.getFocusedRow().getUniqueKey(), cm.getHistory());
 
     // Any change should unset the current error state of the
     this.setState({
@@ -852,6 +855,10 @@ export default class ExpressionInput extends React.Component {
       editedValue: originalValue,
     }, () => {
       this.recalibrateEditor();
+      if (!this._historyMap.get(focusedRow.getUniqueKey())) {
+        this._historyMap.set(focusedRow.getUniqueKey(), {done: [], undone: []});
+      }
+      this.codemirror.setHistory(this._historyMap.get(focusedRow.getUniqueKey()));
       this.handleEditorChange(this.codemirror, {});
     });
   }


### PR DESCRIPTION
Summary of changes:

This prevents inputs on the timeline from sharing the same undo/redo
buffer causing values to cross over inputs if the user undoes/redoes
multiple times.

Asana Task: https://app.asana.com/0/922186784503552/1113303258027099

Regressions to look for:

- None expected, check undo/redo of timeline inputs?

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
