### PR TITLE
fix: improve the logic to determine if a Keyframe is a transition

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -7,7 +7,8 @@
       "Modified core Vue adapter for compatibility with production builds.",
       "Improved undo/redo management in Timeline inputs.",
       "Fixed a bug causing the app to crash when dragging the Main row of the Timeline.",
-      "Prevented Timeline marquee selection to start from the properties panel."
+      "Prevented Timeline marquee selection to start from the properties panel.",
+      "Prevented crashes on invalid curve string values."
     ]
   }
 }

--- a/packages/haiku-serialization/src/bll/Keyframe.js
+++ b/packages/haiku-serialization/src/bll/Keyframe.js
@@ -1,5 +1,6 @@
 const HaikuComponent = require('@haiku/core/lib/HaikuComponent').default;
 const expressionToRO = require('@haiku/core/lib/reflection/expressionToRO').default;
+const Curve = require('@haiku/core/lib/api').Curve;
 const isDecomposableCurve = require('haiku-formats/lib/exporters/curves').isDecomposableCurve;
 const getCurveInterpolationPoints = require('haiku-formats/lib/exporters/curves').getCurveInterpolationPoints;
 const BaseModel = require('./BaseModel');
@@ -222,7 +223,8 @@ class Keyframe extends BaseModel {
   }
 
   isTransitionSegment () {
-    return !!this.getCurve();
+    const curve = this.getCurve();
+    return Boolean(curve) && (Boolean(Curve[this.getCurveCapitalized()]) || Array.isArray(curve));
   }
 
   isConstantSegment () {


### PR DESCRIPTION
Summary of changes:

Don't assume that because a keyframe has a curve defined in the bytecode
is a valid curve, also check:

- If the curve is a string, check if has a valid value (we consider valid
a value in the Curve enum)
- If the curve is an array

Asana Task: https://app.asana.com/0/922186784503552/1113764845664744

Regressions to look for:

- Can't think of anything

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
