### PR TITLE
fix: ensure we have a focused row before setting undo/redo history

### DIFF
--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -300,7 +300,9 @@ export default class ExpressionInput extends React.Component {
       return void (0);
     }
 
-    this._historyMap.set(this.props.component.getFocusedRow().getUniqueKey(), cm.getHistory());
+    if (this.props.component.getFocusedRow()) {
+      this._historyMap.set(this.props.component.getFocusedRow().getUniqueKey(), cm.getHistory());
+    }
 
     // Any change should unset the current error state of the
     this.setState({


### PR DESCRIPTION
⚠️ plz merge before release! 🙏 

Summary of changes:

Because we aren't always updating our Timeline components via `setState`
there are race conditions generated by calling `#handleEditorChange` on
a `setState` callback + our `handleUpdate` logic, making this guard
necessary.

Note that this guard is all over `ExpressionInput` so I should have known
better in the first implementation.


Regressions to look for:

- None expected

Completed checkin tasks:

- [ ] ~Updated `changelog/public/latest.json`.~
