### PR TITLE
Fixes and improvements for color pickers + timeline inputs

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -7,7 +7,9 @@
       "Modified core Vue adapter for compatibility with production builds.",
       "Improved undo/redo management in Timeline inputs.",
       "Fixed a bug causing the app to crash when dragging the Main row of the Timeline.",
-      "Prevented Timeline marquee selection to start from the properties panel."
+      "Prevented Timeline marquee selection to start from the properties panel.",
+      "Fixed a bug preventing to clear the Timeline color picker input.",
+      "Disabled the Timeline color picker for fields with `linear-gradient`s and similar properties."
     ]
   }
 }

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -831,10 +831,15 @@ export default class ExpressionInput extends React.Component {
     }
 
     const originalDescriptor = focusedRow.getPropertyValueDescriptor();
+
+    // HACK: add an UI fallback for color properties with undefined values.
+    if (Property.hasColorPopup(originalDescriptor.propertyName) && originalDescriptor.computedValue === undefined) {
+      originalDescriptor.computedValue = "#fff"
+    }
+
     const originalValue = toValueDescriptor(originalDescriptor);
 
     let editingMode = EDITOR_MODES.SINGLE_LINE;
-
     // If we received an input with multiple lines that is a machine, assume it should be treated like
     // an expression with a multi-line view, otherwise just a normal expression term
     if (originalValue.kind === EXPR_KINDS.MACHINE) {
@@ -1171,13 +1176,7 @@ export default class ExpressionInput extends React.Component {
         return rawValueDescriptor.computedValue;
       }
 
-      const fallbackValue = '#fff';
-
-      if (!Boolean(this.codemirror.getValue())) {
-        this.setEditorValue(fallbackValue);
-      }
-
-      return fallbackValue;
+      return this.codemirror.getValue();
     }
 
     return false;

--- a/packages/haiku-timeline/src/components/ExpressionInput.js
+++ b/packages/haiku-timeline/src/components/ExpressionInput.js
@@ -1167,7 +1167,7 @@ export default class ExpressionInput extends React.Component {
 
   getDisplayColor (rawValueDescriptor) {
     if (rawValueDescriptor && Property.hasColorPopup(rawValueDescriptor.propertyName)) {
-      if (rawValueDescriptor.computedValue) {
+      if (rawValueDescriptor.computedValue && derivateDisplayValueFromColorString(rawValueDescriptor.computedValue) !== null) {
         return rawValueDescriptor.computedValue;
       }
 

--- a/packages/haiku-ui-common/src/helpers/uiColorHelpers.ts
+++ b/packages/haiku-ui-common/src/helpers/uiColorHelpers.ts
@@ -9,7 +9,7 @@ export enum DISPLAY_VALUES {
 
 export function derivateDisplayValueFromColorString (colorString: string) {
   if (typeof colorString !== 'string' || !get(colorString)) {
-    return DISPLAY_VALUES.HEX;
+    return null;
   }
 
   return colorString.charAt(0) === '#'

--- a/packages/haiku-ui-common/src/react/InspectorPanels/ColorPicker.tsx
+++ b/packages/haiku-ui-common/src/react/InspectorPanels/ColorPicker.tsx
@@ -156,6 +156,10 @@ class HaikuColorPicker extends React.PureComponent<HaikuColorPickerProps> {
   };
 
   render () {
+    if (this.state.valueDisplay === null) {
+      return null;
+    }
+
     return (
       <div style={STYLES.wrapper} className="color-picker-wrapper">
         <style>


### PR DESCRIPTION
Summary of changes:

- fix: only display the color picker for color strings: This disables the color picker for `linear-gradients` and similar.
- fix: smarter setting of UI fallback value for color properties: Instead of doing gymnastics with codemirror, hack the value when engaging focus.

Regressions to look for: 

- Color popovers in general

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
