### PR TITLE
 chore: remove repeat/if from JIT menu

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -4,7 +4,7 @@
       "FIRST!"
     ],
     "Fixes": [
-      "FIRST!"
+      "Removed `Control Flow > If` and `Control Flow > Repeat` from the Timeline 'ADD +' menu."
     ]
   }
 }

--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -16,7 +16,6 @@
   "PreserveFrontMatterInCode": true,
   "OutliningElementsOnStage": false,
   "OutliningElementsOnStageFromStage": false,
-  "ControlFlowIf": true,
   "ExpandTimelinePropertiesFromStageChanges": true,
   "DumpBase64Images": true,
   "WindowMenu": false,

--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -17,7 +17,6 @@
   "OutliningElementsOnStage": false,
   "OutliningElementsOnStageFromStage": false,
   "ControlFlowIf": true,
-  "ControlFlowRepeat": true,
   "ExpandTimelinePropertiesFromStageChanges": true,
   "DumpBase64Images": true,
   "WindowMenu": false,

--- a/packages/haiku-common/src/experiments/index.ts
+++ b/packages/haiku-common/src/experiments/index.ts
@@ -24,7 +24,6 @@ export enum Experiment {
   Snapping = 'Snapping',
   PinchToZoomInGlass = 'PinchToZoomInGlass',
   PreserveFrontMatterInCode = 'PreserveFrontMatterInCode',
-  ControlFlowIf = 'ControlFlowIf',
   ExpandTimelinePropertiesFromStageChanges = 'ExpandTimelinePropertiesFromStageChanges',
   DumpBase64Images = 'DumpBase64Images',
   WindowMenu = 'WindowMenu',

--- a/packages/haiku-common/src/experiments/index.ts
+++ b/packages/haiku-common/src/experiments/index.ts
@@ -25,7 +25,6 @@ export enum Experiment {
   PinchToZoomInGlass = 'PinchToZoomInGlass',
   PreserveFrontMatterInCode = 'PreserveFrontMatterInCode',
   ControlFlowIf = 'ControlFlowIf',
-  ControlFlowRepeat = 'ControlFlowRepeat',
   ExpandTimelinePropertiesFromStageChanges = 'ExpandTimelinePropertiesFromStageChanges',
   DumpBase64Images = 'DumpBase64Images',
   WindowMenu = 'WindowMenu',

--- a/packages/haiku-serialization/src/bll/Property.js
+++ b/packages/haiku-serialization/src/bll/Property.js
@@ -594,12 +594,12 @@ Property.areAnyKeyframesDefined = (elementName, propertyName, keyframesObject) =
 Property.DISPLAY_RULES = {
   content: {jit: [NON_ROOT_ONLY, IF_IN_SCHEMA, IF_TEXT_CONTENT_ENABLED], add: [NON_ROOT_ONLY, IF_IN_SCHEMA, IF_TEXT_CONTENT_ENABLED]},
   'controlFlow.if': {
-    jit: [(experimentIsEnabled(Experiment.ControlFlowIf)) ? NON_ROOT_ONLY : NEVER],
-    add: [(experimentIsEnabled(Experiment.ControlFlowIf)) ? IF_EXPLICIT_OR_DEFINED : NEVER],
+    jit: [NEVER],
+    add: [NEVER],
   },
   'controlFlow.repeat': {
-    jit: [(experimentIsEnabled(Experiment.ControlFlowRepeat)) ? NON_ROOT_ONLY : NEVER],
-    add: [(experimentIsEnabled(Experiment.ControlFlowRepeat)) ? IF_EXPLICIT_OR_DEFINED : NEVER],
+    jit: [NEVER],
+    add: [NEVER],
   },
   'controlFlow.placeholder': {jit: [NON_ROOT_ONLY, NON_COMPONENT_ONLY], add: [IF_EXPLICIT_OR_DEFINED], keyframe: [ALWAYS]},
   height: {jit: [NEVER], add: [IF_DEFINED, IF_IN_SCHEMA], keyframe: [ALWAYS]},


### PR DESCRIPTION
Summary of changes:

Remove repeat/if from JIT menu, and since this is the only place where the experiment was enabled, also retire it.

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
