### PR TITLE
 fix: use 'Position' instead of 'Translation' in the JIT menu 

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -4,7 +4,8 @@
       "FIRST!"
     ],
     "Fixes": [
-      "Removed `Control Flow > If` and `Control Flow > Repeat` from the Timeline 'ADD +' menu."
+      "Removed `Control Flow > If` and `Control Flow > Repeat` from the Timeline 'ADD +' menu.",
+      "Reworded 'Translation' to 'Position' in the Timeline 'ADD +' menu."
     ]
   }
 }

--- a/packages/haiku-serialization/src/bll/Property.js
+++ b/packages/haiku-serialization/src/bll/Property.js
@@ -78,6 +78,9 @@ Property.humanizePropertyName = (propertyName) => {
 };
 
 Property.humanizePropertyNamePart = (propertyNamePart) => {
+  if (Property.PREFIX_TO_CLUSTER_NAME[propertyNamePart]) {
+    return Property.PREFIX_TO_CLUSTER_NAME[propertyNamePart];
+  }
   return titlecase(decam(propertyNamePart));
 };
 


### PR DESCRIPTION
Summary of changes:

Use 'Position' instead of 'Translation' in the JIT menu, notes:

- Because of the way I solved this, any prefix in the `PREFIX_TO_CLUSTER_NAME` object will also be affected.
- We are careful about perf when dealing with this code because is a hot path, should we worry about this change on paper?

Regressions to look for:

- Maybe the 'notes' below are potential regressions?

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
