### PR TITLE
fix: don't hardcode paths in autoupdate & use ditto

### DIFF
--- a/packages/haiku-creator/package.json
+++ b/packages/haiku-creator/package.json
@@ -22,8 +22,8 @@
   "dependencies": {
     "@babel/parser": "7.0.0",
     "@haiku/core": "4.5.2",
-    "@haiku/tina-haikuerror": "^0.0.6",
     "@haiku/taylor-nocon": "^0.0.2",
+    "@haiku/tina-haikuerror": "^0.0.6",
     "async": "^2.5.0",
     "better-react-spinkit": "2.0.0-4",
     "color": "^2.0.1",
@@ -57,9 +57,11 @@
     "react-onclickoutside": "^6.4.0",
     "react-popover": "^0.4.18",
     "react-selectize": "^3.0.1",
-    "react-transition-group": "^2.2.1"
+    "react-transition-group": "^2.2.1",
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
+    "@types/uuid": "^3.2.1",
     "@types/fs-extra": "^4.0.8",
     "@types/node-fetch": "^2.1.1",
     "@types/qs": "^6.5.1",

--- a/packages/haiku-creator/src/utils/autoUpdate.ts
+++ b/packages/haiku-creator/src/utils/autoUpdate.ts
@@ -8,7 +8,7 @@ import nodeFetch from 'node-fetch';
 import * as os from 'os';
 import * as path from 'path';
 import * as qs from 'qs';
-import * as uuid from 'uuid';
+import {v4} from 'uuid';
 
 const DEFAULT_OPTIONS = {
   server: process.env.HAIKU_AUTOUPDATE_SERVER,
@@ -38,8 +38,8 @@ export default {
       }
 
       const tempPath = os.tmpdir();
-      const zipPath = path.join(tempPath, `${uuid.v4()}.zip`);
-      const extractPath = path.join(tempPath, uuid.v4());
+      const zipPath = path.join(tempPath, `${v4()}.zip`);
+      const extractPath = path.join(tempPath, v4());
       const appPath = path.resolve(electron.remote.app.getPath('exe'), '..', '..', '..');
       logger.info('[autoupdater] About to download an update:', options, url);
       await download(url, zipPath, progressCallback);

--- a/packages/haiku-creator/src/utils/autoUpdate.ts
+++ b/packages/haiku-creator/src/utils/autoUpdate.ts
@@ -34,7 +34,7 @@ export default {
         !options.platform ||
         !options.version
       ) {
-        throw(Error('Missing release/autoupdate environment variables'));
+        throw new Error('Missing release/autoupdate environment variables');
       }
 
       const tempPath = os.tmpdir();
@@ -51,7 +51,7 @@ export default {
       });
 
       if (!newAppName) {
-        throw(Error('Couldn\'t find a valid application from the downloaded zip'));
+        throw new Error('Couldn\'t find a valid application from the downloaded zip');
       }
 
       // `ditto` the contents of the extract path folder (the .app package) into `appPath`

--- a/packages/haiku-serialization/src/utils/fileManipulation.js
+++ b/packages/haiku-serialization/src/utils/fileManipulation.js
@@ -43,7 +43,7 @@ module.exports = {
   unzip (zipPath, destination) {
     const saneZipPath = JSON.stringify(zipPath);
     const saneDestination = JSON.stringify(destination);
-    const unzipCommand = `unzip -o -qq ${saneZipPath} -d ${saneDestination}`;
+    const unzipCommand = `/usr/bin/unzip -o -qq ${saneZipPath} -d ${saneDestination}`;
 
     return new Promise((resolve, reject) => {
       exec(unzipCommand, {}, (err) => {
@@ -55,7 +55,7 @@ module.exports = {
   ditto (src, dest) {
     const saneSrc = JSON.stringify(src);
     const saneDest = JSON.stringify(dest);
-    const dittoComand = `ditto ${saneSrc} ${saneDest}`;
+    const dittoComand = `/usr/bin/ditto ${saneSrc} ${saneDest}`;
 
     return new Promise((resolve, reject) => {
       exec(dittoComand, {}, (err) => {

--- a/packages/haiku-serialization/src/utils/fileManipulation.js
+++ b/packages/haiku-serialization/src/utils/fileManipulation.js
@@ -52,6 +52,18 @@ module.exports = {
     });
   },
 
+  ditto (src, dest) {
+    const saneSrc = JSON.stringify(src);
+    const saneDest = JSON.stringify(dest);
+    const dittoComand = `ditto ${saneSrc} ${saneDest}`;
+
+    return new Promise((resolve, reject) => {
+      exec(dittoComand, {}, (err) => {
+        err ? reject(err) : resolve(true);
+      });
+    });
+  },
+
   sanitize (name) {
     if (typeof name !== 'string') {
       return '';

--- a/yarn.lock
+++ b/yarn.lock
@@ -577,6 +577,13 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-2.3.5.tgz#9da44ed75571999b65c37b60c9b2b88db54c585d"
   integrity sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==
 
+"@types/uuid@^3.2.1":
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.4.tgz#7af69360fa65ef0decb41fd150bf4ca5c0cefdf5"
+  integrity sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/ws@^3.0.2":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-3.2.1.tgz#b0c1579e58e686f83ce0a97bb9463d29705827fb"


### PR DESCRIPTION
Summary of changes:

This implements a series of refactors to autoupdate logic by:

- Letting Electron's `app.relaunch();` figure out the execution path by
themselves instead of hardcoding one. We used to provide a path to cover
for users executing the app from outside Applications folder, but since
forking we are enforcing this.
- Using the `ditto` command (present in all macOS distributions) to sync
the downloaded file with Applications, so we don't have to worry about
the app name.

*How I tested this*

- Booted up a local squirrel server that always returns a hardcoded
download link.
- Compiled and repacked (using @sasha.com's `repack` bash script) a
production app living in Applications.
- Run the repacked app, let autoupdate do it's thing
- When the app is relaunched, verify that:
  - Everything works
  - The app is the provided by squirrel.

Regressions to look for:

- Autoupdate in general

Completed checkin tasks:

- [ ] ~Updated `changelog/public/latest.json`.~
