### PR TITLE
fix: retire OutliningElementsOnStage experiment and stop trashing the…

### DIFF
--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -14,7 +14,6 @@
   "Snapping": true,
   "PinchToZoomInGlass": true,
   "PreserveFrontMatterInCode": true,
-  "OutliningElementsOnStage": false,
   "OutliningElementsOnStageFromStage": false,
   "ExpandTimelinePropertiesFromStageChanges": true,
   "DumpBase64Images": true,

--- a/packages/haiku-common/src/experiments/index.ts
+++ b/packages/haiku-common/src/experiments/index.ts
@@ -9,7 +9,6 @@ import {getExperimentConfig} from './config';
 export enum Experiment {
   ShowSubElementsInJitMenu = 'ShowSubElementsInJitMenu',
   AdvancedMultiTransform = 'AdvancedMultiTransform',
-  OutliningElementsOnStage = 'OutliningElementsOnStage',
   OutliningElementsOnStageFromStage = 'OutliningElementsOnStageFromStage',
   DirectSelectionOfPrimitives = 'DirectSelectionOfPrimitives',
   IpcIntegrityCheck = 'IpcIntegrityCheck',

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -3014,7 +3014,6 @@ export class Glass extends React.Component {
 
     this.renderSelectionMarquee(overlays);
 
-    this.renderHoverOutline(overlays);
     this.renderSnapLines(overlays);
 
     return overlays;
@@ -3067,34 +3066,6 @@ export class Glass extends React.Component {
         break;
       default:
         // ...noop.
-    }
-  }
-
-  renderHoverOutline (overlays) {
-    if (
-      !experimentIsEnabled(Experiment.OutliningElementsOnStage) ||
-      this.isPreviewMode() ||
-      this.isMarqueeActive()
-    ) {
-      return;
-    }
-
-    const activeComponent = this.getActiveComponent();
-    if (activeComponent) {
-      const hoveredElement = Element.findHoveredElement(activeComponent);
-
-      if (hoveredElement && !hoveredElement.isSelected()) {
-        const points = hoveredElement.getBoxPointsTransformed();
-        overlays.push(
-          boxMana(
-            [points[0], points[2], points[8], points[6]].map((point) => [
-              point.x,
-              point.y,
-            ]),
-            Palette.LIGHTEST_PINK,
-          ),
-        );
-      }
     }
   }
 

--- a/packages/haiku-serialization/src/bll/Row.js
+++ b/packages/haiku-serialization/src/bll/Row.js
@@ -203,11 +203,6 @@ class Row extends BaseModel {
     if (!this._isHovered) {
       this._isHovered = true;
       this.emit('update', 'row-hovered');
-
-      // Roundabout! Note that elements, when hovered, will hover their corresponding row
-      if (this.isHeading() && this.element && !this.element.isHovered() && !this.element.isSelected()) {
-        this.element.hoverOn(metadata);
-      }
     }
     return this;
   }
@@ -229,11 +224,6 @@ class Row extends BaseModel {
     if (this._isHovered) {
       this._isHovered = false;
       this.emit('update', 'row-unhovered');
-
-      // Roundabout! Note that elements, when hovered, will hover their corresponding row
-      if (this.isHeading() && this.element && this.element.isHovered()) {
-        this.element.hoverOff(metadata);
-      }
     }
     return this;
   }


### PR DESCRIPTION
… update loop

Summary of changes:


Possible fix to stop thrashing the update/sync loop, after investigation I arrived to the conclusion that this code was implemented only to send hover events to glass for the `OutliningElementsOnStage` experiment.

I also pushed #1000 which alternatively just disables the damaging code under the experiment flag. 

(I like this one more!)

Regressions to look for:

- None expected

Completed checkin tasks:

- [ ] ~Updated `changelog/public/latest.json`.~
