### PR TITLE
fix: prevent crashes when executing `cmd+key` during stage drag

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -5,7 +5,8 @@
     ],
     "Fixes": [
       "Removed `Control Flow > If` and `Control Flow > Repeat` from the Timeline 'ADD +' menu.",
-      "Reworded 'Translation' to 'Position' in the Timeline 'ADD +' menu."
+      "Reworded 'Translation' to 'Position' in the Timeline 'ADD +' menu.",
+      "Fixed crash when pressing `cmd + A` when an element is being dragged."
     ]
   }
 }

--- a/packages/haiku-glass/src/react/Glass.js
+++ b/packages/haiku-glass/src/react/Glass.js
@@ -2269,9 +2269,6 @@ export class Glass extends React.Component {
       case 93: this.handleKeyCommand(false); break;
     }
 
-    const proxy = this.fetchProxyElementForSelection();
-    proxy.handleKeyUp();
-
     if (this.getActiveComponent()) {
       this.getActiveComponent().getSelectionMarquee().endSelection();
     }

--- a/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
+++ b/packages/haiku-serialization/src/bll/ElementSelectionProxy.js
@@ -704,20 +704,11 @@ class ElementSelectionProxy extends BaseModel {
   }
 
   handleMouseDown (mousePosition) {
-    ElementSelectionProxy._shouldCaptureMousePosition = true;
+    this._shouldCaptureMousePosition = true;
   }
 
   handleMouseUp (mousePosition) {
     ElementSelectionProxy.snaps = [];
-    // We set this._lastMouseDownPosition = undefined to imply that there isn't any mouse action in course
-    this._lastMouseDownPosition = undefined;
-  }
-
-  // this is used specifically for the CMD key (though it is not explicitly filtered here.)
-  // if we don't "recapture" mouse position when CMD is released, the element will unexpectedly
-  // jolt back to its original position pre-drag.
-  handleKeyUp () {
-    ElementSelectionProxy._shouldCaptureMousePosition = true;
   }
 
   // snapDefinitions are the element-side 'snap points' (lines)
@@ -969,9 +960,7 @@ class ElementSelectionProxy extends BaseModel {
     }
 
     // 'mousetrap' for snapping
-    // We assume that `ElementSelectionProxy._shouldCaptureMousePosition === undefined` means that no
-    // mouse action is in course, so we only capture new mouse position if is true
-    if (ElementSelectionProxy._shouldCaptureMousePosition && this._lastMouseDownPosition === undefined) {
+    if (this._shouldCaptureMousePosition || globals.isSpecialKeyDown() || this._lastMouseDownPosition === undefined) {
       this._lastMouseDownPosition = mouseCoordsCurrent;
       this._lastBbox = this.getBoundingClientRect();
       this._lastProxyBox = this.getBoxPointsTransformed();
@@ -980,7 +969,7 @@ class ElementSelectionProxy extends BaseModel {
       this._lastOrigins = this.selection.map((elem) => {
         return elem.getOriginTransformed();
       });
-      ElementSelectionProxy._shouldCaptureMousePosition = false;
+      this._shouldCaptureMousePosition = false;
     }
 
     // track mouse positions, offsets, and original bounding boxes for snapping
@@ -2476,9 +2465,6 @@ const isWithinEpsilon = (v0, v1, override) => {
 
 // Storage for snap lines data
 ElementSelectionProxy.snaps = [];
-// Storage to preserve `_shouldCaptureMousePosition` set on handleMouseDown method on former ElementSelectionProxy
-// instance up to `drag` method on newly created ElementSelectionProxy instance
-ElementSelectionProxy._shouldCaptureMousePosition = false;
 
 ElementSelectionProxy.fromSelection = (rawSelection, component) => {
   const uid = `${component && component.getPrimaryKey()}+${rawSelection.map((element) => element.getPrimaryKey()).sort().join('+') || 'none'}`;


### PR DESCRIPTION
Summary of changes:

This fixes a [crash][1] occasionated when executing a command during a
drag, for example by pressing `cmd + A` while an element is being dragged.

This involves two main things:

- Virtually reverting back PR #831 (2252e6a) which introduced part of the
faulty logic in order to solve a [bug][2].
- By taking adventage of the `Globals` object instead of setting an
internal value to track if the `cmd` key is down, which generated problems
because many of the functions are throttled.

Asana Task: https://app.asana.com/0/922186784503552/958155168927487

[1]: https://sentry.io/organizations/haiku-systems/issues/824060464/?project=226387&referrer=asana_plugin&statsPeriod=14d&utc=false
[2]: https://app.asana.com/0/813447917062242/827578786675323

Regressions to look for:

- Glass dnd, and selection

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
