### PR TITLE
fix: disable `user-select` for child elements of RowManager

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -5,7 +5,8 @@
     ],
     "Fixes": [
       "Removed `Control Flow > If` and `Control Flow > Repeat` from the Timeline 'ADD +' menu.",
-      "Reworded 'Translation' to 'Position' in the Timeline 'ADD +' menu."
+      "Reworded 'Translation' to 'Position' in the Timeline 'ADD +' menu.",
+      "Removed a drag ghost image randomly appearing when keyframes are dragged."
     ]
   }
 }

--- a/packages/haiku-timeline/public/styles/Timeline.css
+++ b/packages/haiku-timeline/public/styles/Timeline.css
@@ -194,11 +194,6 @@ input:focus, button:focus {
   height: 100%;
 }
 
-#timeline .no-select {
-  -webkit-user-select: none;
-  cursor: default;
-}
-
 #timeline .no-incrementor input[type=number]::-webkit-inner-spin-button,
 input[type=number]::-webkit-outer-spin-button {
   -webkit-appearance: none;
@@ -208,6 +203,10 @@ input[type=number]::-webkit-outer-spin-button {
 .no-select {
   -webkit-user-select: none;
   cursor: default;
+}
+
+.no-select-children * {
+  -webkit-user-select: none;
 }
 
 :root {

--- a/packages/haiku-timeline/src/components/RowManager.tsx
+++ b/packages/haiku-timeline/src/components/RowManager.tsx
@@ -182,7 +182,7 @@ class RowManager extends React.PureComponent<RowManagerProps> {
 
     return (
       <div
-        className={`row-manager ${this.state.canReceiveDrag ? 'row-manager-receiving-drag' : ''}`}
+        className={`no-select-children row-manager ${this.state.canReceiveDrag ? 'row-manager-receiving-drag' : ''}`}
         onDragOver={this.onDragOver}
         onDragEnter={this.onDragEnter}
         onDragLeave={this.onDragLeave}


### PR DESCRIPTION
Summary of changes:

This fixes a drag ghost randomly appearing when draging keyframes, caused
because the text of the Rows was being selected (though not visibly)
triggering native drag and drop behaviors.

While the dragging issue is difficult to repro, you can notice this
behavior if you:

- Click anywhere on the Timeline.
- Check that `window.getSelection().toString()` is "".
- Drag a keyframe in a downward motion.
- Check that `window.getSelection().toString()` has contents, this
causes the drag ghost to randomly appear.

Asana Task: https://app.asana.com/0/922186784503552/1113905370581295

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
