### PR TITLE
feat: remove tween before keyframes if a single tween is selected

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -2,7 +2,8 @@
   "sections": {
     "What's new": [
       "Added the ability drag and reposition the Bezier Editor.",
-      "Added support for <line> elements in Lottie export."
+      "Added support for <line> elements in Lottie export.",
+      "Added the ability to delete a single tween by pressing ⌫ (delete) without deleting the related keyframes. "
     ],
     "Fixes": [
       "Fixed a crash when pressing `Cmd + A` while an element is being dragged.",

--- a/packages/haiku-serialization/src/bll/ActiveComponent.js
+++ b/packages/haiku-serialization/src/bll/ActiveComponent.js
@@ -2024,6 +2024,10 @@ class ActiveComponent extends BaseModel {
   deleteSelectedKeyframes (metadata) {
     const keyframes = this.getSelectedKeyframes();
 
+    if (Keyframe.groupIsSingleTween(keyframes)) {
+      return keyframes[0].removeCurve(metadata);
+    }
+
     keyframes.forEach((keyframe) => {
       if (!keyframe.isTransitionSegment()) {
         const prev = keyframe.prev();


### PR DESCRIPTION
Summary of changes:

Click a tween. Press 'backspace' (delete), tween is removed. [leave keyframes selected; delete those upon subsequent backspace]

![2019-03-20 21 25 45](https://user-images.githubusercontent.com/4419992/54717159-d3d99200-4b57-11e9-8dc9-b17bf13708f5.gif)


Regressions to look for:

- None, really, but I noticed some weirdness on the Timeline while testing this, and I found that's because a very very old [underlying issue](https://app.asana.com/0/922186784503552/1115259939111443), which I'm working on #1009. My initial plan was to include this alongside the fix, but I think this is better.

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
