### PR TITLE
 fix: add a missing key in order to make Radium happy and prevent crashes

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -10,7 +10,8 @@
       "Fixed a crash when an invalid curve value is entered while the Curve Editor is open.",
       "Removed `Control Flow > If` and `Control Flow > Repeat` from the Timeline 'ADD +' menu.",
       "Renamed 'Translation' to 'Position' in the Timeline 'ADD +' menu.",
-      "Removed a drag ghost image appearing while keyframes are dragged."
+      "Removed a drag ghost image appearing while keyframes are dragged.",
+      "Fixed a crash when the internet connection is lost on some scenarios."
     ]
   }
 }

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -288,6 +288,7 @@ class ProjectBrowser extends React.Component {
             <div>The Animator free trial requires an active intenet connection.</div>
             <div>Upgrade to Animator Pro for offline capabilities.</div>
             <div
+              key="go-pro-button"
               style={[
                 BTN_STYLES.btnText,
                 BTN_STYLES.btnPrimary,

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -647,7 +647,7 @@ class ProjectBrowser extends React.Component {
               key="new_proj"
               title="Create new Animator project"
               onClick={() => this.showNewProjectModal()}
-              style={[BTN_STYLES.btnIcon, BTN_STYLES.btnIconHovered]}
+              style={[BTN_STYLES.btnIcon, BTN_STYLES.btnIconHover]}
             >
               <span style={{fontSize: 18, marginRight: 2, transform: 'translateY(-1px)'}}>+ </span>
               <span>New Project</span>
@@ -678,7 +678,7 @@ class ProjectBrowser extends React.Component {
               onClick={this.openPopover}
               style={[
                 BTN_STYLES.btnIcon,
-                BTN_STYLES.btnIconHovered,
+                BTN_STYLES.btnIconHover,
                 this.props.isAdmin && STYLES.adminButton,
               ]}
             >

--- a/packages/haiku-creator/src/react/components/ProjectBrowser.js
+++ b/packages/haiku-creator/src/react/components/ProjectBrowser.js
@@ -22,7 +22,7 @@ import * as  NoCon from '@haiku/taylor-nocon/react';  // Actual Ku Credit: Ms Ti
 const STYLES = {
   adminButton: {
     // TODO: make this a bit more insane?
-    backgroundColor: 'linear-gradient(180deg, rgb(247,183,89), rgb(229,116,89) 50%, rgb(213,53,89))',
+    background: 'linear-gradient(180deg, rgb(247,183,89), rgb(229,116,89) 50%, rgb(213,53,89))',
   },
 };
 

--- a/packages/haiku-creator/src/react/styles/dashShared.ts
+++ b/packages/haiku-creator/src/react/styles/dashShared.ts
@@ -296,7 +296,7 @@ export const DASH_STYLES: React.CSSProperties = {
     transform: 'translateX(-50%)',
     borderLeft: '10px solid transparent',
     borderRight: '10px solid transparent',
-    borderBottom: '10px solid ' + Palette.COAL,
+    borderBottom: `10px solid ${Palette.COAL}`,
   },
   emptyState: {
     position: 'absolute',
@@ -414,7 +414,7 @@ export const DASH_STYLES: React.CSSProperties = {
     display: 'inline-block',
   },
   notice: {
-    border: '1px solid ' + Palette.LIGHT_BLUE,
+    border: `1px solid ${Palette.LIGHT_BLUE}`,
     padding: '34px 50px 30px',
     textAlign: 'center',
     position: 'relative',

--- a/packages/haiku-timeline/src/components/ScrollView.js
+++ b/packages/haiku-timeline/src/components/ScrollView.js
@@ -1,8 +1,6 @@
 import * as React from 'react';
-import * as Color from 'color';
 import Palette from 'haiku-ui-common/lib/Palette';
 import zIndex from './styles/zIndex';
-import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
 
 class ScrollView extends React.PureComponent {
   constructor (props) {

--- a/packages/haiku-ui-common/src/react/Paginator.tsx
+++ b/packages/haiku-ui-common/src/react/Paginator.tsx
@@ -11,6 +11,7 @@ const STYLES = {
     pointerEvents: 'none',
     bottom: '0px',
     transition: 'opacity 125ms, filter 140ms',
+    userSelect: 'none',
   },
   pagerHolster: {
     transform: 'translateY(-12px)',


### PR DESCRIPTION
Summary of changes:

As the title says, this one took a while because of a combination of how Radium reports this error (by the name of the component) + uglyfication in prod without source maps, causing the error to be:

> Radium requires each element with interactive styles to have a unique key, set using either the ref or key prop. Multiple elements have no key specified. Component: "n". Element: "div".

Turns out that  the error is in the offline screen, this fixes it and adds a couple of extra small improvements here and there.

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
