### PR TITLE
 feat: warn users when importing large files 

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -11,7 +11,8 @@
       "Removed `Control Flow > If` and `Control Flow > Repeat` from the Timeline 'ADD +' menu.",
       "Renamed 'Translation' to 'Position' in the Timeline 'ADD +' menu.",
       "Removed a drag ghost image appearing while keyframes are dragged.",
-      "Fixed a crash when the internet connection is lost on some scenarios."
+      "Fixed a crash when the internet connection is lost on some scenarios.",
+      "Added helpful warnings when trying to import big design assets."
     ]
   }
 }

--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -12,7 +12,7 @@
       "Renamed 'Translation' to 'Position' in the Timeline 'ADD +' menu.",
       "Removed a drag ghost image appearing while keyframes are dragged.",
       "Fixed a crash when the internet connection is lost on some scenarios.",
-      "Added helpful warnings when trying to import big design assets."
+      "Added helpful warnings when trying to import complex design assets."
     ]
   }
 }

--- a/packages/haiku-creator/src/react/components/library/FileImporter.tsx
+++ b/packages/haiku-creator/src/react/components/library/FileImporter.tsx
@@ -51,7 +51,7 @@ const STYLES: React.CSSProperties = {
 export interface FileImporterProps {
   onFileDrop (paths: string[]): void;
   conglomerateComponent (options: any): void;
-  onImportFigmaAsset (): void;
+  onImportFigmaAsset (url: string, warnOnComplexFile?: boolean): void;
   onAskForFigmaAuth (): void;
   figma: any;
 }

--- a/packages/haiku-creator/src/react/components/library/FileImporter.tsx
+++ b/packages/haiku-creator/src/react/components/library/FileImporter.tsx
@@ -1,13 +1,15 @@
-import * as React from 'react';
 import * as Color from 'color';
-import * as Popover from 'react-popover';
-import Palette from 'haiku-ui-common/lib/Palette';
+// @ts-ignore
 import * as mixpanel from 'haiku-serialization/src/utils/Mixpanel';
+import Palette from 'haiku-ui-common/lib/Palette';
+import * as React from 'react';
+// @ts-ignore
+import * as Popover from 'react-popover';
+import {DASH_STYLES} from '../../styles/dashShared';
 import FigmaImporter from './importers/FigmaImporter';
 import FileSystemImporter from './importers/FileSystemImporter';
-import {DASH_STYLES} from '../../styles/dashShared';
 
-const STYLES = {
+const STYLES: React.CSSProperties = {
   popover: {
     background: Palette.COAL,
     borderRadius: '4px',
@@ -46,14 +48,18 @@ const STYLES = {
   },
 };
 
-class FileImporter extends React.PureComponent {
-  constructor (props) {
-    super(props);
+export interface FileImporterProps {
+  onFileDrop (paths: string[]): void;
+  conglomerateComponent (options: any): void;
+  onImportFigmaAsset (): void;
+  onAskForFigmaAuth (): void;
+  figma: any;
+}
 
-    this.state = {
-      isPopoverOpen: false,
-    };
-  }
+class FileImporter extends React.PureComponent<FileImporterProps> {
+  state = {
+    isPopoverOpen: false,
+  };
 
   showPopover = () => {
     this.setState({isPopoverOpen: true});
@@ -64,7 +70,7 @@ class FileImporter extends React.PureComponent {
     this.setState({isPopoverOpen: false});
   };
 
-  onFileDrop = (filePaths) => {
+  onFileDrop = (filePaths: string[]) => {
     this.hidePopover();
 
     if (filePaths) {
@@ -138,14 +144,5 @@ class FileImporter extends React.PureComponent {
     );
   }
 }
-
-FileImporter.propTypes = {
-  onFileDrop: React.PropTypes.func.isRequired,
-  onImportFigmaAsset: React.PropTypes.func.isRequired,
-  onAskForFigmaAuth: React.PropTypes.func.isRequired,
-  figma: React.PropTypes.object,
-  websocket: React.PropTypes.object.isRequired,
-  projectModel: React.PropTypes.object.isRequired,
-};
 
 export default FileImporter;

--- a/packages/haiku-creator/src/react/components/library/Library.js
+++ b/packages/haiku-creator/src/react/components/library/Library.js
@@ -390,7 +390,7 @@ class Library extends React.Component {
         this.props.createNotice({
           type: 'warning',
           title: 'Warning',
-          message: `${basename(path)} seems to be a big file, you may experience performance problems.`,
+          message: `${basename(path)} is a large file, you may experience performance problems.`,
         });
         mixpanel.haikuTrack(`creator:${extname(path)}:complex-design-warning-shown`);
       }

--- a/packages/haiku-creator/src/react/components/library/importers/FigmaForm.tsx
+++ b/packages/haiku-creator/src/react/components/library/importers/FigmaForm.tsx
@@ -1,11 +1,13 @@
-import * as React from 'react';
-import Palette from 'haiku-ui-common/lib/Palette';
+// @ts-ignore
 import {Figma} from 'haiku-serialization/src/bll/Figma';
+// @ts-ignore
 import * as mixpanel from 'haiku-serialization/src/utils/Mixpanel';
-import {DASH_STYLES} from '../../../styles/dashShared';
+import Palette from 'haiku-ui-common/lib/Palette';
+import * as React from 'react';
 import {BTN_STYLES} from '../../../styles/btnShared';
+import {DASH_STYLES} from '../../../styles/dashShared';
 
-const STYLES = {
+const STYLES: React.CSSProperties = {
   form: {
     position: 'absolute',
     background: Palette.COAL,
@@ -41,14 +43,25 @@ const STYLES = {
   },
 };
 
-class FigmaForm extends React.PureComponent {
-  constructor (props) {
-    super(props);
-    this.state = {
-      isMessageVisible: false,
-      error: null,
-    };
-  }
+export interface FigmaFormProps {
+  figma: any;
+  onAskForFigmaAuth (): void;
+  onImportFigmaAsset (url: string, warnOnComplexFile?: boolean): void;
+  onPopoverHide (): void;
+}
+
+export interface FigmaFormState {
+  isMessageVisible: boolean;
+  error: null|string;
+}
+
+class FigmaForm extends React.PureComponent<FigmaFormProps, FigmaFormState> {
+  private inputRef: HTMLInputElement;
+
+  state: FigmaFormState = {
+    isMessageVisible: false,
+    error: null,
+  };
 
   componentDidMount () {
     if (!this.props.figma.token) {
@@ -58,17 +71,17 @@ class FigmaForm extends React.PureComponent {
     mixpanel.haikuTrack('creator:file-importer:open-figma');
   }
 
-  onFormSubmit (submitEvent) {
+  onFormSubmit = (submitEvent: React.FormEvent<HTMLFormElement>) => {
     submitEvent.preventDefault();
     const url = this.inputRef.value;
 
     if (Figma.parseProjectURL(url)) {
-      this.props.onImportFigmaAsset(url);
+      this.props.onImportFigmaAsset(url, true);
       this.setState({isMessageVisible: true});
     } else {
       this.setState({error: 'Invalid URL'});
     }
-  }
+  };
 
   render () {
     return (
@@ -84,9 +97,7 @@ class FigmaForm extends React.PureComponent {
           </div>
         ) : (
           <form
-            onSubmit={(submitEvent) => {
-              this.onFormSubmit(submitEvent);
-            }}
+            onSubmit={this.onFormSubmit}
             style={STYLES.form}
           >
             <label style={STYLES.inputTitle}>Project URL</label>
@@ -109,10 +120,5 @@ class FigmaForm extends React.PureComponent {
     );
   }
 }
-
-FigmaForm.propTypes = {
-  onPopoverHide: React.PropTypes.func.isRequired,
-  onImportFigmaAsset: React.PropTypes.func.isRequired,
-};
 
 export default FigmaForm;

--- a/packages/haiku-creator/src/react/components/library/importers/FigmaImporter.tsx
+++ b/packages/haiku-creator/src/react/components/library/importers/FigmaImporter.tsx
@@ -14,7 +14,7 @@ const STYLES: React.CSSProperties = {
 
 export interface FigmaImporterProps {
   onPopoverHide (): void;
-  onImportFigmaAsset (): void;
+  onImportFigmaAsset (url: string, warnOnComplexFile?: boolean): void;
   onAskForFigmaAuth (): void;
   figma: any;
   style: React.CSSProperties;

--- a/packages/haiku-creator/src/react/components/library/importers/FigmaImporter.tsx
+++ b/packages/haiku-creator/src/react/components/library/importers/FigmaImporter.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import FigmaForm from './FigmaForm';
 
-const STYLES = {
+const STYLES: React.CSSProperties = {
   button: {
     color: 'inherit',
     fontSize: 'inherit',
@@ -12,27 +12,29 @@ const STYLES = {
   },
 };
 
-class FigmaImporter extends React.PureComponent {
-  constructor (props) {
-    super(props);
+export interface FigmaImporterProps {
+  onPopoverHide (): void;
+  onImportFigmaAsset (): void;
+  onAskForFigmaAuth (): void;
+  figma: any;
+  style: React.CSSProperties;
+}
 
-    this.state = {
-      isFormVisible: false,
-    };
-  }
+class FigmaImporter extends React.PureComponent<FigmaImporterProps> {
+  state = {
+    isFormVisible: false,
+  };
 
-  renderForm () {
+  renderForm = () => {
     this.setState({isFormVisible: true});
-  }
+  };
 
   render () {
     return (
       <div style={this.props.style}>
         <button
           style={STYLES.button}
-          onClick={() => {
-            this.renderForm();
-          }}
+          onClick={this.renderForm}
         >
           Connect Figma Project
         </button>
@@ -49,11 +51,5 @@ class FigmaImporter extends React.PureComponent {
     );
   }
 }
-
-FigmaImporter.propTypes = {
-  onPopoverHide: React.PropTypes.func.isRequired,
-  onImportFigmaAsset: React.PropTypes.func.isRequired,
-  figma: React.PropTypes.object,
-};
 
 export default FigmaImporter;

--- a/packages/haiku-creator/src/react/components/library/importers/FileSystemImporter.tsx
+++ b/packages/haiku-creator/src/react/components/library/importers/FileSystemImporter.tsx
@@ -1,10 +1,16 @@
-import * as React from 'react';
 import {remote} from 'electron';
 import {isMac} from 'haiku-common/lib/environments/os';
-import {experimentIsEnabled, Experiment} from 'haiku-common/lib/experiments';
+import {Experiment, experimentIsEnabled} from 'haiku-common/lib/experiments';
+import * as React from 'react';
 
-class FileSystemImporter extends React.PureComponent {
-  showImportDialog () {
+export interface FileSystemImporterProps {
+  onFileDrop (files: string[]): void;
+  style?: React.CSSProperties;
+  text?: string;
+}
+
+class FileSystemImporter extends React.PureComponent<FileSystemImporterProps> {
+  showImportDialog = () => {
     const validExtensions = [
       'svg',
       'ai',
@@ -33,17 +39,15 @@ class FileSystemImporter extends React.PureComponent {
       },
       this.props.onFileDrop,
     );
-  }
+  };
 
   render () {
     return (
       <div
         style={this.props.style}
-        onClick={() => {
-          this.showImportDialog();
-        }}
+        onClick={this.showImportDialog}
       >
-        {this.props.text ? this.props.text : 'Import From File'}
+        {this.props.text || 'Import From File'}
       </div>
     );
   }

--- a/packages/haiku-serialization/src/bll/Figma.js
+++ b/packages/haiku-serialization/src/bll/Figma.js
@@ -29,7 +29,7 @@ const FOLDERS = {
   [VALID_TYPES.FRAME]: 'frames/',
 };
 
-export const MAX_ITEMS_TO_IMPORT = 100;
+const MAX_ITEMS_TO_IMPORT = 100;
 
 const PRIORITY_TO_IMPORT = [
   VALID_TYPES.SLICE,
@@ -399,4 +399,4 @@ class Figma {
   }
 }
 
-module.exports = {Figma, PHONY_FIGMA_FILE, FIGMA_DEFAULT_FILENAME};
+module.exports = {Figma, PHONY_FIGMA_FILE, FIGMA_DEFAULT_FILENAME, MAX_ITEMS_TO_IMPORT};

--- a/packages/haiku-serialization/src/bll/Figma.js
+++ b/packages/haiku-serialization/src/bll/Figma.js
@@ -29,7 +29,7 @@ const FOLDERS = {
   [VALID_TYPES.FRAME]: 'frames/',
 };
 
-const MAX_ITEMS_TO_IMPORT = 100;
+export const MAX_ITEMS_TO_IMPORT = 100;
 
 const PRIORITY_TO_IMPORT = [
   VALID_TYPES.SLICE,
@@ -75,22 +75,26 @@ class Figma {
     logger.info('[figma] about to import document with id ' + id);
     mixpanel.haikuTrack('creator:figma:fileImport:start');
 
-    return this.fetchDocument(id)
-      .then((rawDocument) => {
-        const document = JSON.parse(rawDocument);
-        const abspath = path.join(projectFolder, 'designs', `${id}-${document.name}.figma`);
-        assetBaseFolder = `${abspath}.contents`;
-        this.createFolders(assetBaseFolder);
-        return document;
-      })
-      .then((document) => this.findInstantiableElements(document, id))
-      .then((elements) => this.sortElementsByPriorityToImport(elements))
-      .then((elements) => this.getSVGLinks(elements, id))
-      .then((elements) => this.getSVGContents(elements))
-      .then((elements) => this.writeSVGInDisk(elements, assetBaseFolder))
-      .then(() => {
-        mixpanel.haikuTrack('creator:figma:fileImport:success');
-      });
+    return new Promise((resolve, reject) => {
+      this.fetchDocument(id)
+        .then((rawDocument) => {
+          const document = JSON.parse(rawDocument);
+          const abspath = path.join(projectFolder, 'designs', `${id}-${document.name}.figma`);
+          assetBaseFolder = `${abspath}.contents`;
+          this.createFolders(assetBaseFolder);
+          return document;
+        })
+        .then((document) => this.findInstantiableElements(document, id))
+        .then((elements) => this.sortElementsByPriorityToImport(elements))
+        .then((elements) => this.getSVGLinks(elements, id))
+        .then((elements) => this.getSVGContents(elements))
+        .then((elements) => this.writeSVGInDisk(elements, assetBaseFolder))
+        .then((elements) => {
+          mixpanel.haikuTrack('creator:figma:fileImport:success');
+          resolve(elements.length);
+        })
+        .catch(reject);
+    });
   }
 
   /**


### PR DESCRIPTION
Summary of changes:

This is just a poor man's way to warn users about performance/crashes
implications of huge files, we used this approach:

- Warn for files larger than 30mb for Illustrator and Sketch.
- Warn if we imported our maximum number of allowed items to import
from Figma (defined in Figma.js)

I also TSifyed some components along the way.

Regressions to look for:

- None expected

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
