### PR TITLE
chore: s/Haiku/Haiku Animator on distro scripts

### DIFF
--- a/scripts/distro-build.js
+++ b/scripts/distro-build.js
@@ -22,7 +22,7 @@ switch (platform) {
     const distRoot = path.resolve(ROOT, 'dist');
     const {productName} = require(path.join(ROOT, 'package.json')).build;
     const zipTarget = path.join(distRoot, `${productName}-${nowVersion()}-mac.zip`);
-    cp.execSync(`/usr/bin/ditto -c -k --sequesterRsrc --keepParent Haiku.app '${zipTarget}'`, {cwd: path.join(distRoot, 'mac'), stdio: 'inherit'});
+    cp.execSync(`/usr/bin/ditto -c -k --sequesterRsrc --keepParent '${productName}.app' '${zipTarget}'`, {cwd: path.join(distRoot, 'mac'), stdio: 'inherit'});
     break;
   case 'windows':
     // process.env.WIN_CSC_LINK = `file://${deploy.vault}/${deploy.certificate}`

--- a/scripts/distro-open.js
+++ b/scripts/distro-open.js
@@ -1,4 +1,0 @@
-const cp = require('child_process');
-const path = require('path');
-let ROOT = path.join(__dirname, '..');
-cp.execSync('open ./dist/mac/Haiku.app/Contents/MacOS/Haiku', {cwd: ROOT, stdio: 'inherit'});


### PR DESCRIPTION
Summary of changes:

This should fix Jenkins builds failing (see [here](https://ci.haiku.ai/blue/organizations/jenkins/Haiku/detail/Haiku/1611/pipeline/)

Regressions to look for:

- None expected
