### PR TITLE
fix: bad logic breaking main row normal collapsed behavior

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -12,7 +12,8 @@
       "Renamed 'Translation' to 'Position' in the Timeline 'ADD +' menu.",
       "Removed a drag ghost image appearing while keyframes are dragged.",
       "Fixed a crash when the internet connection is lost on some scenarios.",
-      "Added helpful warnings when trying to import complex design assets."
+      "Added helpful warnings when trying to import complex design assets.",
+      "Fixed a bug causing the Timeline to appear empty when the Main Row is collapsed."
     ]
   }
 }

--- a/packages/haiku-timeline/src/components/ComponentHeadingRow.tsx
+++ b/packages/haiku-timeline/src/components/ComponentHeadingRow.tsx
@@ -269,11 +269,9 @@ export default class ComponentHeadingRow extends React.Component<ComponentHeadin
                 style={{
                   width: 11,
                   padding: '0 3px',
-                  ...(!isRootRow && {
-                    marginTop: 3,
-                    marginLeft: -3,
-                    marginRight: 3,
-                  }),
+                  marginTop: 3,
+                  marginLeft: -3,
+                  marginRight: 3,
                 }}
                 onClick={this.toggleExpandAndSelect}
               >

--- a/packages/haiku-timeline/src/components/RowManager.tsx
+++ b/packages/haiku-timeline/src/components/RowManager.tsx
@@ -102,7 +102,9 @@ class RowManager extends React.PureComponent<RowManagerProps> {
             component={activeComponent}
             row={row}
             onEventHandlerTriggered={this.props.showEventHandlersEditor}
-            isExpanded={row.isRootRow() ? true : (this.props.forceCollapse ? false : row.isExpanded())}
+            isExpanded={
+              (row.isRootRow() && this.props.forceCollapse) || (!this.props.forceCollapse && row.isExpanded())
+            }
             isHidden={row.isHidden()}
             isSelected={row.isSelected()}
             hasAttachedActions={row.element.getVisibleEvents().length > 0}


### PR DESCRIPTION
Summary of changes:

When we refactored DnD of timeline rows, we introduced a new helper
prop `forceCollapse` in order to force the rows to be collapsed when
a drag is being performed, but since what we really want is to collapse
_all rows except Main_ I introduced some faulty logic to handle this
specific scenario.

This fixes this logic by not assuming that the Main row has to be always
expanded.

Asana Task: https://app.asana.com/0/1114158148688266/1117678624456373

Regressions to look for:

- DnD, collapsing & expanding rows.

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
