### PR TITLE
Implemented fix changing the way how is checked if Sketch is installed

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -13,7 +13,8 @@
       "Removed a drag ghost image appearing while keyframes are dragged.",
       "Fixed a crash when the internet connection is lost on some scenarios.",
       "Added helpful warnings when trying to import complex design assets.",
-      "Fixed a bug causing the Timeline to appear empty when the Main Row is collapsed."
+      "Fixed a bug causing the Timeline to appear empty when the Main Row is collapsed.",
+      "Fixed a bug causing to ask the user to install Sketch, even though it was already installed."
     ]
   }
 }

--- a/packages/haiku-serialization/src/utils/sketchUtils.js
+++ b/packages/haiku-serialization/src/utils/sketchUtils.js
@@ -3,7 +3,7 @@ const {exec} = require('child_process');
 const logger = require('./LoggerInstance');
 const {isMac} = require('haiku-common/lib/environments/os');
 
-const SKETCH_PATH_FINDER = `$(/usr/bin/find /System/Library/Frameworks -name lsregister) -dump | grep 'path:.*/Sketch\\( (\\d)\\)\\?\\.app$'`;
+const SKETCH_PATH_FINDER = `mdfind "kMDItemKind == 'Application'" | grep Sketch.app`
 const PARSER_CLI_PATH = '/Contents/Resources/sketchtool/bin/sketchtool';
 let sketchInstalledCache = null;
 
@@ -79,10 +79,9 @@ module.exports = {
         this.getDumpInfo()
           .then(this.dumpToPaths)
           .then(this.pathsToInstallationInfo)
-          .then(this.findBestPath)
-          .then((bestPath) => {
-            sketchInstalledCache = Boolean(bestPath);
-            resolve(bestPath);
+          .then((path) => {
+            sketchInstalledCache = Boolean(path);
+            resolve(path);
           })
           .catch((error) => {
             logger.info('[sketch utils] error finding Sketch: ', error);


### PR DESCRIPTION
Summary of changes:

- Changed the way how is checked if Sketch is installed (`SKETCH_PATH_FINDER` and `checkIfInstalled` in `sketchUtils.js`).

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
