### PR TITLE
Disable CodeEditor experiment

### DIFF
--- a/changelog/public/latest.json
+++ b/changelog/public/latest.json
@@ -14,7 +14,8 @@
       "Fixed a crash when the internet connection is lost on some scenarios.",
       "Added helpful warnings when trying to import complex design assets.",
       "Fixed a bug causing the Timeline to appear empty when the Main Row is collapsed.",
-      "Fixed a bug causing to ask the user to install Sketch, even though it was already installed."
+      "Fixed a bug causing to ask the user to install Sketch, even though it was already installed.",
+      "Removed 'Code Editor'"
     ]
   }
 }

--- a/packages/haiku-common/config/experiments.json
+++ b/packages/haiku-common/config/experiments.json
@@ -5,7 +5,7 @@
   "IpcIntegrityCheck": true,
   "CrashOnIpcIntegrityCheckFailure": true,
   "OrderedActionStack": true,
-  "CodeEditor": true,
+  "CodeEditor": false,
   "WarnOnUndefinedStateVariables": true,
   "TimelineMarqueeSelection": true,
   "LocalAssetExport": true,


### PR DESCRIPTION
Summary of changes:

- This PR just disables the code view by turning off the feature `CodeEditor`.

Completed checkin tasks:

- [x] Updated `changelog/public/latest.json`.
