### PR TITLE
fix: align post keyframes vertically

### DIFF
--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -32,7 +32,7 @@ const THROTTLE_TIME = 17; // ms
 
 const STYLE = {
   keyframePole: {
-    transform: 'translateY(-1.5px)',
+    transform: 'scale(1.7) translateY(-1.5px)',
   },
 };
 
@@ -299,7 +299,7 @@ export default class TransitionBody extends React.Component {
                   ? 'pointer'
                   : 'move',
               }}>
-              <KeyframeSVG style={STYLE.keyframePole} color={Palette[this.props.keyframe.getRightKeyframeColorState()]} />
+              <KeyframeSVG color={Palette[this.props.keyframe.getRightKeyframeColorState()]} />
             </span>
           </span>
         </span>

--- a/packages/haiku-timeline/src/components/TransitionBody.js
+++ b/packages/haiku-timeline/src/components/TransitionBody.js
@@ -32,7 +32,7 @@ const THROTTLE_TIME = 17; // ms
 
 const STYLE = {
   keyframePole: {
-    transform: 'scale(1.7) translateY(-1.5px)',
+    transform: 'translateY(-1.5px)',
   },
 };
 


### PR DESCRIPTION
This PR fixes a visual issue that was duplicating keyframes in the timeline. The following images show how it was before the fix and how it's now.

Before:
![image](https://user-images.githubusercontent.com/7218580/79394354-a2471c00-7f4d-11ea-9702-aaa9c0d0870c.png)

After:
![image](https://user-images.githubusercontent.com/7218580/79394184-49778380-7f4d-11ea-8135-225df80341b9.png)
